### PR TITLE
fix: link math library (PROOF-0000)

### DIFF
--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -24,6 +24,7 @@ cc_binary(
     name = "libblitzar.so",
     linkopts = [
         "-Wl,--version-script=$(location :libblitzar-export-map.ld)",
+        "-lm",
     ],
     linkshared = 1,
     visibility = ["//visibility:public"],


### PR DESCRIPTION
# Rationale for this change

libblitzar.so is failing to load in some environments because the libm isn't linked.

# What changes are included in this PR?

Add "-lm" to the linker flags.

# Are these changes tested?

Our CI environment doesn't appear to have the problem, but verified the fix on an environment that gives the loading error.
