### PR TITLE
feat: the G1 curve should support element compression ( PROOF-664 )

### DIFF
--- a/sxt/curve_g1/operation/BUILD
+++ b/sxt/curve_g1/operation/BUILD
@@ -50,6 +50,33 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "compression",
+    impl_deps = [
+        "//sxt/base/error:assert",
+        "//sxt/base/num:cmov",
+        "//sxt/curve_g1/type:conversion_utility",
+        "//sxt/curve_g1/type:compressed_element",
+        "//sxt/curve_g1/type:element_affine",
+        "//sxt/curve_g1/type:element_p2",
+        "//sxt/field12/base:byte_conversion",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/operation:cmov",
+        "//sxt/field12/property:lexicographically_largest",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_g1/constant:generator",
+        "//sxt/curve_g1/type:compressed_element",
+        "//sxt/curve_g1/type:element_p2",
+        "//sxt/field12/constant:one",
+        "//sxt/field12/constant:zero",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)
+
+sxt_cc_component(
     name = "double",
     impl_deps = [
         ":cmov",

--- a/sxt/curve_g1/operation/BUILD
+++ b/sxt/curve_g1/operation/BUILD
@@ -70,6 +70,8 @@ sxt_cc_component(
         "//sxt/curve_g1/type:element_p2",
         "//sxt/field12/constant:one",
         "//sxt/field12/constant:zero",
+        "//sxt/field12/operation:mul",
+        "//sxt/field12/type:element",
     ],
     deps = [
         "//sxt/base/container:span",

--- a/sxt/curve_g1/operation/compression.cc
+++ b/sxt/curve_g1/operation/compression.cc
@@ -14,6 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
 #include "sxt/curve_g1/operation/compression.h"
 
 #include "sxt/base/error/assert.h"

--- a/sxt/curve_g1/operation/compression.cc
+++ b/sxt/curve_g1/operation/compression.cc
@@ -49,13 +49,13 @@ void compress(cg1t::compressed_element& e_c, const cg1t::element_p2& e_p) noexce
   f12b::to_bytes(e_c.data(), e_a.X.data());
 
   // This point is in compressed form, so we set the most significant bit.
-  e_c.data()[47] |= static_cast<uint8_t>(1) << 7;
+  e_c.data()[0] |= static_cast<uint8_t>(1) << 7;
 
   // Is this point at infinity? If so, set the second-most significant bit.
   uint8_t pt_inf{static_cast<uint8_t>(0)};
   constexpr uint8_t pt_inf_bit{static_cast<uint8_t>(1) << 6};
   basn::cmov(pt_inf, pt_inf_bit, e_a.infinity);
-  e_c.data()[47] |= pt_inf;
+  e_c.data()[0] |= pt_inf;
 
   // Is the y-coordinate the lexicographically largest of the two associated with the
   // x-coordinate? If so, set the third-most significant bit so long as this is not
@@ -64,7 +64,7 @@ void compress(cg1t::compressed_element& e_c, const cg1t::element_p2& e_p) noexce
   constexpr uint8_t lx_lrg_bit{static_cast<uint8_t>(1) << 5};
   const bool t{!e_a.infinity && f12p::lexicographically_largest(e_a.Y)};
   basn::cmov(y_lx_lrg, lx_lrg_bit, t);
-  e_c.data()[47] |= y_lx_lrg;
+  e_c.data()[0] |= y_lx_lrg;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/curve_g1/operation/compression.cc
+++ b/sxt/curve_g1/operation/compression.cc
@@ -1,0 +1,71 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/operation/compression.h"
+
+#include "sxt/base/error/assert.h"
+#include "sxt/base/num/cmov.h"
+#include "sxt/curve_g1/type/compressed_element.h"
+#include "sxt/curve_g1/type/conversion_utility.h"
+#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/base/byte_conversion.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/operation/cmov.h"
+#include "sxt/field12/property/lexicographically_largest.h"
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// compress
+//--------------------------------------------------------------------------------------------------
+void compress(cg1t::compressed_element& e_c, const cg1t::element_p2& e_p) noexcept {
+  cg1t::element_affine e_a;
+  cg1t::to_element_affine(e_a, e_p);
+
+  f12o::cmov(e_a.X, f12cn::zero_v, e_a.infinity);
+
+  f12b::to_bytes(e_c.data(), e_a.X.data());
+
+  // This point is in compressed form, so we set the most significant bit.
+  e_c.data()[47] |= static_cast<uint8_t>(1) << 7;
+
+  // Is this point at infinity? If so, set the second-most significant bit.
+  uint8_t pt_inf{static_cast<uint8_t>(0)};
+  constexpr uint8_t pt_inf_bit{static_cast<uint8_t>(1) << 6};
+  basn::cmov(pt_inf, pt_inf_bit, e_a.infinity);
+  e_c.data()[47] |= pt_inf;
+
+  // Is the y-coordinate the lexicographically largest of the two associated with the
+  // x-coordinate? If so, set the third-most significant bit so long as this is not
+  // the point at infinity.
+  uint8_t y_lx_lrg{static_cast<uint8_t>(0)};
+  constexpr uint8_t lx_lrg_bit{static_cast<uint8_t>(1) << 5};
+  const bool t{!e_a.infinity && f12p::lexicographically_largest(e_a.Y)};
+  basn::cmov(y_lx_lrg, lx_lrg_bit, t);
+  e_c.data()[47] |= y_lx_lrg;
+}
+
+//--------------------------------------------------------------------------------------------------
+// batch_compress
+//--------------------------------------------------------------------------------------------------
+void batch_compress(basct::span<cg1t::compressed_element> ex_c,
+                    basct::cspan<cg1t::element_p2> ex_p) noexcept {
+  SXT_DEBUG_ASSERT(ex_c.size() == ex_p.size());
+  for (size_t i = 0; i < ex_p.size(); ++i) {
+    compress(ex_c[i], ex_p[i]);
+  }
+}
+} // namespace sxt::cg1o

--- a/sxt/curve_g1/operation/compression.h
+++ b/sxt/curve_g1/operation/compression.h
@@ -1,0 +1,37 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::cg1t {
+class compressed_element;
+struct element_p2;
+} // namespace sxt::cg1t
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// compress
+//--------------------------------------------------------------------------------------------------
+void compress(cg1t::compressed_element& e_c, const cg1t::element_p2& e_p) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// batch_compress
+//--------------------------------------------------------------------------------------------------
+void batch_compress(basct::span<cg1t::compressed_element> ex_c,
+                    basct::cspan<cg1t::element_p2> ex_p) noexcept;
+} // namespace sxt::cg1o

--- a/sxt/curve_g1/operation/compression.t.cc
+++ b/sxt/curve_g1/operation/compression.t.cc
@@ -22,6 +22,8 @@
 #include "sxt/curve_g1/type/element_p2.h"
 #include "sxt/field12/constant/one.h"
 #include "sxt/field12/constant/zero.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/type/element.h"
 
 using namespace sxt;
 using namespace sxt::cg1o;
@@ -97,5 +99,35 @@ TEST_CASE("batch compression correctly marks bits related to the") {
       REQUIRE(!((results[i].data()[47] & infinity_bit) >> 6));
       REQUIRE(!((results[i].data()[47] & lexicographically_largest_bit) >> 5));
     }
+  }
+}
+
+TEST_CASE("compression of two G1 curve elements that are") {
+  SECTION("different remain different") {
+    cg1t::compressed_element ce1;
+    cg1t::compressed_element ce2;
+
+    compress(ce1, cg1cn::generator_p2_v);
+    compress(ce2, cg1t::element_p2::identity());
+
+    REQUIRE(ce1 != ce2);
+  }
+
+  SECTION("projected remain the same") {
+    cg1t::compressed_element ce1;
+    cg1t::compressed_element ce2;
+
+    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
+                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+    f12t::element gpx_z;
+    f12t::element gpy_z;
+    f12o::mul(gpx_z, cg1cn::generator_p2_v.X, z);
+    f12o::mul(gpy_z, cg1cn::generator_p2_v.Y, z);
+    cg1t::element_p2 projected_generator{gpx_z, gpy_z, z};
+
+    compress(ce1, cg1cn::generator_p2_v);
+    compress(ce2, projected_generator);
+
+    REQUIRE(ce1 == ce2);
   }
 }

