### PR TITLE
ci: add docker files to repo ( PROOF-615 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,6 @@ Note: some tests will fail in case you don't have a GPU available.
 ```bash
 ./ci/docker/run_docker_gpu.sh
 
-# build the c++/cuda shared library and generate the rust bindings
-./ci/build.sh 0.0.0
-
 # run the sys-crate tests
 cargo test --manifest-path rust/blitzar-sys/Cargo.toml
 ```
@@ -285,8 +282,6 @@ See the Rust example here: [rust/tests/src/main.rs](./rust/tests/src/main.rs). T
 
 ```bash
 ./ci/docker/run_docker_gpu.sh
-
-./ci/build.sh 0.0.0
 
 cargo test --manifest-path rust/tests/Cargo.toml
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.2-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -171,7 +171,7 @@ See the [example](./example) folder for some examples.
 
 * `x86_64` Linux instance.
 * Docker installed (check [install guidelines](https://docs.docker.com/engine/install/ubuntu/)).
-* Nvidia GPU capable of run CUDA 12.1 code.
+* Nvidia GPU capable of run CUDA 12.2 code.
 * Recommended Nvidia Toolkit Driver Version: >= 530.30.02 (check the [compatibility list here](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html)).
 * [Nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) (necessary only if you intend to run tests and benchmarks on the GPU).
 

--- a/ci/docker/Dockerfile
+++ b/ci/docker/Dockerfile
@@ -1,0 +1,23 @@
+FROM nvidia/cuda:12.2.0-devel-ubuntu22.04
+
+WORKDIR /third_party
+
+ADD setup_build_environment.sh /third_party
+RUN chmod +x /third_party/setup_build_environment.sh
+RUN /third_party/setup_build_environment.sh
+
+ADD install_bazel.sh /third_party
+ADD install_buildifier.sh /third_party
+ADD install_clang_format.sh /third_party
+RUN chmod +x /third_party/install_buildifier.sh
+RUN chmod +x /third_party/install_clang_format.sh
+RUN chmod +x /third_party/install_bazel.sh
+RUN /third_party/install_bazel.sh && \
+    /third_party/install_clang_format.sh && \
+    /third_party/install_buildifier.sh
+
+ADD install_rust.sh /third_party
+RUN chmod +x /third_party/install_rust.sh
+RUN /third_party/install_rust.sh
+
+EXPOSE 8888

--- a/ci/docker/install_bazel.sh
+++ b/ci/docker/install_bazel.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+BAZELISK_VERSION=v1.1.0
+
+wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/$BAZELISK_VERSION/bazelisk-linux-amd64
+chmod +x /usr/local/bin/bazel

--- a/ci/docker/install_buildifier.sh
+++ b/ci/docker/install_buildifier.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+export DEBIAN_FRONTEND="noninteractive"
+export TZ=Etc/UTC
+
+# Install Go
+wget https://go.dev/dl/go1.18.4.linux-amd64.tar.gz
+tar -xzvf go1.18.4.linux-amd64.tar.gz -C /usr/local
+echo "export GOPATH=\"/usr/local/go\"" >> /etc/profile
+echo "export PATH=\$PATH:/usr/local/go/bin" >> /etc/profile
+
+# Install buildifier
+echo "export BUILDIFIER_BIN=\"\$GOPATH/bin/buildifier\"" >> /etc/profile
+source /etc/profile
+
+go install github.com/bazelbuild/buildtools/buildifier@5.1.0

--- a/ci/docker/install_clang_format.sh
+++ b/ci/docker/install_clang_format.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+# Install latest clang-format
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|apt-key add -
+apt-get update
+add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal main"
+apt-get update
+apt-get install --no-install-recommends --no-install-suggests -y \
+      clang-format
+
+# Export clang-format
+echo "export CLANG_FORMAT=\"$(which clang-format)\"" >> /etc/profile

--- a/ci/docker/install_rust.sh
+++ b/ci/docker/install_rust.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+export DEBIAN_FRONTEND="noninteractive"
+export TZ=Etc/UTC
+
+# Install rust
+curl https://sh.rustup.rs -sSf | bash -s -- -y --profile minimal
+
+echo 'source $HOME/.cargo/env' >> $HOME/.bashrc
+
+source "$HOME/.cargo/env"
+
+rustup install 1.71.1
+
+rustup component add rustfmt
+
+$HOME/.cargo/bin/cargo install --version 0.66.1 bindgen-cli

--- a/ci/docker/run_docker_cpu.sh
+++ b/ci/docker/run_docker_cpu.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+
+# If you don't have a GPU instance configured
+docker run --rm -v "$PWD":/src -w /src --privileged -it "$IMAGE" /bin/bash -l

--- a/ci/docker/run_docker_gpu.sh
+++ b/ci/docker/run_docker_gpu.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+
+# If you have a GPU instance configured in your machine
+docker run --rm -v "$PWD":/src -w /src --gpus all --privileged -it "$IMAGE" /bin/bash -l

--- a/ci/docker/setup_build_environment.sh
+++ b/ci/docker/setup_build_environment.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+set -e
+
+export DEBIAN_FRONTEND="noninteractive"
+export TZ=Etc/UTC
+
+apt-get update
+apt-get install --no-install-recommends --no-install-suggests -y \
+                software-properties-common \
+                build-essential \
+                zip \
+                git \
+                ca-certificates \
+                curl \
+                gnupg2 \
+                ssh \
+                wget \
+                python3 \
+                python3-pip \
+                llvm-dev \
+                libclang-dev \
+                clang \
+                graphviz \
+                valgrind
+
+# Upgrade to g++10
+# See https://ahelpme.com/linux/ubuntu/install-and-make-gnu-gcc-10-default-in-ubuntu-20-04-focal/
+apt-get install --no-install-recommends --no-install-suggests -y \
+                gcc-10 g++-10 cpp-10
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+
+# Install benchmark dependencies
+pip install gprof2dot===2022.7.29
+pip install matplotlib===3.7.0
+pip install slack_sdk===3.20.1
+pip install psutil===5.9.4
+pip install py-cpuinfo===9.0.0
+pip install pandas===1.5.3
+


### PR DESCRIPTION
# Rationale for this change

This PR adds the docker file scripts, necessary to build the development docker image `spaceandtimelabs/blitzar`.

# What changes are included in this PR?

* Only add the dockerfile and the auxiliary bash scripts.

# Are these changes tested?

No need.