### PR TITLE
build: drop unnecessary rust version restriction ( PROOF-625 )

### DIFF
--- a/rust/blitzar-sys/Cargo.toml
+++ b/rust/blitzar-sys/Cargo.toml
@@ -2,7 +2,6 @@
 name = "blitzar-sys"
 version = "0.0.0" # DO NOT CHANGE
 edition = "2021"
-rust-version = "1.71.1"
 license = "Apache-2.0"
 description = "Rust bindings for the Blitzar library"
 repository = "https://github.com/spaceandtimelabs/blitzar"


### PR DESCRIPTION
# Rationale for this change

This PR removes the Rust version requirement of at least 1.71.1 from the Cargo.toml file for the Blitzar-sys crate.

# What changes are included in this PR?

* Remove the Rust version restriction.

# Are these changes tested?

No.
