### PR TITLE
feat: combination step of bucket method (PROOF-642)

### DIFF
--- a/bazel/sxt_build_system.bzl
+++ b/bazel/sxt_build_system.bzl
@@ -45,7 +45,10 @@ def sxt_cc_component(
             copts = sxt_copts() + copts,
             deps = [
                 ":" + name,
-            ] + test_deps,
+            ] + test_deps + [
+                "@com_github_catchorg_catch2//:catch2",
+                "@com_github_catchorg_catch2//:catch2_main",
+            ],
             srcs = [
                 name + ".t.cc",
             ],
@@ -56,8 +59,12 @@ def sxt_cc_component(
             name = name + ".t",
             copts = sxt_copts() + copts,
             deps = [
-                ":" + test_lib,
-            ] + test_deps,
+                       ":" + test_lib,
+                   ] + test_deps +
+                   [
+                       "@com_github_catchorg_catch2//:catch2",
+                       "@com_github_catchorg_catch2//:catch2_main",
+                   ],
             visibility = ["//visibility:public"],
             **kwargs
         )

--- a/sxt/base/curve/BUILD
+++ b/sxt/base/curve/BUILD
@@ -10,10 +10,10 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "example_element",
-    deps = [
-      "//sxt/base/macro:cuda_callable",
-    ],
     test_deps = [
-      ":element",
-    ]
+        ":element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
 )

--- a/sxt/base/curve/BUILD
+++ b/sxt/base/curve/BUILD
@@ -7,3 +7,13 @@ sxt_cc_component(
     name = "element",
     with_test = False,
 )
+
+sxt_cc_component(
+    name = "example_element",
+    deps = [
+      "//sxt/base/macro:cuda_callable",
+    ],
+    test_deps = [
+      ":element",
+    ]
+)

--- a/sxt/base/num/log2p1.h
+++ b/sxt/base/num/log2p1.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <concepts>
 #include <cstdint>
 
 #include "sxt/base/container/span.h"
@@ -31,4 +32,16 @@ namespace sxt::basn {
  */
 double log2p1(basct::cspan<uint8_t> x) noexcept;
 
+//--------------------------------------------------------------------------------------------------
+// log2p1
+//--------------------------------------------------------------------------------------------------
+template <std::integral T> consteval T log2p1(T x) noexcept {
+  T res = 0;
+  T y = 1;
+  while (y <= x) {
+    y *= 2;
+    res += 1;
+  }
+  return res;
+}
 } // namespace sxt::basn

--- a/sxt/base/num/log2p1.t.cc
+++ b/sxt/base/num/log2p1.t.cc
@@ -80,3 +80,19 @@ TEST_CASE("we can take the base 2 logarithmic of arbitrary numbers") {
                                                                .data()),
                                 127)) == Approx(1016.));
 }
+
+TEST_CASE("we can compute log2p1 at compile-time") {
+  SECTION("we handle 0") { REQUIRE(log2p1(0) == 0); }
+
+  SECTION("we handle 1") { REQUIRE(log2p1(1) == 1); }
+
+  SECTION("we handle 2") { REQUIRE(log2p1(2) == 2); }
+
+  SECTION("we handle 3") { REQUIRE(log2p1(3) == 2); }
+
+  SECTION("we handle 4") { REQUIRE(log2p1(4) == 3); }
+
+  SECTION("we handle 121") { REQUIRE(log2p1(121) == 7); }
+
+  SECTION("we handle 255") { REQUIRE(log2p1(255) == 8); }
+}

--- a/sxt/multiexp/bucket_method/BUILD
+++ b/sxt/multiexp/bucket_method/BUILD
@@ -1,0 +1,20 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "combination_kernel",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/base/device:synchronization",
+    ],
+    deps = [
+        "//sxt/base/curve:element",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:log2p1",
+    ],
+)

--- a/sxt/multiexp/bucket_method/combination_kernel.cc
+++ b/sxt/multiexp/bucket_method/combination_kernel.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/combination_kernel.h"

