### PR TITLE
feat: support min/max chunk sizes (PROOF-642)

### DIFF
--- a/sxt/base/iterator/index_range.cc
+++ b/sxt/base/iterator/index_range.cc
@@ -22,5 +22,40 @@ namespace sxt::basit {
 //--------------------------------------------------------------------------------------------------
 // constructor
 //--------------------------------------------------------------------------------------------------
-index_range::index_range(size_t a, size_t b) noexcept : a_{a}, b_{b} { SXT_DEBUG_ASSERT(a <= b); }
+index_range::index_range(size_t a, size_t b) noexcept
+    : index_range{a, b, 1, std::numeric_limits<size_t>::max()} {}
+
+index_range::index_range(size_t a, size_t b, size_t min_chunk_size, size_t max_chunk_size) noexcept
+    : a_{a}, b_{b}, min_chunk_size_{min_chunk_size}, max_chunk_size_{max_chunk_size} {
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      0 <= a && a <= b &&
+      0 < min_chunk_size_ && min_chunk_size_ <= max_chunk_size_
+      // clang-format on
+  );
+}
+
+//--------------------------------------------------------------------------------------------------
+// min_chunk_size
+//--------------------------------------------------------------------------------------------------
+index_range index_range::min_chunk_size(size_t val) const noexcept {
+  return {
+      a_,
+      b_,
+      val,
+      max_chunk_size_,
+  };
+}
+
+//--------------------------------------------------------------------------------------------------
+// max_chunk_size
+//--------------------------------------------------------------------------------------------------
+index_range index_range::max_chunk_size(size_t val) const noexcept {
+  return {
+      a_,
+      b_,
+      min_chunk_size_,
+      val,
+  };
+}
 } // namespace sxt::basit

--- a/sxt/base/iterator/index_range.h
+++ b/sxt/base/iterator/index_range.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <cstddef>
+#include <limits>
 
 namespace sxt::basit {
 //--------------------------------------------------------------------------------------------------
@@ -28,6 +29,8 @@ public:
 
   index_range(size_t a, size_t b) noexcept;
 
+  index_range(size_t a, size_t b, size_t min_chunk_size, size_t max_chunk_size) noexcept;
+
   size_t a() const noexcept { return a_; }
   size_t b() const noexcept { return b_; }
 
@@ -35,8 +38,17 @@ public:
 
   bool operator==(const index_range&) const noexcept = default;
 
+  size_t min_chunk_size() const noexcept { return min_chunk_size_; }
+  size_t max_chunk_size() const noexcept { return max_chunk_size_; }
+
+  [[nodiscard]] index_range min_chunk_size(size_t val) const noexcept;
+
+  [[nodiscard]] index_range max_chunk_size(size_t val) const noexcept;
+
 private:
   size_t a_{0};
   size_t b_{0};
+  size_t min_chunk_size_{1};
+  size_t max_chunk_size_{std::numeric_limits<size_t>::max()};
 };
 } // namespace sxt::basit

--- a/sxt/base/iterator/index_range_utility.cc
+++ b/sxt/base/iterator/index_range_utility.cc
@@ -32,6 +32,8 @@ std::pair<index_range_iterator, index_range_iterator> split(const index_range& r
   SXT_DEBUG_ASSERT(n > 0);
   auto delta = rng.b() - rng.a();
   auto step = std::max(basn::divide_up(delta, n), size_t{1});
+  step = std::max(step, rng.min_chunk_size());
+  step = std::min(step, rng.max_chunk_size());
   index_range_iterator first{index_range{rng.a(), rng.b()}, step};
   index_range_iterator last{index_range{rng.b(), rng.b()}, step};
   return {first, last};

--- a/sxt/base/iterator/index_range_utility.t.cc
+++ b/sxt/base/iterator/index_range_utility.t.cc
@@ -60,4 +60,20 @@ TEST_CASE("we can split an index_range") {
     REQUIRE(*iter++ == index_range{2, 3});
     REQUIRE(iter == last);
   }
+
+  SECTION("we respect the min chunk size") {
+    auto [iter, last] = split(index_range{0, 4}.min_chunk_size(2), 4);
+    REQUIRE(std::distance(iter, last) == 2);
+    REQUIRE(*iter++ == index_range{0, 2});
+    REQUIRE(*iter++ == index_range{2, 4});
+    REQUIRE(iter == last);
+  }
+
+  SECTION("we respect the max chunk size") {
+    auto [iter, last] = split(index_range{0, 4}.max_chunk_size(2), 1);
+    REQUIRE(std::distance(iter, last) == 2);
+    REQUIRE(*iter++ == index_range{0, 2});
+    REQUIRE(*iter++ == index_range{2, 4});
+    REQUIRE(iter == last);
+  }
 }


### PR DESCRIPTION
# Rationale for this change

Currently, large computations can fail if they require too much GPU memory, and smaller computations can run inefficiently if we try to split them across multiple GPUs and the coordination overhead is greater than the parallelization benefit.

This PR adds the capability to specify min and max chunk sizes for an index range to give us greater control over how computations are split. This is similar to what Intel's TBB library provides: https://oneapi-src.github.io/oneTBB/main/tbb_userguide/Controlling_Chunking_os.html.

# What changes are included in this PR?

* Add ability to specify min/max chunk sizes for an index range
* Put in some ballpark min/max chunk sizes for multiexponentiation.

# Are these changes tested?

Yes.
