### PR TITLE
feat: add host-side bucket accumulation function (PROOF-642)

### DIFF
--- a/sxt/multiexp/bucket_method/BUILD
+++ b/sxt/multiexp/bucket_method/BUILD
@@ -24,8 +24,8 @@ sxt_cc_component(
         "//sxt/memory/resource:managed_device_resource",
         "//sxt/base/device:synchronization",
         "//sxt/base/curve:example_element",
-        "//sxt/execution/schedule:scheduler",
         "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
     ],
     deps = [
         ":accumulation_kernel",

--- a/sxt/multiexp/bucket_method/BUILD
+++ b/sxt/multiexp/bucket_method/BUILD
@@ -19,6 +19,38 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "accumulation",
+    test_deps = [
+        "//sxt/memory/resource:managed_device_resource",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/curve:example_element",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":accumulation_kernel",
+        ":combination_kernel",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:property",
+        "//sxt/base/device:stream",
+        "//sxt/base/error:assert",
+        "//sxt/base/iterator:index_range",
+        "//sxt/base/iterator:index_range_iterator",
+        "//sxt/base/iterator:index_range_utility",
+        "//sxt/base/num:divide_up",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/async:future",
+        "//sxt/execution/device:device_viewable",
+        "//sxt/execution/device:for_each",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:pinned_resource",
+    ],
+)
+
+sxt_cc_component(
     name = "combination_kernel",
     test_deps = [
         "//sxt/base/curve:example_element",

--- a/sxt/multiexp/bucket_method/accumulation.cc
+++ b/sxt/multiexp/bucket_method/accumulation.cc
@@ -1,0 +1,41 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/accumulation.h"
+
+namespace sxt::mtxbk {
+//--------------------------------------------------------------------------------------------------
+// make_exponents_viewable
+//--------------------------------------------------------------------------------------------------
+basct::cspan<const uint8_t>
+make_exponents_viewable(memmg::managed_array<uint8_t>& exponents_viewable_data,
+                        basct::cspan<const uint8_t*> exponents, const basit::index_range& rng,
+                        const basdv::stream& stream) noexcept {
+  static constexpr size_t exponent_size = 32; // hard coded for now
+  auto num_outputs = exponents.size();
+  auto n = rng.size();
+  exponents_viewable_data.resize(exponent_size * n * num_outputs);
+  auto out = exponents_viewable_data.data();
+  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+    basdv::async_copy_to_device(
+        basct::span<uint8_t>{out, n * exponent_size},
+        basct::cspan<uint8_t>{exponents[output_index] + rng.a() * exponent_size, n * exponent_size},
+        stream);
+    out += n * exponent_size;
+  }
+  return exponents_viewable_data;
+}
+} // namespace sxt::mtxbk

--- a/sxt/multiexp/bucket_method/accumulation.h
+++ b/sxt/multiexp/bucket_method/accumulation.h
@@ -1,0 +1,170 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/property.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/iterator/index_range.h"
+#include "sxt/base/iterator/index_range_iterator.h"
+#include "sxt/base/iterator/index_range_utility.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/device/device_viewable.h"
+#include "sxt/execution/device/for_each.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/bucket_method/accumulation_kernel.h"
+#include "sxt/multiexp/bucket_method/combination_kernel.h"
+
+namespace sxt::mtxbk {
+//--------------------------------------------------------------------------------------------------
+// make_exponents_viewable
+//--------------------------------------------------------------------------------------------------
+basct::cspan<const uint8_t>
+make_exponents_viewable(memmg::managed_array<uint8_t>& exponents_viewable_data,
+                        basct::cspan<const uint8_t*> exponents, const basit::index_range& rng,
+                        const basdv::stream& stream) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// accumulate_buckets_impl
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+xena::future<> accumulate_buckets_impl(basct::span<T> bucket_sums, basct::cspan<T> generators,
+                                       basct::cspan<const uint8_t*> exponents,
+                                       basit::index_range rng) noexcept {
+  unsigned n = rng.size();
+  auto num_outputs = exponents.size();
+  auto num_blocks = std::min(192u, n);
+  static constexpr int num_bytes = 32; // hard code to 32 for now
+
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+
+  // make generators accessible to the active device
+  memmg::managed_array<T> generators_viewable_data{&resource};
+  auto generators_viewable = xendv::make_active_device_viewable(
+      generators_viewable_data, generators.subspan(rng.a(), rng.size()));
+
+  // make exponents accessible to the active device
+  memmg::managed_array<uint8_t> exponents_viewable_data{&resource};
+  auto exponents_viewable =
+      make_exponents_viewable(exponents_viewable_data, exponents, rng, stream);
+
+  // accumulate generators into buckets of partial sums
+  xendv::synchronize_event(stream, generators_viewable);
+  memmg::managed_array<T> partial_bucket_sums{bucket_sums.size() * num_blocks, &resource};
+  bucket_accumulate<<<dim3(num_blocks, num_outputs, 1), num_bytes, 0, stream>>>(
+      partial_bucket_sums.data(), generators_viewable.value().data(), exponents_viewable.data(), n);
+  generators_viewable_data.reset();
+  exponents_viewable_data.reset();
+
+  // combine partial sums
+  memmg::managed_array<T> bucket_sums_dev{bucket_sums.size(), &resource};
+  combine_partial_bucket_sums<<<dim3(255, num_outputs, 1), num_bytes, 0, stream>>>(
+      bucket_sums_dev.data(), partial_bucket_sums.data(), num_blocks);
+  partial_bucket_sums.reset();
+  basdv::async_copy_to_device(bucket_sums, bucket_sums_dev, stream);
+  co_await xendv::await_stream(stream);
+}
+
+template <bascrv::element T>
+xena::future<> accumulate_buckets_impl(basct::span<T> bucket_sums, basct::cspan<T> generators,
+                                       basct::cspan<const uint8_t*> exponents,
+                                       size_t split_factor) noexcept {
+  constexpr size_t bucket_group_size = 255;
+  constexpr size_t num_bucket_groups = 32;
+  static constexpr unsigned num_bytes = 32; // hard code to 32 for now
+  auto num_outputs = exponents.size();
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      bucket_sums.size() == bucket_group_size * num_bucket_groups * num_outputs &&
+      (bucket_sums.empty() || basdv::is_active_device_pointer(bucket_sums.data()))
+      // clang-format on
+  );
+
+  // Pick some reasonable values for min and max chunk size so that
+  // we don't run out of GPU memory or split computations that are
+  // too small.
+  //
+  // Note: These haven't been informed by much benchmarking. I'm
+  // sure there are better values. This is just putting in some
+  // ballpark estimates to get started.
+  size_t min_chunk_size = 1ull << 10u;
+  size_t max_chunk_size = 1ull << 20u;
+  if (num_outputs > 0) {
+    max_chunk_size = basn::divide_up(max_chunk_size, num_outputs);
+    min_chunk_size *= num_outputs;
+    min_chunk_size = std::min(max_chunk_size, min_chunk_size);
+  }
+
+  auto [first, last] = basit::split(basit::index_range{0, generators.size()}
+                                        .min_chunk_size(min_chunk_size)
+                                        .max_chunk_size(max_chunk_size),
+                                    split_factor);
+  auto num_chunks = std::distance(first, last);
+
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  memmg::managed_array<T> partial_bucket_sums_data{&resource};
+  basct::span<T> partial_bucket_sums;
+  if (num_chunks > 1) {
+    partial_bucket_sums_data.resize(num_bucket_groups * bucket_group_size * num_chunks);
+    partial_bucket_sums = partial_bucket_sums_data;
+  } else {
+    partial_bucket_sums = bucket_sums;
+  }
+
+  size_t step = bucket_group_size * num_bucket_groups * num_outputs;
+  size_t i = 0;
+  co_await xendv::concurrent_for_each(first, last, [&](const basit::index_range& rng) noexcept {
+    return accumulate_buckets_impl(partial_bucket_sums.subspan(step * i++, step), generators,
+                                   exponents, rng);
+  });
+  if (num_chunks <= 1) {
+    co_return;
+  }
+  combine_partial_bucket_sums<<<dim3(255, num_outputs, 1), num_bytes, 0, stream>>>(
+      bucket_sums.data(), partial_bucket_sums.data(), num_chunks);
+  co_await xendv::await_stream(stream);
+}
+
+//--------------------------------------------------------------------------------------------------
+// accumulate_buckets
+//--------------------------------------------------------------------------------------------------
+/**
+ * Accumulate generators into buckets, splitting the work across available devices.
+ *
+ * This function corresponds roughly to the 1st loop of Algorithm 1 described in
+ *
+ *    PipeMSM: Hardware Acceleration for Multi-Scalar Multiplication
+ *    https://eprint.iacr.org/2022/999.pdf
+ */
+template <bascrv::element T>
+xena::future<> accumulate_buckets(basct::span<T> bucket_sums, basct::cspan<T> generators,
+                                  basct::cspan<const uint8_t*> exponents) noexcept {
+  return accumulate_buckets_impl(bucket_sums, generators, exponents, basdv::get_num_devices());
+}
+} // namespace sxt::mtxbk

