### PR TITLE
ci: update rust build script to download shared lib from github releases ( PROOF-603 )

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -50,4 +50,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run rust tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_rust:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bash ci/build.sh 0.0.0; source /root/.cargo/env; /root/.cargo/bin/cargo test --manifest-path rust/blitzar-sys/Cargo.toml; /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml"
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_rust:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; source /root/.cargo/env; /root/.cargo/bin/cargo test --manifest-path rust/blitzar-sys/Cargo.toml; /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml"

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -41,3 +41,13 @@ jobs:
       
       - name: Run cpp-asan tests
         run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_asan:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test --config=asan //..."
+
+  test-rust:
+    name: Rust Sys Crate
+    runs-on: self-hosted
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Run rust tests
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_rust:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bash ci/build.sh 0.0.0; source /root/.cargo/env; /root/.cargo/bin/cargo test --manifest-path rust/blitzar-sys/Cargo.toml; /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -eou pipefail
+
+export PATH=$PATH:/root/.cargo/bin/
+
+rustup default stable
+
+DST_SO_LIB_PATH=$1
+NEW_VERSION=$2
+
+# Validate the new version
+if ! [[ ${NEW_VERSION} =~ ^[0-9]+[.][0-9]+[.][0-9]+$ ]]
+then
+    echo "Incorrect semantic version format: " $NEW_VERSION
+    exit 1
+fi
+
+INCLUDE_FILE="blitzar_api"
+INCLUDE_PATH="cbindings"
+LIB_PATH="blitzar-sys"
+RUST_PATH="$(pwd)/rust"
+SRC_SO_LIB_PATH="bazel-bin/cbindings/libblitzar.so"
+
+# Generate the rust bindings based on the C bindings
+bindgen --allowlist-file ${INCLUDE_PATH}/${INCLUDE_FILE}.h ${INCLUDE_PATH}/${INCLUDE_FILE}.h -o ${RUST_PATH}/${LIB_PATH}/src/bindings.rs
+
+# Build the Shared Library
+bazel build -c opt --config=portable_glibc //cbindings:libblitzar.so
+
+# Copy the Shared Library to the `DST_SO_LIB_PATH
+if ! cmp -s $SRC_SO_LIB_PATH $DST_SO_LIB_PATH; then
+    cp $SRC_SO_LIB_PATH $DST_SO_LIB_PATH
+fi
+
+# Update the version in the blitzar-sys/Cargo.toml
+sed -i 's/version = "*.*.*" # DO NOT CHANGE/version = "'${NEW_VERSION}'" # DO NOT CHANGE/' ${RUST_PATH}/${LIB_PATH}/Cargo.toml

--- a/rust/blitzar-sys/Cargo.toml
+++ b/rust/blitzar-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blitzar-sys"
-version = "0.0.1" # DO NOT CHANGE
+version = "0.0.0" # DO NOT CHANGE
 edition = "2021"
 rust-version = "1.71.1"
 license = "Apache-2.0"

--- a/rust/blitzar-sys/Cargo.toml
+++ b/rust/blitzar-sys/Cargo.toml
@@ -1,10 +1,23 @@
 [package]
 name = "blitzar-sys"
-version = "0.0.0" 
+version = "0.0.1" # DO NOT CHANGE
 edition = "2021"
+rust-version = "1.71.1"
+license = "Apache-2.0"
+description = "Rust bindings for the Blitzar library"
 repository = "https://github.com/spaceandtimelabs/blitzar"
+keywords = ["gpu-cryptography", "gpu-crypto", "gpu-ristretto", "gpu-curve25519", "gpu-ristretto255"]
 
-exclude = ["/target", "/Cargo.lock"]
-include = ["/src", "build.rs", "Cargo.toml", "*.so*"]
+exclude = [
+    "**/.gitignore",
+    ".gitignore",
+    "/target",
+    "/Cargo.lock",
+    "*.so*"
+]
+include = ["/src", "build.rs", "Cargo.toml"]
 
 [dependencies]
+
+[build-dependencies]
+reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "rustls-tls"] }

--- a/rust/blitzar-sys/build.rs
+++ b/rust/blitzar-sys/build.rs
@@ -13,8 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!("Unsupported architecture. Only x86_64 is supported.");
     }
 
-    const LIB_NAME: &'static str = "blitzar";
-    const SHARED_LIB: &'static str = "libblitzar.so";
+    const LIB_NAME: &'static str = "blitzar-linux-amd64";
+    const SHARED_LIB: &'static str = "libblitzar-linux-amd64.so";
     const PKG_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);

--- a/rust/blitzar-sys/build.rs
+++ b/rust/blitzar-sys/build.rs
@@ -13,8 +13,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         panic!("Unsupported architecture. Only x86_64 is supported.");
     }
 
-    const LIB_NAME: &'static str = "blitzar-linux-amd64";
-    const SHARED_LIB: &'static str = "libblitzar-linux-amd64.so";
+    const LIB_NAME: &'static str = "blitzar-linux-x86_64";
+    const SHARED_LIB: &'static str = "libblitzar-linux-x86_64.so";
     const PKG_VERSION: &'static str = env!("CARGO_PKG_VERSION");
 
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);