--- a/sxt/curve_g1/operation/compression.t.cc
+++ b/sxt/curve_g1/operation/compression.t.cc
@@ -1,0 +1,101 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/operation/compression.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/constant/generator.h"
+#include "sxt/curve_g1/type/compressed_element.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+
+using namespace sxt;
+using namespace sxt::cg1o;
+
+TEST_CASE("compression correctly marks bits related to the") {
+  constexpr uint8_t compressed_bit{static_cast<uint8_t>(1) << 7};
+  constexpr uint8_t infinity_bit{static_cast<uint8_t>(1) << 6};
+  constexpr uint8_t lexicographically_largest_bit{static_cast<uint8_t>(1) << 5};
+
+  SECTION("generator") {
+    cg1t::compressed_element result;
+
+    compress(result, cg1cn::generator_p2_v);
+
+    REQUIRE((result.data()[47] & compressed_bit) >> 7);
+    REQUIRE(!((result.data()[47] & infinity_bit) >> 6));
+    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+  }
+
+  SECTION("point at infinity") {
+    cg1t::compressed_element result;
+
+    cg1t::element_p2 inf_elm{f12cn::zero_v, f12cn::one_v, f12cn::zero_v};
+
+    compress(result, inf_elm);
+
+    REQUIRE((result.data()[47] & compressed_bit) >> 7);
+    REQUIRE((result.data()[47] & infinity_bit) >> 6);
+    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+  }
+
+  SECTION("lexicographically largest element") {
+    cg1t::compressed_element result;
+
+    // This element is not on the curve. It is just used for testing compression.
+    f12t::element e{0x43f5fffffffcaaae, 0x32b7fff2ed47fffd, 0x07e83a49a2e99d69,
+                    0xeca8f3318332bb7a, 0xef148d1ea0f4c069, 0x040ab3263eff0206};
+    cg1t::element_p2 ll_elm{f12cn::one_v, e, f12cn::one_v};
+
+    compress(result, ll_elm);
+
+    REQUIRE((result.data()[47] & compressed_bit) >> 7);
+    REQUIRE(!((result.data()[47] & infinity_bit) >> 6));
+    REQUIRE(((result.data()[47] & lexicographically_largest_bit) >> 5));
+
+    // Make point at infinity.
+    ll_elm.Z = f12cn::zero_v;
+
+    compress(result, ll_elm);
+
+    REQUIRE((result.data()[47] & compressed_bit) >> 7);
+    REQUIRE((result.data()[47] & infinity_bit) >> 6);
+    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+  }
+}
+
+TEST_CASE("batch compression correctly marks bits related to the") {
+  constexpr uint8_t compressed_bit{static_cast<uint8_t>(1) << 7};
+  constexpr uint8_t infinity_bit{static_cast<uint8_t>(1) << 6};
+  constexpr uint8_t lexicographically_largest_bit{static_cast<uint8_t>(1) << 5};
+
+  SECTION("generator") {
+    std::vector<cg1t::compressed_element> res_vec{cg1t::compressed_element{},
+                                                  cg1t::compressed_element{}};
+    basct::span<cg1t::compressed_element> results{res_vec};
+    const std::vector<cg1t::element_p2> gen_vec{cg1cn::generator_p2_v, cg1cn::generator_p2_v};
+    basct::cspan<cg1t::element_p2> generators{gen_vec};
+
+    batch_compress(results, generators);
+
+    for (size_t i = 0; i < generators.size(); ++i) {
+      REQUIRE((results[i].data()[47] & compressed_bit) >> 7);
+      REQUIRE(!((results[i].data()[47] & infinity_bit) >> 6));
+      REQUIRE(!((results[i].data()[47] & lexicographically_largest_bit) >> 5));
+    }
+  }
+}

