### PR TITLE
chore: minor code and build clean ups (PROOF-642)

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,7 +22,6 @@ build --enable_cuda=True
 # Use --config=clang to build with clang instead of gcc and nvcc.
 build:clang --repo_env=CC=clang
 build:clang --@rules_cuda//cuda:compiler=clang
-build:clang --copt=-stdlib=libstdc++
 build:clang --action_env CC=/usr/bin/clang-18
 build:clang --action_env CXX=/usr/bin/clang++-18
 build --@rules_cuda//cuda:copts=-std=c++20

--- a/sxt/base/functional/function_ref.h
+++ b/sxt/base/functional/function_ref.h
@@ -66,10 +66,8 @@ public:
   function_ref() noexcept = default;
 
   template <
-      class F,
-      std::enable_if_t<!std::is_same<function_ref, typename std::decay<F>::type>{}>* = nullptr,
-      std::enable_if_t<std::is_convertible<typename std::result_of<F&(Args...)>::type, R>{}>* =
-          nullptr>
+      class F, std::enable_if_t<!std::is_same<function_ref, std::decay_t<F>>{}>* = nullptr,
+      std::enable_if_t<std::is_convertible<std::invoke_result_t<F&, Args...>, R>{}>* = nullptr>
   function_ref(F&& f) {
     bind_to(f); // not forward
   }

--- a/sxt/proof/inner_product/gpu_driver.cc
+++ b/sxt/proof/inner_product/gpu_driver.cc
@@ -103,7 +103,6 @@ gpu_driver::make_workspace(const proof_descriptor& descriptor,
                            basct::cspan<s25t::element> a_vector) const noexcept {
   auto res = std::make_unique<gpu_workspace>();
   basdv::stream stream;
-  auto alloc = res->a_vector.get_allocator();
 
   res->descriptor = &descriptor;
   res->round_index = 0;


### PR DESCRIPTION
# Rationale for this change

Minor clean ups of code and build.

# What changes are included in this PR?

* Replace std::result_of with std::invoke_result since std::result_of is deprecated and removed in c++20: https://en.cppreference.com/w/cpp/types/result_of
* Fix compiler warning for unused variable
* Drop -stdlib=libstdc++ from c++ options as it's the default for our build environment anyways.

# Are these changes tested?

Uses existing tests.