--- a/rust/blitzar-sys/build.rs
+++ b/rust/blitzar-sys/build.rs
@@ -32,12 +32,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .success()
         );
     } else {
-        const REPO_NAME: &'static str = "blitzar";
-        const REPO_OWNER: &'static str = "spaceandtimelabs";
-
         // Download the shared library from GitHub releases and place it in the `OUT_DIR`.
         let mut lib_file = File::create(&lib_path)?;
-        let release_url = format!("http://github.com/{REPO_OWNER}/{REPO_NAME}/releases/download/v{PKG_VERSION}/{SHARED_LIB}");
+        let release_url = format!("http://github.com/spaceandtimelabs/blitzar/releases/download/v{PKG_VERSION}/{SHARED_LIB}");
         let mut response = reqwest::blocking::get(release_url)?;
         copy(&mut response, &mut lib_file)?;
 

--- a/rust/blitzar-sys/build.rs
+++ b/rust/blitzar-sys/build.rs
@@ -1,53 +1,53 @@
 use std::env;
-use std::fs;
-use std::path::Path;
+use std::fs::File;
+use std::io::copy;
 use std::path::PathBuf;
+use std::process::Command;
 
-fn build_blitzar_lib() {
-    const VERSION: &'static str = env!("CARGO_PKG_VERSION");
-    let reduced_lib_name = "blitzar";
-    let mut lib_name = format!("lib{}-v{}.so", reduced_lib_name, VERSION);
-    let lib_name_local = format!("lib{}.so", reduced_lib_name);
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if !cfg!(target_os = "linux") {
+        panic!("Unsupported OS. Only Linux is supported.");
+    }
 
-    // verify if the system is supported
-    if cfg!(target_os = "linux") {
-        lib_name = format!("{}-linux", lib_name);
+    if !cfg!(target_arch = "x86_64") {
+        panic!("Unsupported architecture. Only x86_64 is supported.");
+    }
+
+    const LIB_NAME: &'static str = "blitzar";
+    const SHARED_LIB: &'static str = "libblitzar.so";
+    const PKG_VERSION: &'static str = env!("CARGO_PKG_VERSION");
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let lib_path = out_dir.join(SHARED_LIB);
+
+    if PKG_VERSION == "0.0.0" {
+        // This is used solely with local tests. It will build the shared library from source.
+        assert!(Command::new("bash")
+            .current_dir("../../")
+            .arg("ci/build.sh")
+            .arg(&lib_path)
+            .arg("0.0.0")
+            .status()
+            .expect("Failed to run the build script")
+            .success()
+        );
     } else {
-        panic!("Unsupported OS");
+        const REPO_NAME: &'static str = "blitzar";
+        const REPO_OWNER: &'static str = "spaceandtimelabs";
+
+        // Download the shared library from GitHub releases and place it in the `OUT_DIR`.
+        let mut lib_file = File::create(&lib_path)?;
+        let release_url = format!("http://github.com/{REPO_OWNER}/{REPO_NAME}/releases/download/v{PKG_VERSION}/{SHARED_LIB}");
+        let mut response = reqwest::blocking::get(release_url)?;
+        copy(&mut response, &mut lib_file)?;
+
+        // Re-build the sys crate only under the following conditions
+        println!("cargo:rerun-if-changed=build.rs");
+        println!("cargo:rerun-if-env-changed=CARGO_PKG_VERSION");
     }
 
-    // verify if the architecture is supported
-    if cfg!(target_arch = "x86") {
-        lib_name = format!("{}-x86", lib_name);
-    } else if cfg!(target_arch = "x86_64") {
-        lib_name = format!("{}-x86_64", lib_name);
-    } else {
-        panic!("Unsupported architecture");
-    }
+    println!("cargo:rustc-link-search=native={}", out_dir.display());
+    println!("cargo:rustc-link-lib=dylib={LIB_NAME}");
 
-    let lib_src_path = format!("{}", lib_name);
-    let dst = PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    let lib_path = dst.join("lib");
-
-    if Path::new(lib_path.to_str().unwrap()).exists() {
-        fs::remove_dir_all(lib_path.clone())
-            .expect("Error removing lib directory");
-    }
-
-    // copy shared lib to output directory
-    fs::create_dir_all(lib_path.clone())
-        .expect("Couldn't create lib directory");
-
-    fs::copy(lib_src_path, lib_path.join(lib_name_local))
-        .expect("Couldn't find shared library");
-
-    println!("cargo:root={}", dst.to_str().unwrap());
-    println!("cargo:rustc-link-search=native={}", lib_path.to_str().unwrap());
-    println!("cargo:rustc-link-lib={}", reduced_lib_name);
-}
-
-fn main() {
-    build_blitzar_lib();
-
-    println!("cargo:rerun-if-changed=build.rs");
+    Ok(())
 }

--- a/rust/tests/Cargo.toml
+++ b/rust/tests/Cargo.toml
@@ -8,4 +8,4 @@ edition = "2021"
 [dependencies]
 
 [dependencies.blitzar-sys]
-path = "../blitzar-sys/"
+path = "../blitzar-sys/" # DO NOT CHANGE


### PR DESCRIPTION
# Rationale for this change

The Blitzar shared library needs to be downloaded by the Rust sys crate during the build process. This approach is better than building the library each time, which would be unfeasible as this process requires many dependencies.

# What changes are included in this PR?

* Update the Rust build script to build the Blitzar shared library locally under version 0.0.0 (only used with CI and tests).
* Update the Rust build script to download the Blitzar shared library from the GitHub release when the version is not 0.0.0.
* Update CI to test this build.

# Are these changes tested?

Only the local build is tested. The shared lib download will be tested in a consecutive PR.
