### PR TITLE
Draft: ci: add clang-18 to Docker image env setup ( PROOF-633 )

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
     container:
-      image: spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+      image: spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run check
-        run: docker run --rm -v "$PWD":/src -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "PYTHONDONTWRITEBYTECODE=1 ./tools/code_format/check_format.py check"
+        run: docker run --rm -v "$PWD":/src -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "PYTHONDONTWRITEBYTECODE=1 ./tools/code_format/check_format.py check"
 
   test-cpp:
     name: C++ code
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cpp tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test //..."
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test //..."
 
   test-cpp-asan:
     name: C++ code with address sanitizer
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
       
       - name: Run cpp-asan tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_asan:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test --config=asan //..."
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_asan:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test --config=asan //..."
 
   test-rust:
     name: Rust Sys Crate
@@ -50,4 +50,4 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run rust tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_rust:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; source /root/.cargo/env; /root/.cargo/bin/cargo test --manifest-path rust/blitzar-sys/Cargo.toml; /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml"
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_rust:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; source /root/.cargo/env; /root/.cargo/bin/cargo test --manifest-path rust/blitzar-sys/Cargo.toml; /root/.cargo/bin/cargo test --manifest-path rust/tests/Cargo.toml"

--- a/ci/docker/run_docker_cpu.sh
+++ b/ci/docker/run_docker_cpu.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1
 
 # If you don't have a GPU instance configured
 docker run --rm -v "$PWD":/src -w /src --privileged -it "$IMAGE" /bin/bash -l

--- a/ci/docker/run_docker_gpu.sh
+++ b/ci/docker/run_docker_gpu.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-0
+IMAGE=spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1
 
 # If you have a GPU instance configured in your machine
 docker run --rm -v "$PWD":/src -w /src --gpus all --privileged -it "$IMAGE" /bin/bash -l

--- a/ci/docker/setup_build_environment.sh
+++ b/ci/docker/setup_build_environment.sh
@@ -24,6 +24,12 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 graphviz \
                 valgrind
 
+# Upgrade to g++10
+# See https://ahelpme.com/linux/ubuntu/install-and-make-gnu-gcc-10-default-in-ubuntu-20-04-focal/
+apt-get install --no-install-recommends --no-install-suggests -y \
+                gcc-10 g++-10 cpp-10
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+
 # Upgrade to clang-18
 # See https://linux.how2shout.com/how-to-install-clang-on-ubuntu-linux/
 wget https://apt.llvm.org/llvm.sh

--- a/ci/docker/setup_build_environment.sh
+++ b/ci/docker/setup_build_environment.sh
@@ -24,11 +24,13 @@ apt-get install --no-install-recommends --no-install-suggests -y \
                 graphviz \
                 valgrind
 
-# Upgrade to g++10
-# See https://ahelpme.com/linux/ubuntu/install-and-make-gnu-gcc-10-default-in-ubuntu-20-04-focal/
-apt-get install --no-install-recommends --no-install-suggests -y \
-                gcc-10 g++-10 cpp-10
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10 --slave /usr/bin/gcov gcov /usr/bin/gcov-10
+# Upgrade to clang-18
+# See https://linux.how2shout.com/how-to-install-clang-on-ubuntu-linux/
+wget https://apt.llvm.org/llvm.sh
+chmod +x llvm.sh
+./llvm.sh 18
+update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
 
 # Install benchmark dependencies
 pip install gprof2dot===2022.7.29


### PR DESCRIPTION
# Rationale for this change
The build environment for the Docker image should be updated to add `clang-18` as a compiler option.

What still needs done:
- [x] The Docker image needs to be uploaded to Docker hub.

# What changes are included in this PR?
- `clang-18` is now also installed in the `ci/docker/setup_build_environment.sh` shell script.
- `spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1` has been built.
- The tag has been updated in the appropriate files.

# Are these changes tested?
Yes