### PR TITLE
build: fix tests (PROOF-620)

### DIFF
--- a/bazel/sxt_build_system.bzl
+++ b/bazel/sxt_build_system.bzl
@@ -43,13 +43,14 @@ def sxt_cc_component(
         ] + deps + test_deps
         cuda_library(
             name = test_lib,
-            copts = sxt_copts(),
+            copts = sxt_copts() + copts,
             deps = [
                 ":" + name,
             ] + test_deps,
             srcs = [
                 name + ".t.cc",
             ],
+            alwayslink = 1,
             rdc = True,
         )
         native.cc_test(

--- a/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h
+++ b/sxt/multiexp/multiproduct_gpu/multiproduct_computation_descriptor.h
@@ -29,6 +29,6 @@ struct multiproduct_computation_descriptor {
   xenk::block_size_t max_block_size;
   memmg::managed_array<block_computation_descriptor> block_descriptors;
 
-  auto operator<=>(const multiproduct_computation_descriptor&) const noexcept = default;
+  bool operator==(const multiproduct_computation_descriptor&) const noexcept = default;
 };
 } // namespace sxt::mtxmpg


### PR DESCRIPTION
# Rationale for this change

In switching to clang, I missed an option in the build that is skipping all of the tests.

# What changes are included in this PR?

* Add missing alwayslink option so that tests can run
* Fix a warning that clang gives.

# Are these changes tested?

Yes.
