### PR TITLE
ci: add clang rdc compilation error workaround to multiexp kernel component ( PROOF-630 )

### DIFF
--- a/sxt/multiexp/multiproduct_gpu/kernel.h
+++ b/sxt/multiexp/multiproduct_gpu/kernel.h
@@ -38,6 +38,13 @@ __global__ void multiproduct_kernel(typename Reducer::value_type* out,
                                     const block_computation_descriptor* block_descriptors) {
   using T = typename Reducer::value_type;
   extern __shared__ T shared_data_p[];
+  // Creating a object that points to shared_data_p to pass to the algr::thread_reduce
+  // function is a workaround for this issue https://github.com/llvm/llvm-project/issues/65806.
+  // According to the related PR fix that is currently open
+  // (https://github.com/llvm/llvm-project/pull/65990): "Clang puts extern shared var ODR-used by
+  // host device functions in global var __clang_gpu_used_external. This behavior was due to
+  // https://reviews.llvm.org/D123441. However, clang should not do that for extern shared vars
+  // since their addresses are per warp, therefore cannot be accessed by host code."
   T* shared_data = shared_data_p;
   auto thread_index = threadIdx.x;
   auto block_index = blockIdx.x;

--- a/sxt/multiexp/multiproduct_gpu/kernel.h
+++ b/sxt/multiexp/multiproduct_gpu/kernel.h
@@ -37,7 +37,8 @@ __global__ void multiproduct_kernel(typename Reducer::value_type* out,
                                     const unsigned* indexes,
                                     const block_computation_descriptor* block_descriptors) {
   using T = typename Reducer::value_type;
-  extern __shared__ T shared_data[];
+  extern __shared__ T shared_data_p[];
+  T* shared_data = shared_data_p;
   auto thread_index = threadIdx.x;
   auto block_index = blockIdx.x;
   auto descriptor = block_descriptors[block_index];


### PR DESCRIPTION
# Rationale for this change
The clang-18 compiler fails when compiling relocatable device code with dynamically allocated shared memory passed through a lambda expression ([see issue](https://github.com/llvm/llvm-project/issues/65806)). This situation happens in the `multiexp/multiproduct_gup:kernel` component.

In order to switch the compiler to clang-18, we need to use the a work around. The work around is to pass an object that points to the dynamically allocated shared memory object. This should be a temporary change while the clang compiler bug is still open.

# What changes are included in this PR?
* The function passed a dynamically allocated shared memory object in the `multiexp/multiproduct_gup:kernel` component is now passed an object that points to the dynamically allocated shared memory object

# Are these changes tested?
Yes, from previous tests with additional benchmark results outlined below.

## Benchmark results
Benchmarks were run on a System 76 laptop with an NVIDIA GeForce RTX 3080 GPU inside the Blitzar GPU Docker container to determine if any performance differences were introduced. The results are averaged over 5 consecutive executions. Both the method of testing (laptop instead of VM) and number of executions which might not make this benchmark statistically significant.

Test criteria
```
bazel run -c opt //benchmark/multi_commitment:benchmark -- gpu 1000000 5 1 32 1
backend : gpu
commitment length : 1000000
number of commitments : 1
element_nbytes : 32
is boolean : 0
table_size (MB) : 31250
num_exponentations : 1000000
```
Results before update
```
average compute duration (s) : 0.1797044
average compute std deviation (s) : 0.0024874
average throughput (exponentiations / s) : 5.56e+06
```
Results after update
```
average compute duration (s) : 0.1856728 (3.21% slower than before)
average compute std deviation (s) : 0.0047892 (48% more std deviation)
average throughput (exponentiations / s) : 5.39e+06 (3.25% less throughput)
```