### PR TITLE
feat: setup semantic release and crates.io publishing ( PROOF-609 )

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - main
+      - feat/setup-semantic-release-PROOF-609
 
 jobs:
   test-check-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
         run: |
           sleep 5
           sed -i 's,path = "../blitzar-sys/" # DO NOT CHANGE,version = "*" # DO NOT CHANGE,' rust/tests/Cargo.toml
-          cargo test --manifest-path rust/tests/Cargo.toml
+          /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - feat/setup-semantic-release-PROOF-609
+      - main
 
 jobs:
   test-check-lint:
@@ -35,4 +35,4 @@ jobs:
           npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
-          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }} # TODO: enable once blitzar is open source
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,9 +36,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }} # TODO: enable once blitzar is open source
-
-      - name: Test published crate
-        run: |
-          sleep 5
-          sed -i 's,path = "../blitzar-sys/" # DO NOT CHANGE,version = "*" # DO NOT CHANGE,' rust/tests/Cargo.toml
-          /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  test-check-lint:
+    uses: ./.github/workflows/test-check-lint.yml
+
+  release:
+    name: Build Publish Library - Linux-x86_64
+    runs-on: ubuntu-latest
+    needs: [test-check-lint]
+    environment: deploy #!! DO NOT CHANGE THIS LINE !! #
+    container:
+      image: spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_TOKEN }}
+
+      - run: git config --global --add safe.directory $(realpath .)
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18.x"
+
+      - name: Semantic relase
+        run: |
+          npm install semantic-release
+          npx semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }} # TODO: enable once blitzar is open source
+
+      - name: Test published crate
+        run: |
+          sleep 5
+          sed -i 's,path = "../blitzar-sys/" # DO NOT CHANGE,version = "*" # DO NOT CHANGE,' rust/tests/Cargo.toml
+          cargo test --manifest-path rust/tests/Cargo.toml

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -2,10 +2,10 @@ name: Test-Check-Lint
 
 on:
   workflow_call:
-  # pull_request:
-  #   types:
-  #     - opened
-  #     - synchronize
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -2,10 +2,10 @@ name: Test-Check-Lint
 
 on:
   workflow_call:
-  pull_request:
-    types:
-      - opened
-      - synchronize
+  # pull_request:
+  #   types:
+  #     - opened
+  #     - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -50,7 +50,7 @@ if [ "$#" -eq 3 ]; then
         cd ..
         zip -r ${DIST_PATH}/blitzar-sys-v${NEW_VERSION}.zip ${LIB_PATH}
         tar -czvf ${DIST_PATH}/blitzar-sys-v${NEW_VERSION}.tar.gz ${LIB_PATH}
-        
+
         cd ${LIB_PATH}
         cargo publish --allow-dirty --token ${CRATES_TOKEN}
     fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -34,3 +34,24 @@ fi
 
 # Update the version in the blitzar-sys/Cargo.toml
 sed -i 's/version = "*.*.*" # DO NOT CHANGE/version = "'${NEW_VERSION}'" # DO NOT CHANGE/' ${RUST_PATH}/${LIB_PATH}/Cargo.toml
+
+# Generate the release assets and publish the crate to crates.io
+if [ "$#" -eq 3 ]; then
+    if [[ $3 == "--with-release" ]]
+    then
+        DIST_PATH="$(pwd)/dist"
+
+        mkdir -p ${DIST_PATH}
+        cp -f $DST_SO_LIB_PATH ${DIST_PATH}/$(basename "$DST_SO_LIB_PATH")
+        cp -f ${INCLUDE_PATH}/${INCLUDE_FILE}.h ${DIST_PATH}/${INCLUDE_FILE}.h
+
+        cd ${RUST_PATH}/${LIB_PATH}
+        cargo clean
+        cd ..
+        zip -r ${DIST_PATH}/blitzar-sys-v${NEW_VERSION}.zip ${LIB_PATH}
+        tar -czvf ${DIST_PATH}/blitzar-sys-v${NEW_VERSION}.tar.gz ${LIB_PATH}
+        
+        cd ${LIB_PATH}
+        cargo publish --allow-dirty --token ${CRATES_TOKEN}
+    fi
+fi

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "release": {
         "branches": [
-            "main"
+            "feat/setup-semantic-release-PROOF-609"
         ],
         "plugins": [
             [

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "release": {
         "branches": [
-            "feat/setup-semantic-release-PROOF-609"
+            "main"
         ],
         "plugins": [
             [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
             [
                 "@semantic-release/exec",
                 {
-                    "prepareCmd": "bash ci/build.sh bazel-bin/cbindings/libblitzar.so ${nextRelease.version} --with-release"
+                    "prepareCmd": "bash libblitzar-linux-x86_64.so ${nextRelease.version} --with-release"
                 }
             ],
             [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
             [
                 "@semantic-release/exec",
                 {
-                    "prepareCmd": "bash libblitzar-linux-x86_64.so ${nextRelease.version} --with-release"
+                    "prepareCmd": "bash ./ci/build.sh libblitzar-linux-x86_64.so ${nextRelease.version} --with-release"
                 }
             ],
             [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,63 @@
+{
+    "name": "blitzar_sxt",
+    "version": "0.0.0-development",
+    "devDependencies": {
+        "conventional-changelog-conventionalcommits": "^5.0.0",
+        "semantic-release": "^21.0.2"
+    },
+    "release": {
+        "branches": [
+            "main"
+        ],
+        "plugins": [
+            [
+                "@semantic-release/commit-analyzer",
+                {
+                    "preset": "conventionalCommits",
+                    "releaseRules": [
+                        {
+                            "type": "build",
+                            "release": "patch"
+                        }
+                    ],
+                    "parserOpts": {
+                        "noteKeywords": [
+                            "BREAKING CHANGE",
+                            "BREAKING CHANGES",
+                            "BREAKING"
+                        ]
+                    }
+                }
+            ],
+            "@semantic-release/release-notes-generator",
+            [
+                "@semantic-release/exec",
+                {
+                    "prepareCmd": "bash ci/build.sh bazel-bin/cbindings/libblitzar.so ${nextRelease.version} --with-release"
+                }
+            ],
+            [
+                "@semantic-release/github",
+                {
+                    "assets": [
+                        {
+                            "path": "dist/*.h"
+                        },
+                        {
+                            "path": "dist/*.so*"
+                        },
+                        {
+                            "path": "dist/*.zip"
+                        },
+                        {
+                            "path": "dist/*.tar.gz"
+                        }
+                    ]
+                }
+            ]
+        ]
+    },
+    "dependencies": {
+        "@semantic-release/exec": "^6.0.3"
+    }
+}


### PR DESCRIPTION
# Rationale for this change

We need to properly version the blitzar code. For that, we use semantic-release with the guidelines highlighted [here](https://github.com/spaceandtimelabs/blitzar/blob/main/CONTRIBUTING.md#-commit-message-guidelines). Assets are published to both GitHub releases and crates.io during this process. 

# What changes are included in this PR?

* Add semantic-release workflow to CI. It only executes during merges to main.
* Push the Blitzar sys crate, the Blitzar shared library, and the header file to GitHub releases.
* Publish the blitzar sys-crate to crates.io. Note: The sys crate downloads the shared library from GitHub releases during building time.
* Add a step to test the published crate.

# Are these changes tested?

No. We'll see the results after the code is merged into the main.
