### PR TITLE
ci: clean up code related clang warnings ( PROOF-635 )

### DIFF
--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -32,7 +32,7 @@ struct element_p3;
 }
 
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prft {

--- a/sxt/cbindings/backend/cpu_backend.h
+++ b/sxt/cbindings/backend/cpu_backend.h
@@ -33,7 +33,7 @@ struct element_p3;
 }
 
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prft {

--- a/sxt/cbindings/backend/gpu_backend.h
+++ b/sxt/cbindings/backend/gpu_backend.h
@@ -33,7 +33,7 @@ struct element_p3;
 }
 
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prft {

--- a/sxt/curve21/operation/scalar_multiply.h
+++ b/sxt/curve21/operation/scalar_multiply.h
@@ -34,7 +34,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::c21o {

--- a/sxt/curve_g1/operation/cmov.h
+++ b/sxt/curve_g1/operation/cmov.h
@@ -19,7 +19,7 @@
 #include "sxt/base/macro/cuda_callable.h"
 
 namespace sxt::cg1t {
-class element_p2;
+struct element_p2;
 }
 
 namespace sxt::cg1o {

--- a/sxt/curve_g1/operation/mul_by_3b.h
+++ b/sxt/curve_g1/operation/mul_by_3b.h
@@ -19,7 +19,7 @@
 #include "sxt/base/macro/cuda_callable.h"
 
 namespace sxt::f12t {
-struct element;
+class element;
 }
 
 namespace sxt::cg1o {

--- a/sxt/field12/base/arithmetic_utility.t.cc
+++ b/sxt/field12/base/arithmetic_utility.t.cc
@@ -116,8 +116,8 @@ TEST_CASE("sbb (subtraction and borrow) can handle computation") {
     uint64_t borrow{0};
     uint64_t ret{0};
     sbb(ret, borrow, a, b);
-    REQUIRE(ret == 1378099289637323008);
-    REQUIRE(borrow == 18446744073709551615);
+    REQUIRE(ret == 0x131ffe00a00d0100);
+    REQUIRE(borrow == 0xffffffffffffffff);
   }
 
   SECTION("with left summand less than than right summand and borrow") {
@@ -126,8 +126,8 @@ TEST_CASE("sbb (subtraction and borrow) can handle computation") {
     uint64_t borrow{0xdd5902076eb30a06};
     uint64_t ret{0};
     sbb(ret, borrow, a, b);
-    REQUIRE(ret == 2496962287454975480);
-    REQUIRE(borrow == 18446744073709551615);
+    REQUIRE(ret == 0x22a6fdf8914cf5f8);
+    REQUIRE(borrow == 0xffffffffffffffff);
   }
 
   SECTION("with left summand greater than right summand and no borrow") {
@@ -136,7 +136,7 @@ TEST_CASE("sbb (subtraction and borrow) can handle computation") {
     uint64_t borrow{0};
     uint64_t ret{0};
     sbb(ret, borrow, a, b);
-    REQUIRE(ret == 17068644784072228608);
+    REQUIRE(ret == 0xece001ff5ff2ff00);
     REQUIRE(borrow == 0);
   }
 
@@ -146,8 +146,8 @@ TEST_CASE("sbb (subtraction and borrow) can handle computation") {
     uint64_t borrow{0xdd5902076eb30a06};
     uint64_t ret{0};
     sbb(ret, borrow, a, b);
-    REQUIRE(ret == 15949781786254576134);
-    REQUIRE(borrow == 0);
+    REQUIRE(ret == 0xdd5902076eb30a06);
+    REQUIRE(borrow == 0x0);
   }
 }
 

--- a/sxt/multiexp/pippenger/driver.h
+++ b/sxt/multiexp/pippenger/driver.h
@@ -29,7 +29,7 @@ class span_cvoid;
 } // namespace sxt::basct
 
 namespace sxt::mtxb {
-class exponent_sequence;
+struct exponent_sequence;
 }
 namespace sxt::mtxi {
 class index_table;

--- a/sxt/multiexp/pippenger/exponent_aggregates_computation.h
+++ b/sxt/multiexp/pippenger/exponent_aggregates_computation.h
@@ -21,7 +21,7 @@
 #include "sxt/base/container/span.h"
 
 namespace sxt::mtxb {
-struct exponent_sequence;
+class exponent_sequence;
 }
 
 namespace sxt::mtxpi {

--- a/sxt/multiexp/pippenger/multiproduct_table.h
+++ b/sxt/multiexp/pippenger/multiproduct_table.h
@@ -25,7 +25,7 @@ namespace sxt::basct {
 class blob_array;
 }
 namespace sxt::mtxb {
-class exponent_sequence;
+struct exponent_sequence;
 } // namespace sxt::mtxb
 namespace sxt::mtxi {
 class index_table;

--- a/sxt/proof/inner_product/cpu_workspace.h
+++ b/sxt/proof/inner_product/cpu_workspace.h
@@ -26,7 +26,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prfip {

--- a/sxt/proof/inner_product/driver.h
+++ b/sxt/proof/inner_product/driver.h
@@ -25,7 +25,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::s25t {
-struct element;
+class element;
 }
 namespace sxt::rstt {
 class compressed_element;

--- a/sxt/proof/inner_product/proof_computation.h
+++ b/sxt/proof/inner_product/proof_computation.h
@@ -26,7 +26,7 @@ namespace sxt::rstt {
 class compressed_element;
 }
 namespace sxt::s25t {
-struct element;
+class element;
 }
 namespace sxt::prft {
 class transcript;

--- a/sxt/proof/inner_product/workspace.h
+++ b/sxt/proof/inner_product/workspace.h
@@ -19,7 +19,7 @@
 #include "sxt/execution/async/future_fwd.h"
 
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prfip {

--- a/sxt/proof/transcript/transcript_primitive.h
+++ b/sxt/proof/transcript/transcript_primitive.h
@@ -19,11 +19,11 @@
 #include <type_traits>
 
 namespace sxt::rstt {
-struct compressed_element;
+class compressed_element;
 }
 
 namespace sxt::s25t {
-struct element;
+class element;
 }
 
 namespace sxt::prft {

--- a/sxt/ristretto/operation/add.h
+++ b/sxt/ristretto/operation/add.h
@@ -22,7 +22,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::rstt {
-struct compressed_element;
+class compressed_element;
 }
 
 namespace sxt::rsto {

--- a/sxt/ristretto/operation/scalar_multiply.h
+++ b/sxt/ristretto/operation/scalar_multiply.h
@@ -26,7 +26,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::rstt {
-struct compressed_element;
+class compressed_element;
 }
 
 namespace sxt::rsto {

--- a/sxt/seqcommit/generator/base_element.h
+++ b/sxt/seqcommit/generator/base_element.h
@@ -24,7 +24,7 @@ namespace sxt::c21t {
 struct element_p3;
 }
 namespace sxt::rstt {
-struct compressed_element;
+class compressed_element;
 }
 
 namespace sxt::sqcgn {


### PR DESCRIPTION
# Rationale for this change
When building with the clang compiler, we get various code warnings. Fixing these code warnings will help the code base and can be done before the compiler is updated to clang. This PR addresses code updates needed to get rid of the warnings issued from the clang compiler.

# What changes are included in this PR?
* multiple struct/class instance renaming
* integer literal converted to hex in test component

# Are these changes tested?
Yes, from previous tests.