--- a/sxt/multiexp/bucket_method/combination_kernel.h
+++ b/sxt/multiexp/bucket_method/combination_kernel.h
@@ -1,0 +1,108 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+
+#include "sxt/base/curve/element.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/log2p1.h"
+
+namespace sxt::mtxbk {
+//--------------------------------------------------------------------------------------------------
+// combine_partial_bucket_sums
+//--------------------------------------------------------------------------------------------------
+/**
+ * Suppose we have a multi-dimensional array of partial bucket sums
+ *
+ *     Bp[bucket_index, bucket_group_index, output_index, partial_sum_index]
+ *
+ * Then this kernel combines all of the partial sums to produce the result
+ *
+ *     B[bucket_index, bucket_group_index, output_index] =
+ *                sum_{partial_sum_index} Bp[bucket_index, bucket_group_index, output_index]
+ */
+template <bascrv::element T>
+__global__ void combine_partial_bucket_sums(T* out, T* partial_bucket_sums, unsigned num_partials) {
+  assert(num_partials > 0);
+
+  auto bucket_group_size = gridDim.x;
+  auto bucket_group_index = threadIdx.x;
+  auto num_bucket_groups = blockDim.x;
+  auto bucket_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+
+  partial_bucket_sums += bucket_index + bucket_group_size * bucket_group_index +
+                         bucket_group_size * num_bucket_groups * num_partials * output_index;
+
+  out += bucket_index + bucket_group_size * bucket_group_index +
+         bucket_group_size * num_bucket_groups * output_index;
+
+  T sum = *partial_bucket_sums;
+  partial_bucket_sums += bucket_group_size * num_bucket_groups;
+  for (unsigned i = 1; i < num_partials; ++i) {
+    add_inplace(sum, *partial_bucket_sums);
+    partial_bucket_sums += bucket_group_size * num_bucket_groups;
+  }
+
+  *out = sum;
+}
+
+//--------------------------------------------------------------------------------------------------
+// combine_bucket_groups
+//--------------------------------------------------------------------------------------------------
+/**
+ * Suppose we have a multi-dimensional array of grouped buckets
+ *
+ *    B[bucket_index, bucket_group_index, output_index]
+ *
+ * This kernel combines the bucket groups to produce
+ *
+ *    B'[bucket_index, output_index] =
+ *            sum_{bucket_group_index}
+ *                    2^{log2(BucketGroupSize+1) * bucket_group_index} * B[bucket_index,
+ * bucket_group_index, output_index]
+ */
+template <unsigned BucketGroupSize, unsigned NumBucketGroups, bascrv::element T>
+__global__ void combine_bucket_groups(T* out, T* bucket_sums) {
+  assert(NumBucketGroups > 0);
+  auto thread_index = threadIdx.x;
+  auto block_index = blockIdx.x;
+  auto num_threads = blockDim.x;
+  auto bucket_index = thread_index + block_index * num_threads;
+  if (bucket_index >= BucketGroupSize) {
+    return;
+  }
+
+  auto output_index = blockIdx.y;
+
+  bucket_sums += bucket_index + BucketGroupSize * NumBucketGroups * output_index;
+  out += bucket_index + BucketGroupSize * output_index;
+
+  unsigned i = NumBucketGroups - 1;
+  T sum = bucket_sums[i * BucketGroupSize];
+  constexpr auto bucket_group_size_log2p1 = basn::log2p1(BucketGroupSize);
+  while (i-- > 0) {
+    for (int j = 0; j < bucket_group_size_log2p1; ++j) {
+      double_element(sum, sum);
+    }
+    add_inplace(sum, bucket_sums[BucketGroupSize * i]);
+  }
+
+  *out = sum;
+}
+} // namespace sxt::mtxbk

