### PR TITLE
feat: add element concept to base field package ( PROOF-748 )

### DIFF
--- a/sxt/base/field/BUILD
+++ b/sxt/base/field/BUILD
@@ -16,6 +16,19 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "element",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "example_element",
+    test_deps = [
+        ":element",
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "subtract_p",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/base/field/BUILD
+++ b/sxt/base/field/BUILD
@@ -36,5 +36,6 @@ sxt_cc_component(
     deps = [
         ":arithmetic_utility",
         "//sxt/base/macro:cuda_callable",
+        "//sxt/base/num:cmov",
     ],
 )

--- a/sxt/base/field/element.cc
+++ b/sxt/base/field/element.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/field/example_element.h"

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -23,7 +23,8 @@ namespace sxt::basfld {
 // element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires(T& elm) {
-  { elm.num_limbs_v } noexcept -> std::convertible_to<size_t>;
+concept element = requires() {
+  T::num_limbs_v > 0;
+  { T::modulus() } noexcept -> std::same_as<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+
+namespace sxt::basfld {
+//--------------------------------------------------------------------------------------------------
+// element
+//--------------------------------------------------------------------------------------------------
+template <class T>
+concept element = requires(T& elm) {
+  { elm.num_limbs_v } noexcept -> std::convertible_to<size_t>;
+};
+} // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -20,17 +20,24 @@
 
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
-// element
+// modifiable
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires(T& eref, const T& ecref) {
-  requires(T::num_limbs_v > 0);
-  std::default_initializable<T>;
+concept modifiable = requires(T& eref, const T& ecref) {
   { eref[0] } noexcept -> std::same_as<uint64_t&>;
   { ecref[0] } noexcept -> std::same_as<const uint64_t&>;
   { eref.data() } noexcept -> std::same_as<uint64_t*>;
   { ecref.data() } noexcept -> std::same_as<const uint64_t*>;
+};
+
+//--------------------------------------------------------------------------------------------------
+// element
+//--------------------------------------------------------------------------------------------------
+template <class T>
+concept element = requires {
+  requires T::num_limbs_v > 0 &&
+           std::equality_comparable<T> &&
+           modifiable<T>;
   { T::modulus() } noexcept -> std::same_as<T>;
-  std::equality_comparable<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -23,10 +23,10 @@ namespace sxt::basfld {
 // element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires(T& e) {
+concept element = requires(T e) {
   requires(T::num_limbs_v > 0);
   { T::modulus() } noexcept -> std::same_as<T>;
-  e[0];
+  { e[0] } noexcept -> std::convertible_to<uint64_t>;
   e.data();
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -20,22 +20,15 @@
 
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
-// modifiable
+// element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept modifiable = requires(T& eref, const T& ecref) {
+concept element = requires(T& eref, const T& ecref) {
+  requires T::num_limbs_v > 0 && std::equality_comparable<T>;
   { eref[0] } noexcept -> std::same_as<uint64_t&>;
   { ecref[0] } noexcept -> std::same_as<const uint64_t&>;
   { eref.data() } noexcept -> std::same_as<uint64_t*>;
   { ecref.data() } noexcept -> std::same_as<const uint64_t*>;
-};
-
-//--------------------------------------------------------------------------------------------------
-// element
-//--------------------------------------------------------------------------------------------------
-template <class T>
-concept element = requires {
-  requires T::num_limbs_v > 0 && std::equality_comparable<T> && modifiable<T>;
   { T::modulus() } noexcept -> std::same_as<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -23,8 +23,8 @@ namespace sxt::basfld {
 // element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires() {
-  T::num_limbs_v > 0;
+concept element = requires {
+  requires(T::num_limbs_v > 0);
   { T::modulus() } noexcept -> std::same_as<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -35,9 +35,7 @@ concept modifiable = requires(T& eref, const T& ecref) {
 //--------------------------------------------------------------------------------------------------
 template <class T>
 concept element = requires {
-  requires T::num_limbs_v > 0 &&
-           std::equality_comparable<T> &&
-           modifiable<T>;
+  requires T::num_limbs_v > 0 && std::equality_comparable<T> && modifiable<T>;
   { T::modulus() } noexcept -> std::same_as<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -23,10 +23,14 @@ namespace sxt::basfld {
 // element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires(T e) {
+concept element = requires(T& eref, const T& ecref) {
   requires(T::num_limbs_v > 0);
+  std::default_initializable<T>;
+  { eref[0] } noexcept -> std::same_as<uint64_t&>;
+  { ecref[0] } noexcept -> std::same_as<const uint64_t&>;
+  { eref.data() } noexcept -> std::same_as<uint64_t*>;
+  { ecref.data() } noexcept -> std::same_as<const uint64_t*>;
   { T::modulus() } noexcept -> std::same_as<T>;
-  { e[0] } noexcept -> std::convertible_to<uint64_t>;
-  e.data();
+  std::equality_comparable<T>;
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/element.h
+++ b/sxt/base/field/element.h
@@ -23,8 +23,10 @@ namespace sxt::basfld {
 // element
 //--------------------------------------------------------------------------------------------------
 template <class T>
-concept element = requires {
+concept element = requires(T& e) {
   requires(T::num_limbs_v > 0);
   { T::modulus() } noexcept -> std::same_as<T>;
+  e[0];
+  e.data();
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/example_element.cc
+++ b/sxt/base/field/example_element.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/field/example_element.h"

--- a/sxt/base/field/example_element.h
+++ b/sxt/base/field/example_element.h
@@ -20,22 +20,20 @@
 
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
-// element4
+// element1
 //--------------------------------------------------------------------------------------------------
 /**
  * Provides a minimal implementation of the field element concent that can be used for writing
  * tests.
  *
- * element4 uses the limb count and modulus (in little endian ordering) of the bn254
- * curve.
+ * element1 is a one limb field element that uses modulus 97.
  */
-struct element4 {
-  static constexpr size_t num_limbs_v = 4;
+struct element1 {
+  static constexpr size_t num_limbs_v = 1;
 
-  element4() noexcept = default;
+  element1() noexcept = default;
 
-  CUDA_CALLABLE constexpr element4(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4) noexcept
-      : data_{x1, x2, x3, x4} {}
+  CUDA_CALLABLE constexpr element1(uint64_t x1) noexcept : data_{x1} {}
 
   CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
     return data_[index];
@@ -47,11 +45,9 @@ struct element4 {
 
   CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
 
-  static constexpr element4 modulus() noexcept {
-    return element4{0x3c208c16d87cfd47, 0x97816a916871ca8d, 0xb85045b68181585d, 0x30644e72e131a029};
-  }
+  static constexpr element1 modulus() noexcept { return element1{97}; }
 
-  bool operator==(const element4&) const noexcept = default;
+  bool operator==(const element1&) const noexcept = default;
 
 private:
   uint64_t data_[num_limbs_v];

--- a/sxt/base/field/example_element.h
+++ b/sxt/base/field/example_element.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt::basfld {
+//--------------------------------------------------------------------------------------------------
+// element4
+//--------------------------------------------------------------------------------------------------
+/**
+ * Provides a minimal implementation of the field element concent that can be used for writing
+ * tests.
+ */
+struct element4 {
+  static constexpr size_t num_limbs_v = 4;
+};
+} // namespace sxt::basfld

--- a/sxt/base/field/example_element.h
+++ b/sxt/base/field/example_element.h
@@ -25,6 +25,9 @@ namespace sxt::basfld {
 /**
  * Provides a minimal implementation of the field element concent that can be used for writing
  * tests.
+ *
+ * element4 uses the limb count and modulus (in little endian ordering) of the bn254
+ * curve.
  */
 struct element4 {
   static constexpr size_t num_limbs_v = 4;
@@ -44,7 +47,9 @@ struct element4 {
 
   CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
 
-  static constexpr element4 modulus() noexcept { return element4{0, 0, 0, 97}; }
+  static constexpr element4 modulus() noexcept {
+    return element4{0x3c208c16d87cfd47, 0x97816a916871ca8d, 0xb85045b68181585d, 0x30644e72e131a029};
+  }
 
   bool operator==(const element4&) const noexcept = default;
 

--- a/sxt/base/field/example_element.h
+++ b/sxt/base/field/example_element.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include "sxt/base/macro/cuda_callable.h"
+
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
 // element4
@@ -26,5 +28,27 @@ namespace sxt::basfld {
  */
 struct element4 {
   static constexpr size_t num_limbs_v = 4;
+
+  element4() noexcept = default;
+
+  CUDA_CALLABLE constexpr element4(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4) noexcept
+      : data_{x1, x2, x3, x4} {}
+
+  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
+    return data_[index];
+  }
+
+  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+
+  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+
+  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+
+  static constexpr element4 modulus() noexcept { return element4{0, 0, 0, 97}; }
+
+  bool operator==(const element4&) const noexcept = default;
+
+private:
+  uint64_t data_[num_limbs_v];
 };
 } // namespace sxt::basfld

--- a/sxt/base/field/example_element.h
+++ b/sxt/base/field/example_element.h
@@ -16,8 +16,6 @@
  */
 #pragma once
 
-#include "sxt/base/macro/cuda_callable.h"
-
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
 // element1
@@ -33,17 +31,15 @@ struct element1 {
 
   element1() noexcept = default;
 
-  CUDA_CALLABLE constexpr element1(uint64_t x1) noexcept : data_{x1} {}
+  constexpr element1(uint64_t x1) noexcept : data_{x1} {}
 
-  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
-    return data_[index];
-  }
+  constexpr const uint64_t& operator[](int index) const noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+  constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+  constexpr const uint64_t* data() const noexcept { return data_; }
 
-  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+  constexpr uint64_t* data() noexcept { return data_; }
 
   static constexpr element1 modulus() noexcept { return element1{97}; }
 

--- a/sxt/base/field/example_element.t.cc
+++ b/sxt/base/field/example_element.t.cc
@@ -1,0 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/field/example_element.h"
+
+#include "sxt/base/field/element.h"
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::basfld;
+
+TEST_CASE("element4 satisfies the field concept") { REQUIRE(basfld::element<element4>); }

--- a/sxt/base/field/example_element.t.cc
+++ b/sxt/base/field/example_element.t.cc
@@ -22,4 +22,4 @@
 using namespace sxt;
 using namespace sxt::basfld;
 
-TEST_CASE("element4 satisfies the field concept") { REQUIRE(basfld::element<element4>); }
+TEST_CASE("element1 satisfies the field concept") { REQUIRE(basfld::element<element1>); }

--- a/sxt/base/field/subtract_p.h
+++ b/sxt/base/field/subtract_p.h
@@ -27,6 +27,7 @@
 
 #include "sxt/base/field/arithmetic_utility.h"
 #include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/num/cmov.h"
 
 namespace sxt::basfld {
 //--------------------------------------------------------------------------------------------------
@@ -45,7 +46,8 @@ CUDA_CALLABLE inline void subtract_p(uint64_t* ret, const uint64_t* a, const uin
 
   // If underflow occurred on the final limb, borrow = 0xfff...fff, otherwise
   // borrow = 0x000...000. Thus, we use it as a mask!
-  uint64_t mask{borrow == 0x0 ? (borrow - 1) : 0x0};
+  uint64_t mask{0x0};
+  basn::cmov(mask, borrow - 1, borrow == 0x0);
 
   for (size_t limb = 0; limb < NumLimbs; ++limb) {
     ret[limb] = (a[limb] & borrow) | (ret[limb] & mask);


### PR DESCRIPTION
# Rationale for this change
The `base/field` package now has an `element` concept and a minimal `example_element` component. The `element` concept will allow field operations done with elements in Montgomery form to be written generically. These field operations currently exist in the `field12` package group and depend on the `f12t::element`.

# What changes are included in this PR?
- An `element` concept is added to the `base/field` package that is similar to the `base/curve/element` concept.
- A minimal `example_element` component is added to the `base/field` package that is similar to the `base/curve/example_element` component.
- Branching is removed from the `base/field/subtract_p` component.

# Are these changes tested?
Yes