--- a/sxt/curve_g1/operation/compression.t.cc
+++ b/sxt/curve_g1/operation/compression.t.cc
@@ -38,9 +38,9 @@ TEST_CASE("compression correctly marks bits related to the") {
 
     compress(result, cg1cn::generator_p2_v);
 
-    REQUIRE((result.data()[47] & compressed_bit) >> 7);
-    REQUIRE(!((result.data()[47] & infinity_bit) >> 6));
-    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+    REQUIRE((result.data()[0] & compressed_bit) >> 7);
+    REQUIRE(!((result.data()[0] & infinity_bit) >> 6));
+    REQUIRE(!((result.data()[0] & lexicographically_largest_bit) >> 5));
   }
 
   SECTION("point at infinity") {
@@ -50,9 +50,9 @@ TEST_CASE("compression correctly marks bits related to the") {
 
     compress(result, inf_elm);
 
-    REQUIRE((result.data()[47] & compressed_bit) >> 7);
-    REQUIRE((result.data()[47] & infinity_bit) >> 6);
-    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+    REQUIRE((result.data()[0] & compressed_bit) >> 7);
+    REQUIRE((result.data()[0] & infinity_bit) >> 6);
+    REQUIRE(!((result.data()[0] & lexicographically_largest_bit) >> 5));
   }
 
   SECTION("lexicographically largest element") {
@@ -65,18 +65,18 @@ TEST_CASE("compression correctly marks bits related to the") {
 
     compress(result, ll_elm);
 
-    REQUIRE((result.data()[47] & compressed_bit) >> 7);
-    REQUIRE(!((result.data()[47] & infinity_bit) >> 6));
-    REQUIRE(((result.data()[47] & lexicographically_largest_bit) >> 5));
+    REQUIRE((result.data()[0] & compressed_bit) >> 7);
+    REQUIRE(!((result.data()[0] & infinity_bit) >> 6));
+    REQUIRE(((result.data()[0] & lexicographically_largest_bit) >> 5));
 
     // Make point at infinity.
     ll_elm.Z = f12cn::zero_v;
 
     compress(result, ll_elm);
 
-    REQUIRE((result.data()[47] & compressed_bit) >> 7);
-    REQUIRE((result.data()[47] & infinity_bit) >> 6);
-    REQUIRE(!((result.data()[47] & lexicographically_largest_bit) >> 5));
+    REQUIRE((result.data()[0] & compressed_bit) >> 7);
+    REQUIRE((result.data()[0] & infinity_bit) >> 6);
+    REQUIRE(!((result.data()[0] & lexicographically_largest_bit) >> 5));
   }
 }
 
@@ -95,9 +95,9 @@ TEST_CASE("batch compression correctly marks bits related to the") {
     batch_compress(results, generators);
 
     for (size_t i = 0; i < generators.size(); ++i) {
-      REQUIRE((results[i].data()[47] & compressed_bit) >> 7);
-      REQUIRE(!((results[i].data()[47] & infinity_bit) >> 6));
-      REQUIRE(!((results[i].data()[47] & lexicographically_largest_bit) >> 5));
+      REQUIRE((results[i].data()[0] & compressed_bit) >> 7);
+      REQUIRE(!((results[i].data()[0] & infinity_bit) >> 6));
+      REQUIRE(!((results[i].data()[0] & lexicographically_largest_bit) >> 5));
     }
   }
 }

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -4,6 +4,16 @@ load(
 )
 
 sxt_cc_component(
+    name = "compressed_element",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
     name = "conversion_utility",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/curve_g1/type/compressed_element.cc
+++ b/sxt/curve_g1/type/compressed_element.cc
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/compressed_element.h"
+
+#include <cstring>
+#include <iostream>
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+compressed_element::compressed_element(std::initializer_list<uint8_t> values) noexcept : data_{} {
+  std::memcpy(static_cast<void*>(data_), static_cast<const void*>(&(*values.begin())),
+              values.size());
+}
+
+//--------------------------------------------------------------------------------------------------
+// opeator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept {
+  out << "{";
+  auto data = c.data();
+  for (int i = 0; i < 48; ++i) {
+    out << static_cast<int>(data[i]);
+    if (i != 48) {
+      out << ",";
+    }
+  }
+  out << "}";
+  return out;
+}
+} // namespace sxt::cg1t

