### PR TITLE
refactor!: update api function signatures to support multiple curves ( PROOF-701 )

### DIFF
--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -31,22 +31,22 @@ struct sxt_config {
   uint64_t num_precomputed_generators;
 };
 
-struct sxt_compressed_ristretto {
+struct sxt_ristretto255_compressed {
   // encodes an element of the ristretto255 group
   uint8_t ristretto_bytes[32];
 };
 
-struct sxt_scalar {
+struct sxt_curve25519_scalar {
   // encodes an element of the finite field modulo (2^252 + 27742317777372353535851937790883648493)
   uint8_t bytes[32];
 };
 
-struct sxt_transcript {
+struct sxt_curve25519_transcript {
   // encodes a strobe-based transcript
   uint8_t bytes[203];
 };
 
-struct sxt_ristretto {
+struct sxt_ristretto255 {
   // encodes an element of the curve255 group
   uint64_t X[5];
   uint64_t Y[5];
@@ -88,7 +88,7 @@ struct sxt_sequence_descriptor {
 int sxt_init(const struct sxt_config* config);
 
 /**
- * Compute the pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values
  *
  * Denote an element of a sequence by a_ij where i represents the sequence index
  * and j represents the element index. Let * represent the operator for the
@@ -127,13 +127,13 @@ int sxt_init(const struct sxt_config* config);
  *
  * - num_sequences equal to 0 will skip the computation
  */
-void sxt_compute_pedersen_commitments(struct sxt_compressed_ristretto* commitments,
-                                      uint32_t num_sequences,
-                                      const struct sxt_sequence_descriptor* descriptors,
-                                      uint64_t offset_generators);
+void sxt_curve25519_compute_pedersen_commitments(struct sxt_ristretto255_compressed* commitments,
+                                                 uint32_t num_sequences,
+                                                 const struct sxt_sequence_descriptor* descriptors,
+                                                 uint64_t offset_generators);
 
 /**
- * Compute the pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values
  *
  * Denote an element of a sequence by a_ij where i represents the sequence index
  * and j represents the element index. Let * represent the operator for the
@@ -168,15 +168,15 @@ void sxt_compute_pedersen_commitments(struct sxt_compressed_ristretto* commitmen
  *
  * - num_sequences equal to 0 will skip the computation
  */
-void sxt_compute_pedersen_commitments_with_generators(
-    struct sxt_compressed_ristretto* commitments, uint32_t num_sequences,
-    const struct sxt_sequence_descriptor* descriptors, const struct sxt_ristretto* generators);
+void sxt_curve25519_compute_pedersen_commitments_with_generators(
+    struct sxt_ristretto255_compressed* commitments, uint32_t num_sequences,
+    const struct sxt_sequence_descriptor* descriptors, const struct sxt_ristretto255* generators);
 
 /**
  * Gets the pre-specified random generated elements used for the Pedersen commitments in the
- * `sxt_compute_pedersen_commitments` function
+ * `sxt_curve25519_compute_pedersen_commitments` function
  *
- * sxt_get_generators(generators, num_generators, offset_generators) →
+ * sxt_ristretto255_get_generators(generators, num_generators, offset_generators) →
  *     generators\[0] = generate_random_ristretto(0 + offset_generators)
  *     generators\[1] = generate_random_ristretto(1 + offset_generators)
  *     generators\[2] = generate_random_ristretto(2 + offset_generators)
@@ -206,8 +206,8 @@ void sxt_compute_pedersen_commitments_with_generators(
  *
  * - num_generators equal to 0 will skip the computation
  */
-int sxt_get_generators(struct sxt_ristretto* generators, uint64_t offset_generators,
-                       uint64_t num_generators);
+int sxt_ristretto255_get_generators(struct sxt_ristretto255* generators, uint64_t offset_generators,
+                                    uint64_t num_generators);
 
 /**
  * Gets the n-th ristretto point defined as:
@@ -220,14 +220,15 @@ int sxt_get_generators(struct sxt_ristretto* generators, uint64_t offset_generat
  *
  * where
  *
- * struct sxt_ristretto ristretto_identity = {
+ * struct sxt_ristretto255 ristretto_identity = {
  *    {0, 0, 0, 0, 0},
  *    {1, 0, 0, 0, 0},
  *    {1, 0, 0, 0, 0},
  *    {0, 0, 0, 0, 0},
  * };
  *
- * and `g[i]` is the i-th generator provided by `sxt_get_generators` function at offset 0.
+ * and `g[i]` is the i-th generator provided by `sxt_ristretto255_get_generators` function at offset
+ * 0.
  *
  * # Return:
  *
@@ -237,13 +238,13 @@ int sxt_get_generators(struct sxt_ristretto* generators, uint64_t offset_generat
  *
  * - one_commit == nullptr
  */
-int sxt_get_one_commit(struct sxt_ristretto* one_commit, uint64_t n);
+int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t n);
 
 /**
  * Creates an inner product proof
  *
  * The proof is created with respect to the base G, provided by
- * `sxt_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
+ * `sxt_ristretto255_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
  *
  * The `verifier` transcript is passed in as a parameter so that the
  * challenges depend on the *entire* transcript (including parent
@@ -326,17 +327,19 @@ int sxt_get_one_commit(struct sxt_ristretto* one_commit, uint64_t n);
  * - n is zero
  * - n is non-zero, but l_vector or r_vector is nullptr
  */
-void sxt_prove_inner_product(struct sxt_compressed_ristretto* l_vector,
-                             struct sxt_compressed_ristretto* r_vector, struct sxt_scalar* ap_value,
-                             struct sxt_transcript* transcript, uint64_t n,
-                             uint64_t generators_offset, const struct sxt_scalar* a_vector,
-                             const struct sxt_scalar* b_vector);
+void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_vector,
+                                        struct sxt_ristretto255_compressed* r_vector,
+                                        struct sxt_curve25519_scalar* ap_value,
+                                        struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        uint64_t generators_offset,
+                                        const struct sxt_curve25519_scalar* a_vector,
+                                        const struct sxt_curve25519_scalar* b_vector);
 
 /**
  * Verifies an inner product proof
  *
  * The proof is verified with respect to the base G, provided by
- * `sxt_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
+ * `sxt_ristretto255_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
  *
  * Note that we don't have any restriction to the `n` value, other than
  * it has to be non-zero.
@@ -346,17 +349,17 @@ void sxt_prove_inner_product(struct sxt_compressed_ristretto* l_vector,
  * - transcript (in/out): a single strobe-based transcript
  * - n (in): non-zero length for the input arrays
  * - generators_offset (in): offset used to fetch the bases
- * - b_vector (in): array with length n, the same one used by `sxt_prove_inner_product`
+ * - b_vector (in): array with length n, the same one used by `sxt_curve25519_prove_inner_product`
  * - product (in): a single scalar, represented by <a, b>,
  *                 the inner product of the two vectors `a` and `b` used by
- * `sxt_prove_inner_product`
+ * `sxt_curve25519_prove_inner_product`
  * - a_commit (in): a single ristretto point, represented by <a, G> (the inner product of the two
  * vectors)
  * - l_vector (in): transcript point array with length `ceil(log2(n))`, generated by
- * `sxt_prove_inner_product`
+ * `sxt_curve25519_prove_inner_product`
  * - r_vector (in): transcript point array with length `ceil(log2(n))`, generated by
- * `sxt_prove_inner_product`
- * - ap_value (in): a single scalar, generated by `sxt_prove_inner_product`
+ * `sxt_curve25519_prove_inner_product`
+ * - ap_value (in): a single scalar, generated by `sxt_curve25519_prove_inner_product`
  *
  * # Return:
  *
@@ -368,12 +371,14 @@ void sxt_prove_inner_product(struct sxt_compressed_ristretto* l_vector,
  * - n is zero
  * - n is non-zero, but l_vector or r_vector is nullptr
  */
-int sxt_verify_inner_product(struct sxt_transcript* transcript, uint64_t n,
-                             uint64_t generators_offset, const struct sxt_scalar* b_vector,
-                             const struct sxt_scalar* product, const struct sxt_ristretto* a_commit,
-                             const struct sxt_compressed_ristretto* l_vector,
-                             const struct sxt_compressed_ristretto* r_vector,
-                             const struct sxt_scalar* ap_value);
+int sxt_curve25519_verify_inner_product(struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        uint64_t generators_offset,
+                                        const struct sxt_curve25519_scalar* b_vector,
+                                        const struct sxt_curve25519_scalar* product,
+                                        const struct sxt_ristretto255* a_commit,
+                                        const struct sxt_ristretto255_compressed* l_vector,
+                                        const struct sxt_ristretto255_compressed* r_vector,
+                                        const struct sxt_curve25519_scalar* ap_value);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -41,7 +41,7 @@ struct sxt_curve25519_scalar {
   uint8_t bytes[32];
 };
 
-struct sxt_curve25519_transcript {
+struct sxt_transcript {
   // encodes a strobe-based transcript
   uint8_t bytes[203];
 };
@@ -330,7 +330,7 @@ int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t 
 void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_vector,
                                         struct sxt_ristretto255_compressed* r_vector,
                                         struct sxt_curve25519_scalar* ap_value,
-                                        struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        struct sxt_transcript* transcript, uint64_t n,
                                         uint64_t generators_offset,
                                         const struct sxt_curve25519_scalar* a_vector,
                                         const struct sxt_curve25519_scalar* b_vector);
@@ -371,7 +371,7 @@ void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_ve
  * - n is zero
  * - n is non-zero, but l_vector or r_vector is nullptr
  */
-int sxt_curve25519_verify_inner_product(struct sxt_curve25519_transcript* transcript, uint64_t n,
+int sxt_curve25519_verify_inner_product(struct sxt_transcript* transcript, uint64_t n,
                                         uint64_t generators_offset,
                                         const struct sxt_curve25519_scalar* b_vector,
                                         const struct sxt_curve25519_scalar* product,

--- a/cbindings/get_generators.cc
+++ b/cbindings/get_generators.cc
@@ -27,12 +27,13 @@
 using namespace sxt;
 
 //--------------------------------------------------------------------------------------------------
-// sxt_get_generators
+// sxt_ristretto255_get_generators
 //--------------------------------------------------------------------------------------------------
-int sxt_get_generators(struct sxt_ristretto* generators, uint64_t num_generators,
-                       uint64_t offset_generators) {
-  SXT_RELEASE_ASSERT(sxt::cbn::is_backend_initialized(),
-                     "backend uninitialized in the `sxt_get_generators` c binding function");
+int sxt_ristretto255_get_generators(struct sxt_ristretto255* generators, uint64_t num_generators,
+                                    uint64_t offset_generators) {
+  SXT_RELEASE_ASSERT(
+      sxt::cbn::is_backend_initialized(),
+      "backend uninitialized in the `sxt_ristretto255_get_generators` c binding function");
 
   // we ignore the function call when zero generators are specified.
   // in this case, generators can be null

--- a/cbindings/get_generators.t.cc
+++ b/cbindings/get_generators.t.cc
@@ -32,20 +32,21 @@ static void initialize_backend(int backend, uint64_t precomputed_elements) {
   REQUIRE(sxt_init(&config) == 0);
 }
 
-static std::vector<sxt_ristretto> initialize_generators(int backend,
-                                                        uint64_t num_precomputed_elements,
-                                                        uint64_t num_generators, uint64_t offset) {
+static std::vector<sxt_ristretto255> initialize_generators(int backend,
+                                                           uint64_t num_precomputed_elements,
+                                                           uint64_t num_generators,
+                                                           uint64_t offset) {
   initialize_backend(backend, num_precomputed_elements);
 
-  std::vector<sxt_ristretto> generators(num_generators);
-  REQUIRE(sxt_get_generators(generators.data(), num_generators, offset) == 0);
+  std::vector<sxt_ristretto255> generators(num_generators);
+  REQUIRE(sxt_ristretto255_get_generators(generators.data(), num_generators, offset) == 0);
 
   reset_backend_for_testing();
 
   return generators;
 }
 
-static void verify_generator(const std::vector<sxt_ristretto>& generators, uint64_t index,
+static void verify_generator(const std::vector<sxt_ristretto255>& generators, uint64_t index,
                              uint64_t offset) {
   SXT_DEBUG_ASSERT(generators.size() > index);
 
@@ -58,14 +59,14 @@ static void test_generators_with_given_backend(int backend) {
   SECTION("We cannot fetch more than zero generators when we have a null pointer input") {
     initialize_backend(backend, 0);
     uint64_t num_generators = 3, offset_generators = 0;
-    REQUIRE(sxt_get_generators(nullptr, num_generators, offset_generators) != 0);
+    REQUIRE(sxt_ristretto255_get_generators(nullptr, num_generators, offset_generators) != 0);
     reset_backend_for_testing();
   }
 
   SECTION("We can fetch zero generators with null pointer input") {
     initialize_backend(backend, 0);
     uint64_t num_generators = 0, offset_generators = 0;
-    REQUIRE(sxt_get_generators(nullptr, num_generators, offset_generators) == 0);
+    REQUIRE(sxt_ristretto255_get_generators(nullptr, num_generators, offset_generators) == 0);
     reset_backend_for_testing();
   }
 

--- a/cbindings/get_one_commit.cc
+++ b/cbindings/get_one_commit.cc
@@ -26,13 +26,15 @@
 using namespace sxt;
 
 //--------------------------------------------------------------------------------------------------
-// sxt_get_one_commit
+// sxt_curve25519_get_one_commit
 //--------------------------------------------------------------------------------------------------
-int sxt_get_one_commit(struct sxt_ristretto* one_commit, uint64_t n) {
-  SXT_RELEASE_ASSERT(sxt::cbn::is_backend_initialized(),
-                     "backend uninitialized in the `sxt_get_one_commit` c binding function");
-  SXT_RELEASE_ASSERT(one_commit != nullptr,
-                     "one_commit input to `sxt_get_one_commit` c binding function is null");
+int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t n) {
+  SXT_RELEASE_ASSERT(
+      sxt::cbn::is_backend_initialized(),
+      "backend uninitialized in the `sxt_curve25519_get_one_commit` c binding function");
+  SXT_RELEASE_ASSERT(
+      one_commit != nullptr,
+      "one_commit input to `sxt_curve25519_get_one_commit` c binding function is null");
 
   reinterpret_cast<sxt::c21t::element_p3*>(one_commit)[0] =
       sxt::sqcgn::get_precomputed_one_commit(n);

--- a/cbindings/get_one_commit.t.cc
+++ b/cbindings/get_one_commit.t.cc
@@ -38,8 +38,8 @@ static std::vector<c21t::element_p3> initialize_generators(int backend, uint64_t
   initialize_backend(backend, 0);
 
   std::vector<c21t::element_p3> generators(num_generators);
-  REQUIRE(sxt_get_generators(reinterpret_cast<sxt_ristretto*>(generators.data()), num_generators,
-                             0) == 0);
+  REQUIRE(sxt_ristretto255_get_generators(reinterpret_cast<sxt_ristretto255*>(generators.data()),
+                                          num_generators, 0) == 0);
 
   sxt::cbn::reset_backend_for_testing();
 
@@ -50,8 +50,8 @@ static void verify_one_commit(int backend, uint64_t num_precomputed_els, uint64_
                               const c21t::element_p3& expected_element) {
   initialize_backend(backend, num_precomputed_els);
 
-  sxt_ristretto one_commitment;
-  REQUIRE(sxt_get_one_commit(&one_commitment, n) == 0);
+  sxt_ristretto255 one_commitment;
+  REQUIRE(sxt_curve25519_get_one_commit(&one_commitment, n) == 0);
   REQUIRE(reinterpret_cast<c21t::element_p3*>(&one_commitment)[0] == expected_element);
 
   sxt::cbn::reset_backend_for_testing();

--- a/cbindings/inner_product_proof.cc
+++ b/cbindings/inner_product_proof.cc
@@ -34,7 +34,7 @@ namespace sxt::cbn {
 static void check_prove_inner_product_input(sxt_ristretto255_compressed* l_vector,
                                             sxt_ristretto255_compressed* r_vector,
                                             sxt_curve25519_scalar* ap_value,
-                                            sxt_curve25519_transcript* transcript, uint64_t n,
+                                            sxt_transcript* transcript, uint64_t n,
                                             const sxt_curve25519_scalar* b_vector,
                                             const sxt_curve25519_scalar* a_vector) noexcept {
   SXT_RELEASE_ASSERT(
@@ -59,7 +59,7 @@ static void check_prove_inner_product_input(sxt_ristretto255_compressed* l_vecto
 //--------------------------------------------------------------------------------------------------
 // check_verify_inner_product_input
 //--------------------------------------------------------------------------------------------------
-static void check_verify_inner_product_input(sxt_curve25519_transcript* transcript, uint64_t n,
+static void check_verify_inner_product_input(sxt_transcript* transcript, uint64_t n,
                                              const sxt_curve25519_scalar* b_vector,
                                              const sxt_curve25519_scalar* product,
                                              const sxt_ristretto255* a_commit,
@@ -97,7 +97,7 @@ static void check_verify_inner_product_input(sxt_curve25519_transcript* transcri
 void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_vector,
                                         struct sxt_ristretto255_compressed* r_vector,
                                         struct sxt_curve25519_scalar* ap_value,
-                                        struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        struct sxt_transcript* transcript, uint64_t n,
                                         uint64_t generators_offset,
                                         const struct sxt_curve25519_scalar* a_vector,
                                         const struct sxt_curve25519_scalar* b_vector) {
@@ -128,7 +128,7 @@ void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_ve
 //--------------------------------------------------------------------------------------------------
 // sxt_curve25519_verify_inner_product
 //--------------------------------------------------------------------------------------------------
-int sxt_curve25519_verify_inner_product(struct sxt_curve25519_transcript* transcript, uint64_t n,
+int sxt_curve25519_verify_inner_product(struct sxt_transcript* transcript, uint64_t n,
                                         uint64_t generators_offset,
                                         const struct sxt_curve25519_scalar* b_vector,
                                         const struct sxt_curve25519_scalar* product,

--- a/cbindings/inner_product_proof.cc
+++ b/cbindings/inner_product_proof.cc
@@ -31,72 +31,76 @@ namespace sxt::cbn {
 //--------------------------------------------------------------------------------------------------
 // check_prove_inner_product_input
 //--------------------------------------------------------------------------------------------------
-static void check_prove_inner_product_input(sxt_compressed_ristretto* l_vector,
-                                            sxt_compressed_ristretto* r_vector,
-                                            sxt_scalar* ap_value, sxt_transcript* transcript,
-                                            uint64_t n, const sxt_scalar* b_vector,
-                                            const sxt_scalar* a_vector) noexcept {
+static void check_prove_inner_product_input(sxt_ristretto255_compressed* l_vector,
+                                            sxt_ristretto255_compressed* r_vector,
+                                            sxt_curve25519_scalar* ap_value,
+                                            sxt_curve25519_transcript* transcript, uint64_t n,
+                                            const sxt_curve25519_scalar* b_vector,
+                                            const sxt_curve25519_scalar* a_vector) noexcept {
   SXT_RELEASE_ASSERT(
       transcript != nullptr,
-      "transcript must not be null in the `sxt_prove_inner_product` c binding function");
+      "transcript must not be null in the `sxt_curve25519_prove_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       ap_value != nullptr,
-      "ap_value must not be null in the `sxt_prove_inner_product` c binding function");
+      "ap_value must not be null in the `sxt_curve25519_prove_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       b_vector != nullptr,
-      "b_vector must not be null in the `sxt_prove_inner_product` c binding function");
+      "b_vector must not be null in the `sxt_curve25519_prove_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       a_vector != nullptr,
-      "a_vector must not be null in the `sxt_prove_inner_product` c binding function");
+      "a_vector must not be null in the `sxt_curve25519_prove_inner_product` c binding function");
   SXT_RELEASE_ASSERT(n > 0, "a_vector and b_vector lengths must be greater than zero in the "
-                            "`sxt_prove_inner_product` c binding function");
+                            "`sxt_curve25519_prove_inner_product` c binding function");
   SXT_RELEASE_ASSERT(n == 1 || (l_vector != nullptr && r_vector != nullptr),
                      "l_vector and r_vector lengths must not be null when a_vector size is bigger "
-                     "than one in the `sxt_prove_inner_product` c binding function");
+                     "than one in the `sxt_curve25519_prove_inner_product` c binding function");
 }
 
 //--------------------------------------------------------------------------------------------------
 // check_verify_inner_product_input
 //--------------------------------------------------------------------------------------------------
-static void check_verify_inner_product_input(sxt_transcript* transcript, uint64_t n,
-                                             const sxt_scalar* b_vector, const sxt_scalar* product,
-                                             const sxt_ristretto* a_commit,
-                                             const sxt_compressed_ristretto* l_vector,
-                                             const sxt_compressed_ristretto* r_vector,
-                                             const sxt_scalar* ap_value) noexcept {
-  SXT_RELEASE_ASSERT(
-      transcript != nullptr,
-      "transcript must not be null in the `sxt_verify_inner_product` c binding function");
+static void check_verify_inner_product_input(sxt_curve25519_transcript* transcript, uint64_t n,
+                                             const sxt_curve25519_scalar* b_vector,
+                                             const sxt_curve25519_scalar* product,
+                                             const sxt_ristretto255* a_commit,
+                                             const sxt_ristretto255_compressed* l_vector,
+                                             const sxt_ristretto255_compressed* r_vector,
+                                             const sxt_curve25519_scalar* ap_value) noexcept {
+  SXT_RELEASE_ASSERT(transcript != nullptr,
+                     "transcript must not be null in the `sxt_curve25519_verify_inner_product` c "
+                     "binding function");
   SXT_RELEASE_ASSERT(
       ap_value != nullptr,
-      "ap_value must not be null in the `sxt_verify_inner_product` c binding function");
+      "ap_value must not be null in the `sxt_curve25519_verify_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       product != nullptr,
-      "product must not be null in the `sxt_verify_inner_product` c binding function");
+      "product must not be null in the `sxt_curve25519_verify_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       a_commit != nullptr,
-      "a_commit must not be null in the `sxt_verify_inner_product` c binding function");
+      "a_commit must not be null in the `sxt_curve25519_verify_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       b_vector != nullptr,
-      "b_vector must not be null in the `sxt_verify_inner_product` c binding function");
+      "b_vector must not be null in the `sxt_curve25519_verify_inner_product` c binding function");
   SXT_RELEASE_ASSERT(n > 0, "b_vector length must be greater than zero in the "
-                            "`sxt_verify_inner_product` c binding function");
+                            "`sxt_curve25519_verify_inner_product` c binding function");
   SXT_RELEASE_ASSERT(
       n == 1 || (l_vector != nullptr && r_vector != nullptr),
       "l_vector and r_vector lengths must not be null when a_vector "
-      "size is bigger than one in the `sxt_verify_inner_product` c binding function");
+      "size is bigger than one in the `sxt_curve25519_verify_inner_product` c binding function");
 }
 
 } // namespace sxt::cbn
 
 //--------------------------------------------------------------------------------------------------
-// sxt_prove_inner_product
+// sxt_curve25519_prove_inner_product
 //--------------------------------------------------------------------------------------------------
-void sxt_prove_inner_product(struct sxt_compressed_ristretto* l_vector,
-                             struct sxt_compressed_ristretto* r_vector, struct sxt_scalar* ap_value,
-                             struct sxt_transcript* transcript, uint64_t n,
-                             uint64_t generators_offset, const struct sxt_scalar* a_vector,
-                             const struct sxt_scalar* b_vector) {
+void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_vector,
+                                        struct sxt_ristretto255_compressed* r_vector,
+                                        struct sxt_curve25519_scalar* ap_value,
+                                        struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        uint64_t generators_offset,
+                                        const struct sxt_curve25519_scalar* a_vector,
+                                        const struct sxt_curve25519_scalar* b_vector) {
   sxt::cbn::check_prove_inner_product_input(l_vector, r_vector, ap_value, transcript, n, b_vector,
                                             a_vector);
 
@@ -122,14 +126,16 @@ void sxt_prove_inner_product(struct sxt_compressed_ristretto* l_vector,
 }
 
 //--------------------------------------------------------------------------------------------------
-// sxt_verify_inner_product
+// sxt_curve25519_verify_inner_product
 //--------------------------------------------------------------------------------------------------
-int sxt_verify_inner_product(struct sxt_transcript* transcript, uint64_t n,
-                             uint64_t generators_offset, const struct sxt_scalar* b_vector,
-                             const struct sxt_scalar* product, const struct sxt_ristretto* a_commit,
-                             const struct sxt_compressed_ristretto* l_vector,
-                             const struct sxt_compressed_ristretto* r_vector,
-                             const struct sxt_scalar* ap_value) {
+int sxt_curve25519_verify_inner_product(struct sxt_curve25519_transcript* transcript, uint64_t n,
+                                        uint64_t generators_offset,
+                                        const struct sxt_curve25519_scalar* b_vector,
+                                        const struct sxt_curve25519_scalar* product,
+                                        const struct sxt_ristretto255* a_commit,
+                                        const struct sxt_ristretto255_compressed* l_vector,
+                                        const struct sxt_ristretto255_compressed* r_vector,
+                                        const struct sxt_curve25519_scalar* ap_value) {
   // Even though the input should not be trusted,
   // we abort here in case of invalid input parameters
   sxt::cbn::check_verify_inner_product_input(transcript, n, b_vector, product, a_commit, l_vector,

--- a/cbindings/inner_product_proof.t.cc
+++ b/cbindings/inner_product_proof.t.cc
@@ -67,8 +67,8 @@ static void generate_inner_product_input(std::vector<s25t::element>& a_vector,
   auto np = 1ull << n_lg2;
   g_vector.resize(np);
 
-  REQUIRE(sxt_get_generators(reinterpret_cast<sxt_ristretto*>(g_vector.data()), np,
-                             generators_offset) == 0);
+  REQUIRE(sxt_ristretto255_get_generators(reinterpret_cast<sxt_ristretto255*>(g_vector.data()), np,
+                                          generators_offset) == 0);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -86,12 +86,13 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
   generate_inner_product_input(a_vector, b_vector, g_vector, l_vector, r_vector, n,
                                generators_offset);
 
-  sxt_prove_inner_product(reinterpret_cast<sxt_compressed_ristretto*>(l_vector.data()),
-                          reinterpret_cast<sxt_compressed_ristretto*>(r_vector.data()),
-                          reinterpret_cast<sxt_scalar*>(&ap_value),
-                          reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                          reinterpret_cast<const sxt_scalar*>(a_vector.data()),
-                          reinterpret_cast<const sxt_scalar*>(b_vector.data()));
+  sxt_curve25519_prove_inner_product(
+      reinterpret_cast<sxt_ristretto255_compressed*>(l_vector.data()),
+      reinterpret_cast<sxt_ristretto255_compressed*>(r_vector.data()),
+      reinterpret_cast<sxt_curve25519_scalar*>(&ap_value),
+      reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+      reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
+      reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()));
 
   auto product = a_vector[0] * b_vector[0];
   auto a_commit = a_vector[0] * g_vector[0];
@@ -103,66 +104,66 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
 
   SECTION("We can verify a proof using valid input data") {
     transcript = prft::transcript{"abc"};
-    REQUIRE(sxt_verify_inner_product(
-                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                reinterpret_cast<const sxt_scalar*>(b_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&product),
-                reinterpret_cast<const sxt_ristretto*>(&a_commit),
-                reinterpret_cast<const sxt_compressed_ristretto*>(l_vector.data()),
-                reinterpret_cast<const sxt_compressed_ristretto*>(r_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&ap_value)) == 1);
+    REQUIRE(sxt_curve25519_verify_inner_product(
+                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&product),
+                reinterpret_cast<const sxt_ristretto255*>(&a_commit),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(l_vector.data()),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(r_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&ap_value)) == 1);
   }
 
   SECTION("We cannot verify a proof using an invalid a_commit") {
     transcript = prft::transcript{"abc"};
     auto a_commit_p = 0x123_s25 * g_vector[0];
-    REQUIRE(sxt_verify_inner_product(
-                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                reinterpret_cast<const sxt_scalar*>(b_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&product),
-                reinterpret_cast<const sxt_ristretto*>(&a_commit_p),
-                reinterpret_cast<const sxt_compressed_ristretto*>(l_vector.data()),
-                reinterpret_cast<const sxt_compressed_ristretto*>(r_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&ap_value)) == 0);
+    REQUIRE(sxt_curve25519_verify_inner_product(
+                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&product),
+                reinterpret_cast<const sxt_ristretto255*>(&a_commit_p),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(l_vector.data()),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(r_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&ap_value)) == 0);
   }
 
   SECTION("We cannot verify a proof using an invalid product") {
     transcript = prft::transcript{"abc"};
     auto product_p = product + 0x123_s25;
-    REQUIRE(sxt_verify_inner_product(
-                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                reinterpret_cast<const sxt_scalar*>(b_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&product_p),
-                reinterpret_cast<const sxt_ristretto*>(&a_commit),
-                reinterpret_cast<const sxt_compressed_ristretto*>(l_vector.data()),
-                reinterpret_cast<const sxt_compressed_ristretto*>(r_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&ap_value)) == 0);
+    REQUIRE(sxt_curve25519_verify_inner_product(
+                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&product_p),
+                reinterpret_cast<const sxt_ristretto255*>(&a_commit),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(l_vector.data()),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(r_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&ap_value)) == 0);
   }
 
   SECTION("We cannot verify a proof using an invalid b vector") {
     transcript = prft::transcript{"abc"};
-    REQUIRE(sxt_verify_inner_product(
-                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                reinterpret_cast<const sxt_scalar*>(a_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&product),
-                reinterpret_cast<const sxt_ristretto*>(&a_commit),
-                reinterpret_cast<const sxt_compressed_ristretto*>(l_vector.data()),
-                reinterpret_cast<const sxt_compressed_ristretto*>(r_vector.data()),
-                reinterpret_cast<const sxt_scalar*>(&ap_value)) == 0);
+    REQUIRE(sxt_curve25519_verify_inner_product(
+                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&product),
+                reinterpret_cast<const sxt_ristretto255*>(&a_commit),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(l_vector.data()),
+                reinterpret_cast<const sxt_ristretto255_compressed*>(r_vector.data()),
+                reinterpret_cast<const sxt_curve25519_scalar*>(&ap_value)) == 0);
   }
 
   // we use the `transcript` only with inputs having at least two elements
   if (n > 1) {
     SECTION("We cannot verify a proof using an invalid transcript") {
       transcript = prft::transcript{"wrong_transcript"};
-      REQUIRE(sxt_verify_inner_product(
-                  reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
-                  reinterpret_cast<const sxt_scalar*>(a_vector.data()),
-                  reinterpret_cast<const sxt_scalar*>(&product),
-                  reinterpret_cast<const sxt_ristretto*>(&a_commit),
-                  reinterpret_cast<const sxt_compressed_ristretto*>(l_vector.data()),
-                  reinterpret_cast<const sxt_compressed_ristretto*>(r_vector.data()),
-                  reinterpret_cast<const sxt_scalar*>(&ap_value)) == 0);
+      REQUIRE(sxt_curve25519_verify_inner_product(
+                  reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                  reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
+                  reinterpret_cast<const sxt_curve25519_scalar*>(&product),
+                  reinterpret_cast<const sxt_ristretto255*>(&a_commit),
+                  reinterpret_cast<const sxt_ristretto255_compressed*>(l_vector.data()),
+                  reinterpret_cast<const sxt_ristretto255_compressed*>(r_vector.data()),
+                  reinterpret_cast<const sxt_curve25519_scalar*>(&ap_value)) == 0);
     }
   }
 }

--- a/cbindings/inner_product_proof.t.cc
+++ b/cbindings/inner_product_proof.t.cc
@@ -90,7 +90,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
       reinterpret_cast<sxt_ristretto255_compressed*>(l_vector.data()),
       reinterpret_cast<sxt_ristretto255_compressed*>(r_vector.data()),
       reinterpret_cast<sxt_curve25519_scalar*>(&ap_value),
-      reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+      reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
       reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
       reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()));
 
@@ -105,7 +105,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
   SECTION("We can verify a proof using valid input data") {
     transcript = prft::transcript{"abc"};
     REQUIRE(sxt_curve25519_verify_inner_product(
-                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
                 reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
                 reinterpret_cast<const sxt_curve25519_scalar*>(&product),
                 reinterpret_cast<const sxt_ristretto255*>(&a_commit),
@@ -118,7 +118,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
     transcript = prft::transcript{"abc"};
     auto a_commit_p = 0x123_s25 * g_vector[0];
     REQUIRE(sxt_curve25519_verify_inner_product(
-                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
                 reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
                 reinterpret_cast<const sxt_curve25519_scalar*>(&product),
                 reinterpret_cast<const sxt_ristretto255*>(&a_commit_p),
@@ -131,7 +131,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
     transcript = prft::transcript{"abc"};
     auto product_p = product + 0x123_s25;
     REQUIRE(sxt_curve25519_verify_inner_product(
-                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
                 reinterpret_cast<const sxt_curve25519_scalar*>(b_vector.data()),
                 reinterpret_cast<const sxt_curve25519_scalar*>(&product_p),
                 reinterpret_cast<const sxt_ristretto255*>(&a_commit),
@@ -143,7 +143,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
   SECTION("We cannot verify a proof using an invalid b vector") {
     transcript = prft::transcript{"abc"};
     REQUIRE(sxt_curve25519_verify_inner_product(
-                reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
                 reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
                 reinterpret_cast<const sxt_curve25519_scalar*>(&product),
                 reinterpret_cast<const sxt_ristretto255*>(&a_commit),
@@ -157,7 +157,7 @@ static void test_prove_and_verify_with_given_n(uint64_t n, uint64_t generators_o
     SECTION("We cannot verify a proof using an invalid transcript") {
       transcript = prft::transcript{"wrong_transcript"};
       REQUIRE(sxt_curve25519_verify_inner_product(
-                  reinterpret_cast<sxt_curve25519_transcript*>(&transcript), n, generators_offset,
+                  reinterpret_cast<sxt_transcript*>(&transcript), n, generators_offset,
                   reinterpret_cast<const sxt_curve25519_scalar*>(a_vector.data()),
                   reinterpret_cast<const sxt_curve25519_scalar*>(&product),
                   reinterpret_cast<const sxt_ristretto255*>(&a_commit),

--- a/cbindings/pedersen.cc
+++ b/cbindings/pedersen.cc
@@ -60,7 +60,7 @@ static uint64_t populate_exponent_sequence(basct::span<mtxb::exponent_sequence> 
 //--------------------------------------------------------------------------------------------------
 // process_compute_pedersen_commitments
 //--------------------------------------------------------------------------------------------------
-static void process_compute_pedersen_commitments(struct sxt_compressed_ristretto* commitments,
+static void process_compute_pedersen_commitments(struct sxt_ristretto255_compressed* commitments,
                                                  basct::cspan<sxt_sequence_descriptor> descriptors,
                                                  const c21t::element_p3* generators,
                                                  uint64_t offset_generators) {
@@ -69,7 +69,7 @@ static void process_compute_pedersen_commitments(struct sxt_compressed_ristretto
 
   SXT_RELEASE_ASSERT(commitments != nullptr);
   SXT_RELEASE_ASSERT(sxt::cbn::is_backend_initialized());
-  static_assert(sizeof(rstt::compressed_element) == sizeof(sxt_compressed_ristretto),
+  static_assert(sizeof(rstt::compressed_element) == sizeof(sxt_ristretto255_compressed),
                 "types must be ABI compatible");
 
   memmg::managed_array<mtxb::exponent_sequence> sequences(descriptors.size());
@@ -93,22 +93,23 @@ static void process_compute_pedersen_commitments(struct sxt_compressed_ristretto
 } // namespace sxt::cbn
 
 //--------------------------------------------------------------------------------------------------
-// sxt_compute_pedersen_commitments_with_generators
+// sxt_curve25519_compute_pedersen_commitments_with_generators
 //--------------------------------------------------------------------------------------------------
-void sxt_compute_pedersen_commitments_with_generators(
-    struct sxt_compressed_ristretto* commitments, uint32_t num_sequences,
-    const struct sxt_sequence_descriptor* descriptors, const struct sxt_ristretto* generators) {
+void sxt_curve25519_compute_pedersen_commitments_with_generators(
+    struct sxt_ristretto255_compressed* commitments, uint32_t num_sequences,
+    const struct sxt_sequence_descriptor* descriptors, const struct sxt_ristretto255* generators) {
   cbn::process_compute_pedersen_commitments(commitments, {descriptors, num_sequences},
                                             reinterpret_cast<const c21t::element_p3*>(generators),
                                             0);
 }
 
 //--------------------------------------------------------------------------------------------------
-// sxt_compute_pedersen_commitments
+// sxt_curve25519_compute_pedersen_commitments
 //--------------------------------------------------------------------------------------------------
-void sxt_compute_pedersen_commitments(sxt_compressed_ristretto* commitments, uint32_t num_sequences,
-                                      const sxt_sequence_descriptor* descriptors,
-                                      uint64_t offset_generators) {
+void sxt_curve25519_compute_pedersen_commitments(sxt_ristretto255_compressed* commitments,
+                                                 uint32_t num_sequences,
+                                                 const sxt_sequence_descriptor* descriptors,
+                                                 uint64_t offset_generators) {
   cbn::process_compute_pedersen_commitments(commitments, {descriptors, num_sequences}, nullptr,
                                             offset_generators);
 }

--- a/cbindings/pedersen.t.cc
+++ b/cbindings/pedersen.t.cc
@@ -100,8 +100,9 @@ static void test_pedersen_commitments_with_given_backend_and_no_generators(
     const uint64_t offset_gens = 0;
     const uint32_t num_sequences = 0;
     const sxt_sequence_descriptor* invalid_descriptor = nullptr;
-    sxt_compressed_ristretto commitment{1u};
-    sxt_compute_pedersen_commitments(&commitment, num_sequences, invalid_descriptor, offset_gens);
+    sxt_ristretto255_compressed commitment{1u};
+    sxt_curve25519_compute_pedersen_commitments(&commitment, num_sequences, invalid_descriptor,
+                                                offset_gens);
     REQUIRE(rstt::compressed_element{1u} ==
             *reinterpret_cast<rstt::compressed_element*>(&commitment));
   }
@@ -111,8 +112,9 @@ static void test_pedersen_commitments_with_given_backend_and_no_generators(
     const std::vector<uint8_t> data(0);
     const auto seq_descriptor = make_sequence_descriptor(data);
     const uint32_t num_sequences = 1;
-    sxt_compressed_ristretto commitment;
-    sxt_compute_pedersen_commitments(&commitment, num_sequences, &seq_descriptor, offset_gens);
+    sxt_ristretto255_compressed commitment;
+    sxt_curve25519_compute_pedersen_commitments(&commitment, num_sequences, &seq_descriptor,
+                                                offset_gens);
     REQUIRE(rstt::compressed_element() ==
             *reinterpret_cast<rstt::compressed_element*>(&commitment));
   }
@@ -126,8 +128,9 @@ static void test_pedersen_commitments_with_given_backend_and_no_generators(
     };
     const uint64_t num_sequences = valid_descriptors.size();
     rstt::compressed_element commitments_data[num_sequences];
-    sxt_compute_pedersen_commitments(reinterpret_cast<sxt_compressed_ristretto*>(commitments_data),
-                                     num_sequences, valid_descriptors.data(), 0);
+    sxt_curve25519_compute_pedersen_commitments(
+        reinterpret_cast<sxt_ristretto255_compressed*>(commitments_data), num_sequences,
+        valid_descriptors.data(), 0);
     REQUIRE(commitments_data[0] == -commitments_data[1]);
   }
 
@@ -149,8 +152,9 @@ static void test_pedersen_commitments_with_given_backend_and_no_generators(
 
     // we verify that `c = scal * a + b` implies that `commit_c = scal * commit_a + commit_b`
     rstt::compressed_element commitments_data[num_sequences];
-    sxt_compute_pedersen_commitments(reinterpret_cast<sxt_compressed_ristretto*>(commitments_data),
-                                     num_sequences, valid_descriptors.data(), offset_gens);
+    sxt_curve25519_compute_pedersen_commitments(
+        reinterpret_cast<sxt_ristretto255_compressed*>(commitments_data), num_sequences,
+        valid_descriptors.data(), offset_gens);
 
     auto commit_a = commitments_data[0], commit_b = commitments_data[1],
          commit_c = commitments_data[0];
@@ -167,8 +171,9 @@ static void test_pedersen_commitments_with_given_backend_and_no_generators(
     const auto descriptor = make_sequence_descriptor(data);
 
     rstt::compressed_element commitments_data;
-    sxt_compute_pedersen_commitments(reinterpret_cast<sxt_compressed_ristretto*>(&commitments_data),
-                                     1, &descriptor, offset_gens);
+    sxt_curve25519_compute_pedersen_commitments(
+        reinterpret_cast<sxt_ristretto255_compressed*>(&commitments_data), 1, &descriptor,
+        offset_gens);
 
     const auto generators = compute_random_generators(data.size(), offset_gens);
     const auto expected_commitment = compute_expected_commitment(data, generators);
@@ -194,10 +199,10 @@ test_pedersen_commitments_with_given_backend_and_generators(int backend,
     const auto generators = compute_random_generators(data.size(), 10);
     const auto expected_commitment = compute_expected_commitment(data, generators);
 
-    sxt_compressed_ristretto commitments_data;
-    sxt_compute_pedersen_commitments_with_generators(
+    sxt_ristretto255_compressed commitments_data;
+    sxt_curve25519_compute_pedersen_commitments_with_generators(
         &commitments_data, num_sequences, &seq_descriptor,
-        reinterpret_cast<const sxt_ristretto*>(generators.data()));
+        reinterpret_cast<const sxt_ristretto255*>(generators.data()));
     REQUIRE(*reinterpret_cast<rstt::compressed_element*>(&commitments_data) == expected_commitment);
   }
 

--- a/example/cbindings1/main.cc
+++ b/example/cbindings1/main.cc
@@ -37,8 +37,8 @@ int main() {
   };
   const int num_sequences = 1;
   const sxt_sequence_descriptor descriptors[num_sequences] = {descriptor1};
-  sxt_compressed_ristretto commitments[num_sequences];
-  sxt_compute_pedersen_commitments(commitments, num_sequences, descriptors, 0);
+  sxt_ristretto255_compressed commitments[num_sequences];
+  sxt_curve25519_compute_pedersen_commitments(commitments, num_sequences, descriptors, 0);
   auto commitments_data = reinterpret_cast<unsigned char*>(commitments);
   for (size_t i = 0; i < sizeof(commitments); ++i) {
     std::cout << std::hex << static_cast<unsigned>(commitments_data[i]);

--- a/rust/tests/src/main.rs
+++ b/rust/tests/src/main.rs
@@ -47,7 +47,7 @@ mod tests {
         ];
 
         let mut cbinding_commitments: Vec<blitzar_sys::
-            sxt_compressed_ristretto> = Vec::with_capacity(num_commitments);
+            sxt_ristretto255_compressed> = Vec::with_capacity(num_commitments);
         let mut cbinding_descriptors: Vec<blitzar_sys::
                 sxt_sequence_descriptor> = Vec::with_capacity(num_commitments);
 
@@ -66,7 +66,7 @@ mod tests {
                 cbinding_descriptors[i] = descriptor;
             }
 
-            blitzar_sys::sxt_compute_pedersen_commitments(
+            blitzar_sys::sxt_curve25519_compute_pedersen_commitments(
                 cbinding_commitments.as_mut_ptr(),
                 num_commitments as u32,
                 cbinding_descriptors.as_mut_ptr(),


### PR DESCRIPTION
# Rationale for this change
Now that blitzar will begin supporting multiple curves, the C function signatures in the `blitzar_api` component should follow the naming convention of projects like [libsodium](https://github.com/jedisct1/libsodium). The naming convention is  `<project>_<curve>_<type or function>`. 

We can change this naming convention in the future to include another identifier if our project ever grows to the point where we would want another level of hierarchy.

Note the blitzar-rs project will also have to update to respect the API changes.

# What changes are included in this PR?
- The functions and structs in the `blitzar_api` component now follow the `<project>_<curve>_<type or function>` naming convention.

# Are these changes tested?
Yes
