### PR TITLE
fix: workaround to nvlink bug (PROOF-642)

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -43,7 +43,7 @@ jobs:
           #       See https://developer.nvidia.com/bugs/4288496
           #       As a simple workaround, I'm disabling for now
       - name: Run cpp tests with optimization flags on
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel_opt -v $HOME/.cache_bazel_test_opt:/root/.cache_bazel_opt -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test -c opt //... -- -//sxt/multiexp/multiproduct_gpu:* -//sxt/algorithm/iteration:*"
+        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel_opt -v $HOME/.cache_bazel_test_opt:/root/.cache_bazel_opt -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test -c opt //..."
 
   test-cpp-asan:
     name: C++ code with address sanitizer

--- a/sxt/execution/async/awaiter.cc
+++ b/sxt/execution/async/awaiter.cc
@@ -17,7 +17,7 @@
 #include "sxt/execution/async/awaiter.h"
 
 namespace sxt::xena {
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* template class awaiter<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/awaiter.cc
+++ b/sxt/execution/async/awaiter.cc
@@ -17,5 +17,7 @@
 #include "sxt/execution/async/awaiter.h"
 
 namespace sxt::xena {
-template class awaiter<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* template class awaiter<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/awaiter.h
+++ b/sxt/execution/async/awaiter.h
@@ -60,5 +60,7 @@ private:
   std::optional<basdv::active_device_guard> active_guard_;
 };
 
-extern template class awaiter<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class awaiter<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/awaiter.h
+++ b/sxt/execution/async/awaiter.h
@@ -60,7 +60,7 @@ private:
   std::optional<basdv::active_device_guard> active_guard_;
 };
 
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class awaiter<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/coroutine_promise.cc
+++ b/sxt/execution/async/coroutine_promise.cc
@@ -17,5 +17,7 @@
 #include "sxt/execution/async/coroutine_promise.h"
 
 namespace sxt::xena {
-template class coroutine_promise<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* template class coroutine_promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/coroutine_promise.cc
+++ b/sxt/execution/async/coroutine_promise.cc
@@ -17,7 +17,7 @@
 #include "sxt/execution/async/coroutine_promise.h"
 
 namespace sxt::xena {
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* template class coroutine_promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/coroutine_promise.h
+++ b/sxt/execution/async/coroutine_promise.h
@@ -77,5 +77,7 @@ public:
   void return_void() noexcept { this->promise_.make_ready(); }
 };
 
-extern template class coroutine_promise<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class coroutine_promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/coroutine_promise.h
+++ b/sxt/execution/async/coroutine_promise.h
@@ -77,7 +77,7 @@ public:
   void return_void() noexcept { this->promise_.make_ready(); }
 };
 
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class coroutine_promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/future.cc
+++ b/sxt/execution/async/future.cc
@@ -17,7 +17,9 @@
 #include "sxt/execution/async/future.h"
 
 namespace sxt::xena {
-template class future<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* template class future<void>; */
 
 //--------------------------------------------------------------------------------------------------
 // make_ready_future

--- a/sxt/execution/async/future.cc
+++ b/sxt/execution/async/future.cc
@@ -17,7 +17,7 @@
 #include "sxt/execution/async/future.h"
 
 namespace sxt::xena {
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* template class future<void>; */
 

--- a/sxt/execution/async/future.h
+++ b/sxt/execution/async/future.h
@@ -145,7 +145,9 @@ private:
   }
 };
 
-extern template class future<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class future<void>; */
 
 //--------------------------------------------------------------------------------------------------
 // make_ready_future

--- a/sxt/execution/async/future.h
+++ b/sxt/execution/async/future.h
@@ -145,7 +145,7 @@ private:
   }
 };
 
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class future<void>; */
 

--- a/sxt/execution/async/promise.cc
+++ b/sxt/execution/async/promise.cc
@@ -17,7 +17,7 @@
 #include "sxt/execution/async/promise.h"
 
 namespace sxt::xena {
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class promise<void>; */
 /* template class promise<void>; */

--- a/sxt/execution/async/promise.cc
+++ b/sxt/execution/async/promise.cc
@@ -17,5 +17,8 @@
 #include "sxt/execution/async/promise.h"
 
 namespace sxt::xena {
-template class promise<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class promise<void>; */
+/* template class promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/promise.h
+++ b/sxt/execution/async/promise.h
@@ -83,5 +83,7 @@ private:
   task* continuation_{nullptr};
 };
 
-extern template class promise<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/async/promise.h
+++ b/sxt/execution/async/promise.h
@@ -83,7 +83,7 @@ private:
   task* continuation_{nullptr};
 };
 
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class promise<void>; */
 } // namespace sxt::xena

--- a/sxt/execution/device/computation_event.cc
+++ b/sxt/execution/device/computation_event.cc
@@ -17,5 +17,7 @@
 #include "sxt/execution/device/computation_event.h"
 
 namespace sxt::xendv {
-template class computation_event<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* template class computation_event<void>; */
 } // namespace sxt::xendv

--- a/sxt/execution/device/computation_event.cc
+++ b/sxt/execution/device/computation_event.cc
@@ -17,7 +17,7 @@
 #include "sxt/execution/device/computation_event.h"
 
 namespace sxt::xendv {
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* template class computation_event<void>; */
 } // namespace sxt::xendv

--- a/sxt/execution/device/computation_event.h
+++ b/sxt/execution/device/computation_event.h
@@ -51,7 +51,7 @@ private:
   xena::promise<T> promise_;
 };
 
-// Disable explicit instantiation. Workaround to 
+// Disable explicit instantiation. Workaround to
 // https://developer.nvidia.com/bugs/4288496
 /* extern template class computation_event<void>; */
 } // namespace sxt::xendv

--- a/sxt/execution/device/computation_event.h
+++ b/sxt/execution/device/computation_event.h
@@ -51,5 +51,7 @@ private:
   xena::promise<T> promise_;
 };
 
-extern template class computation_event<void>;
+// Disable explicit instantiation. Workaround to 
+// https://developer.nvidia.com/bugs/4288496
+/* extern template class computation_event<void>; */
 } // namespace sxt::xendv


### PR DESCRIPTION
# Rationale for this change

Nvlink crashes when using `extern templates`. I put in https://developer.nvidia.com/bugs/4288496 and Nvidia should be on track to fix in a future toolkit release. In the meantime, I'm commenting out the cases where we use `extern template`.

# What changes are included in this PR?

Disabling `extern template`.

# Are these changes tested?

Reuses existing tests. Additionally, I re-enabled some test that were failing to build without the workaround.