--- a/sxt/curve_g1/type/compressed_element.h
+++ b/sxt/curve_g1/type/compressed_element.h
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iosfwd>
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// compressed_element
+//--------------------------------------------------------------------------------------------------
+class compressed_element {
+public:
+  compressed_element() noexcept = default;
+
+  explicit compressed_element(std::initializer_list<uint8_t> values) noexcept;
+
+  CUDA_CALLABLE
+  uint8_t* data() noexcept { return data_; }
+
+  CUDA_CALLABLE
+  const uint8_t* data() const noexcept { return data_; }
+
+  auto operator<=>(const compressed_element&) const noexcept = default;
+
+private:
+  uint8_t data_[48] = {};
+};
+
+//--------------------------------------------------------------------------------------------------
+// opeator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept;
+} // namespace sxt::cg1t

--- a/sxt/curve_g1/type/compressed_element.t.cc
+++ b/sxt/curve_g1/type/compressed_element.t.cc
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/compressed_element.h"
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt::cg1t;
+
+TEST_CASE("compressed_element is comparable") {
+  compressed_element c1{};
+  compressed_element c2{1, 2};
+  REQUIRE(c1 == c1);
+  REQUIRE(c2 == c2);
+  REQUIRE(c1 != c2);
+}

--- a/sxt/field12/property/BUILD
+++ b/sxt/field12/property/BUILD
@@ -4,6 +4,25 @@ load(
 )
 
 sxt_cc_component(
+    name = "lexicographically_largest",
+    impl_deps = [
+        "//sxt/field12/base:arithmetic_utility",
+        "//sxt/field12/base:reduce",
+        "//sxt/field12/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/constant:one",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
     name = "zero",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/field12/property/lexicographically_largest.cc
+++ b/sxt/field12/property/lexicographically_largest.cc
@@ -1,0 +1,63 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/property/lexicographically_largest.h"
+
+#include "sxt/field12/base/arithmetic_utility.h"
+#include "sxt/field12/base/reduce.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12p {
+//--------------------------------------------------------------------------------------------------
+// lexicographically_largest
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+bool lexicographically_largest(const f12t::element& e) noexcept {
+  // Checking to see if the element is larger than (p - 1) / 2.
+  // If we subtract by ((p - 1) / 2) + 1 and there is no underflow,
+  // then the element must be larger than (p - 1) / 2.
+
+  // First, because self is in Montgomery form we need to reduce it.
+  f12t::element e_tmp;
+  uint64_t tmp[12]{e[0], e[1], e[2], e[3], e[4], e[5], 0, 0, 0, 0, 0, 0};
+  f12b::reduce(e_tmp.data(), tmp);
+
+  uint64_t dummy{0};
+  uint64_t borrow{0};
+  f12b::sbb(dummy, borrow, e_tmp[0], 0xdcff7fffffffd556);
+  f12b::sbb(dummy, borrow, e_tmp[1], 0x0f55ffff58a9ffff);
+  f12b::sbb(dummy, borrow, e_tmp[2], 0xb39869507b587b12);
+  f12b::sbb(dummy, borrow, e_tmp[3], 0xb23ba5c279c2895f);
+  f12b::sbb(dummy, borrow, e_tmp[4], 0x258dd3db21a5d66b);
+  f12b::sbb(dummy, borrow, e_tmp[5], 0x0d0088f51cbff34d);
+
+  // If the element was smaller, the subtraction will underflow
+  // producing a borrow value of 0xffff...ffff, otherwise it will
+  // be zero. We create a Choice representing true if there was
+  // overflow (and so this element is not lexicographically larger
+  // than its negation) and then negate it.
+  return !(borrow & 1);
+}
+} // namespace sxt::f12p

--- a/sxt/field12/property/lexicographically_largest.h
+++ b/sxt/field12/property/lexicographically_largest.h
@@ -1,0 +1,34 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f12t {
+class element;
+}
+
+namespace sxt::f12p {
+//--------------------------------------------------------------------------------------------------
+// lexicographically_largest
+//--------------------------------------------------------------------------------------------------
+/*
+ Returns whether or not this element is strictly lexicographically larger than its negation.
+ */
+CUDA_CALLABLE
+bool lexicographically_largest(const f12t::element& e) noexcept;
+} // namespace sxt::f12p

--- a/sxt/field12/property/lexicographically_largest.t.cc
+++ b/sxt/field12/property/lexicographically_largest.t.cc
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/property/lexicographically_largest.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f12p;
+
+TEST_CASE("lexicographically largest correctly identifies") {
+  SECTION("zero is not largest") { REQUIRE(!lexicographically_largest(f12cn::zero_v)); }
+
+  SECTION("one is not largest") { REQUIRE(!lexicographically_largest(f12cn::one_v)); }
+
+  SECTION("pre-computed value that is not largest") {
+    constexpr f12t::element e{0xa1fafffffffe5557, 0x995bfff976a3fffe, 0x03f41d24d174ceb4,
+                              0xf6547998c1995dbd, 0x778a468f507a6034, 0x020559931f7f8103};
+    REQUIRE(!lexicographically_largest(e));
+  }
+
+  SECTION("pre-computed value that is largest") {
+    constexpr f12t::element e{0x1804000000015554, 0x855000053ab00001, 0x633cb57c253c276f,
+                              0x6e22d1ec31ebb502, 0xd3916126f2d14ca2, 0x17fbb8571a006596};
+    REQUIRE(lexicographically_largest(e));
+  }
+
+  SECTION("another pre-computed value that is largest") {
+    constexpr f12t::element e{0x43f5fffffffcaaae, 0x32b7fff2ed47fffd, 0x07e83a49a2e99d69,
+                              0xeca8f3318332bb7a, 0xef148d1ea0f4c069, 0x040ab3263eff0206};
+    REQUIRE(lexicographically_largest(e));
+  }
+}


### PR DESCRIPTION
# Rationale for this change
Projective elements in the `curve_g1` package group should be able to support compression. Compressed elements will be used as the output of MSM. Compression means only the `X` value of an affine element is retained. The `Y` value can later be derived from the `X` value and bit flags set during serialization. The serialization of the compressed value follows the serialization outlined in the [librustzcash](https://github.com/zcash/librustzcash/blob/6e0364cd42a2b3d2b958a54771ef51a8db79dd29/pairing/src/bls12_381/README.md#serialization) project.

- Most significant bit - indicates if the element is compressed
- Second-most significant bit - indicates if the element is a point at infinity
- Third-most significant significant - indicates if the `Y` value of the element is lexicographically largest and the element is not a point at infinity

# What changes are included in this PR?
- Projective element compression is added to the `curve_g1\operations` package in the `compression` component.
- Batch compression of projective elements is also added to the `curve_g1\operations` package in the `compression` component.
- A `compressed_element` component is added to the `curve_g1\type` package.
- A check for a lexicographically largest value is added to the base, field `field12\property` package, in the `lexicographically_largest` component.

# Are these changes tested?
Yes