### PR TITLE
fix: fix issues with nix environment (PROOF-537)

### DIFF
--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -4,6 +4,7 @@ let
   path = pkgs.lib.strings.concatStringsSep ":" [
     "${clang}/bin"
     "${clangpp}/bin"
+    "${pkgs.git}/bin"
     "${pkgs.gcc13}/bin"
     "${pkgs.gcc13.libc.bin}/bin"
     "${pkgs.binutils}/bin"


### PR DESCRIPTION
# Rationale for this change

Adds git to bazel's path -- it's needed to download dependencies.

# What changes are included in this PR?

Minor tweaks to bazel wrapepr script.

# Are these changes tested?

Pending.