--- a/sxt/multiexp/bucket_method/accumulation.t.cc
+++ b/sxt/multiexp/bucket_method/accumulation.t.cc
@@ -1,0 +1,159 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method/accumulation.h"
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxbk;
+
+TEST_CASE("we can perform a bucket accumulation pass") {
+  using E = bascrv::element97;
+  memmg::managed_array<E> bucket_sums{255 * 32, memr::get_managed_device_resource()};
+
+  SECTION("we handle the empty case") {
+    bucket_sums.reset();
+    auto fut = accumulate_buckets<E>(bucket_sums, {}, {});
+    REQUIRE(fut.ready());
+  }
+
+  SECTION("we handle a case with a single zero element") {
+    uint8_t scalar[32] = {};
+    const uint8_t* scalars[] = {scalar};
+    E generators[] = {7};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (auto val : bucket_sums) {
+      REQUIRE(val == E::identity());
+    }
+  }
+
+  SECTION("we handle a case with a single element of 1") {
+    uint8_t scalar[32] = {};
+    scalar[0] = 1;
+    const uint8_t* scalars[] = {scalar};
+    E generators[] = {7};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (size_t i = 0; i < bucket_sums.size(); ++i) {
+      auto val = bucket_sums[i];
+      if (i == 0) {
+        REQUIRE(val == 7);
+      } else {
+        REQUIRE(val == E::identity());
+      }
+    }
+  }
+
+  SECTION("we handle two scalars of different values") {
+    uint8_t scalar_data[64] = {};
+    scalar_data[0] = 1;
+    scalar_data[32] = 2;
+    const uint8_t* scalars[] = {scalar_data};
+    E generators[] = {7, 5};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (size_t i = 0; i < bucket_sums.size(); ++i) {
+      auto val = bucket_sums[i];
+      if (i == 0) {
+        REQUIRE(val == 7);
+      } else if (i == 1) {
+        REQUIRE(val == 5);
+      } else {
+        REQUIRE(val == E::identity());
+      }
+    }
+  }
+
+  SECTION("we handle multiple chunks") {
+    uint8_t scalar_data[32 * 4] = {};
+    scalar_data[0] = 1;
+    scalar_data[32] = 1;
+    scalar_data[32 * 2] = 1;
+    scalar_data[32 * 3] = 1;
+    const uint8_t* scalars[] = {scalar_data};
+    E generators[] = {7, 5, 3, 1};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (size_t i = 0; i < bucket_sums.size(); ++i) {
+      auto val = bucket_sums[i];
+      if (i == 0) {
+        REQUIRE(val == 16);
+      } else {
+        REQUIRE(val == E::identity());
+      }
+    }
+  }
+
+  SECTION("we handle two scalars of the same value") {
+    uint8_t scalar_data[64] = {};
+    scalar_data[0] = 2;
+    scalar_data[32] = 2;
+    const uint8_t* scalars[] = {scalar_data};
+    E generators[] = {7, 5};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (size_t i = 0; i < bucket_sums.size(); ++i) {
+      auto val = bucket_sums[i];
+      if (i == 1) {
+        REQUIRE(val == 12);
+      } else {
+        REQUIRE(val == E::identity());
+      }
+    }
+  }
+
+  SECTION("we handle multiple outputs") {
+    bucket_sums = memmg::managed_array<E>(255 * 32 * 2);
+    uint8_t scalar_data1[32] = {};
+    scalar_data1[0] = 2;
+    uint8_t scalar_data2[32] = {};
+    scalar_data2[0] = 2;
+    const uint8_t* scalars[] = {
+        scalar_data1,
+        scalar_data2,
+    };
+    E generators[] = {7};
+    auto fut = accumulate_buckets<E>(bucket_sums, generators, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    for (size_t i = 0; i < bucket_sums.size(); ++i) {
+      auto val = bucket_sums[i];
+      if (i == 1 || i == 255 * 32 + 1) {
+        REQUIRE(val == 7);
+      } else {
+        REQUIRE(val == E::identity());
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a function to accumulate the generators for a multi-exponentiation into buckets. The function is invoked from the host and splits work across available GPUs.

This PR  builds on  #45 and is part of making multi-exponentiation perform better.

# What changes are included in this PR?

A  new function for bucket accumulation.

# Are these changes tested?

Yes.