--- a/sxt/multiexp/bucket_method/combination_kernel.t.cc
+++ b/sxt/multiexp/bucket_method/combination_kernel.t.cc
@@ -1,0 +1,114 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/combination_kernel.h"
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxbk;
+
+TEST_CASE("we can combine partial bucket sums") {
+  memmg::managed_array<bascrv::element97> partial_bucket_sums(memr::get_managed_device_resource());
+  memmg::managed_array<bascrv::element97> bucket_sums(memr::get_managed_device_resource());
+
+  SECTION("we handle the case of a single bucket") {
+    partial_bucket_sums = {12u};
+    bucket_sums = {0u};
+    combine_partial_bucket_sums<<<1, 1>>>(bucket_sums.data(), partial_bucket_sums.data(), 1);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 12u);
+  }
+
+  SECTION("we handle a bucket with two sums") {
+    partial_bucket_sums = {12u, 45u};
+    bucket_sums = {0u};
+    combine_partial_bucket_sums<<<1, 1>>>(bucket_sums.data(), partial_bucket_sums.data(), 2);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 57u);
+  }
+
+  SECTION("we handle a bucket group size > 1") {
+    partial_bucket_sums = {12u, 45u, 7u, 3u};
+    bucket_sums = {0, 0};
+    combine_partial_bucket_sums<<<1, 2>>>(bucket_sums.data(), partial_bucket_sums.data(), 2);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 19u);
+    REQUIRE(bucket_sums[1] == 48u);
+  }
+
+  SECTION("we handle more than one bucket group") {
+    partial_bucket_sums = {12u, 45u, 7u, 3u};
+    bucket_sums = {0, 0};
+    combine_partial_bucket_sums<<<2, 1>>>(bucket_sums.data(), partial_bucket_sums.data(), 2);
+    basdv::synchronize_device();
+    REQUIRE(bucket_sums[0] == 19u);
+    REQUIRE(bucket_sums[1] == 48u);
+  }
+}
+
+TEST_CASE("we can reduce bucket groups") {
+  memmg::managed_array<bascrv::element97> bucket_sums(memr::get_managed_device_resource());
+  memmg::managed_array<bascrv::element97> reduced_bucket_sums(memr::get_managed_device_resource());
+
+  SECTION("we can do a reduction with only a single element") {
+    bucket_sums = {12u};
+    reduced_bucket_sums.resize(1);
+    combine_bucket_groups<1, 1><<<1, 1>>>(reduced_bucket_sums.data(), bucket_sums.data());
+    basdv::synchronize_device();
+    REQUIRE(reduced_bucket_sums[0] == 12u);
+  }
+
+  SECTION("we can do a reduction with two elements and a single group") {
+    bucket_sums = {12u, 34u};
+    reduced_bucket_sums.resize(2);
+    combine_bucket_groups<2, 1><<<2, 1>>>(reduced_bucket_sums.data(), bucket_sums.data());
+    basdv::synchronize_device();
+    REQUIRE(reduced_bucket_sums[0] == 12u);
+    REQUIRE(reduced_bucket_sums[1] == 34u);
+  }
+
+  SECTION("we can do a reduction with a group size of 1 and 2 groups") {
+    bucket_sums = {12u, 34u};
+    reduced_bucket_sums.resize(1);
+    combine_bucket_groups<1, 2><<<1, 1>>>(reduced_bucket_sums.data(), bucket_sums.data());
+    basdv::synchronize_device();
+    REQUIRE(reduced_bucket_sums[0] == 12u + 34u * 2u);
+  }
+
+  SECTION("we can do a reduction with a group size of 2 and 2 groups") {
+    bucket_sums = {12u, 34u, 78u, 91u};
+    reduced_bucket_sums.resize(2);
+    combine_bucket_groups<2, 2><<<1, 2>>>(reduced_bucket_sums.data(), bucket_sums.data());
+    basdv::synchronize_device();
+    REQUIRE(reduced_bucket_sums[0] == 12u + 78u * 4u);
+    REQUIRE(reduced_bucket_sums[1] == 34u + 91u * 4u);
+  }
+
+  SECTION("we can do a reduction with multiple outputs") {
+    bucket_sums = {12u, 34u, 78u, 91u};
+    reduced_bucket_sums.resize(2);
+    combine_bucket_groups<1, 2>
+        <<<dim3(1, 2, 1), 1>>>(reduced_bucket_sums.data(), bucket_sums.data());
+    basdv::synchronize_device();
+    REQUIRE(reduced_bucket_sums[0] == 12u + 34u * 2u);
+    REQUIRE(reduced_bucket_sums[1] == 78u + 91u * 2u);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add kernels for the combination steps of the bucket method. These roughly map to operations from algorithm 1 of https://eprint.iacr.org/2022/999.pdf.

This PR is part of support better multi-exponentiation.

# What changes are included in this PR?

* A component combination_kernel with functions for combining buckets and bucket groups.
* Extended log2p1 to include a consteval version.

# Are these changes tested?

Yes.