### PR TITLE
ci: add dark Blitzar logo ( PROOF-680 )

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 <br />
 <div align="center">
 
-<p align="center">
-<img
- alt="blitzar logo"
- width="200px"
- src="https://github.com/spaceandtimelabs/blitzar/blob/assets/logo.png"/>
-</p>
+<picture>
+  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
+  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
+  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
+</picture>
 
+<p align="center">
   <a href="https://github.com/spaceandtimelabs/blitzar/actions/workflows/release.yml">
     <img alt="Build State" src="https://github.com/spaceandtimelabs/blitzar/actions/workflows/release.yml/badge.svg">
   </a>

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 <div align="center">
 
 <picture>
-  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo.png">
-  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
-  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_crop.png">
+  <source media="(prefers-color-scheme: dark)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_dark_background.png">
+  <source media="(prefers-color-scheme: light)" width="200px" srcset="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_light_background.png">
+  <img alt="Blitzar" width="200px" src="https://raw.githubusercontent.com/spaceandtimelabs/blitzar-rs/assets/logo_light_background.png">
 </picture>
 
 <p align="center">


### PR DESCRIPTION
# Rationale for this change
The text on the Blitzar logo does not appear on light backgrounds. 
![image](https://github.com/spaceandtimelabs/blitzar-rs/assets/6509385/063ba595-4a2f-42e1-901d-756edf68ca9f)
This PR adds a logo that can be displayed on light backgrounds and updates the HTML to detect if the color scheme is light or dark.

Note, this is a companion PR to one in the `blitzar-rs` project: https://github.com/spaceandtimelabs/blitzar-rs/pull/10.

# What changes are included in this PR?
- The image link is updated to default to the dark logo.
- A `<picture>` tag is added to detect dark/light color schemes in Github's markdown following [this post](https://www.stefanjudis.com/notes/how-to-define-dark-light-mode-images-in-github-markdown/).

# Are these changes tested?
Yes.
