### PR TITLE
feat: add chained_resource to support winked out allocations (PROOF-716)

### DIFF
--- a/sxt/memory/resource/BUILD
+++ b/sxt/memory/resource/BUILD
@@ -8,9 +8,6 @@ sxt_cc_component(
     impl_deps = [
         "//sxt/base/error:panic",
     ],
-    test_deps = [
-        "//sxt/base/test:unit_test",
-    ],
     with_test = False,
     deps = [
         "//sxt/base/type:raw_stream",
@@ -33,9 +30,6 @@ sxt_cc_component(
     impl_deps = [
         "//sxt/base/error:panic",
     ],
-    test_deps = [
-        "//sxt/base/test:unit_test",
-    ],
     with_test = False,
 )
 
@@ -44,8 +38,21 @@ sxt_cc_component(
     impl_deps = [
         "//sxt/base/error:panic",
     ],
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "counting_resource",
+    with_test = False,
+)
+
+sxt_cc_component(
+    name = "chained_resource",
+    impl_deps = [
+        "//sxt/base/error:panic",
+    ],
     test_deps = [
+        ":counting_resource",
         "//sxt/base/test:unit_test",
     ],
-    with_test = False,
 )

--- a/sxt/memory/resource/chained_resource.cc
+++ b/sxt/memory/resource/chained_resource.cc
@@ -1,0 +1,53 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/memory/resource/chained_resource.h"
+
+namespace sxt::memr {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+chained_resource::chained_resource() noexcept
+    : chained_resource{std::pmr::get_default_resource()} {}
+
+chained_resource::chained_resource(std::pmr::memory_resource* upstream) noexcept
+    : upstream_{upstream} {}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+chained_resource::~chained_resource() noexcept {
+  for (auto [ptr, bytes, alignment] : allocations_) {
+    upstream_->deallocate(ptr, bytes, alignment);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// do_allocate
+//--------------------------------------------------------------------------------------------------
+void* chained_resource::do_allocate(size_t bytes, size_t alignment) noexcept {
+  auto ptr = upstream_->allocate(bytes, alignment);
+  allocations_.emplace_back(ptr, bytes, alignment);
+  return ptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+// do_is_equal
+//--------------------------------------------------------------------------------------------------
+bool chained_resource::do_is_equal(const std::pmr::memory_resource& other) const noexcept {
+  return this == &other;
+}
+} // namespace sxt::memr

--- a/sxt/memory/resource/chained_resource.h
+++ b/sxt/memory/resource/chained_resource.h
@@ -1,0 +1,52 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory_resource>
+#include <tuple>
+#include <vector>
+
+namespace sxt::memr {
+//--------------------------------------------------------------------------------------------------
+// chained_resource
+//--------------------------------------------------------------------------------------------------
+/**
+ * Provide a resource suitable for winked-out allocations with bost host and device memory.
+ *
+ * See section 3 of https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0089r1.pdf
+ */
+class chained_resource final : public std::pmr::memory_resource {
+public:
+  chained_resource() noexcept;
+
+  explicit chained_resource(std::pmr::memory_resource* upstream) noexcept;
+
+  ~chained_resource() noexcept;
+
+private:
+  std::pmr::memory_resource* upstream_;
+  std::vector<std::tuple<void*, size_t, size_t>> allocations_;
+
+  void* do_allocate(size_t bytes, size_t alignment) noexcept override;
+
+  void do_deallocate(void* /*ptr*/, size_t /*bytes*/, size_t /*alignment*/) noexcept override {
+    // destructor does bulk deallocation
+  }
+
+  bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override;
+};
+} // namespace sxt::memr

--- a/sxt/memory/resource/chained_resource.h
+++ b/sxt/memory/resource/chained_resource.h
@@ -25,7 +25,7 @@ namespace sxt::memr {
 // chained_resource
 //--------------------------------------------------------------------------------------------------
 /**
- * Provide a resource suitable for winked-out allocations with bost host and device memory.
+ * Provide a resource suitable for winked-out allocations with both host and device memory.
  *
  * See section 3 of https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0089r1.pdf
  */

--- a/sxt/memory/resource/chained_resource.t.cc
+++ b/sxt/memory/resource/chained_resource.t.cc
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/memory/resource/chained_resource.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/resource/counting_resource.h"
+
+using namespace sxt;
+using namespace sxt::memr;
+
+TEST_CASE("we can manage a chain of allocations") {
+  counting_resource counter;
+  {
+    chained_resource r{&counter};
+    REQUIRE(counter.bytes_allocated() == 0);
+
+    auto ptr = r.allocate(10);
+    (void)ptr;
+    REQUIRE(counter.bytes_allocated() == 10);
+  }
+  REQUIRE(counter.bytes_deallocated() == 10);
+}

--- a/sxt/memory/resource/counting_resource.cc
+++ b/sxt/memory/resource/counting_resource.cc
@@ -1,0 +1,51 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/memory/resource/counting_resource.h"
+
+namespace sxt::memr {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+counting_resource::counting_resource() noexcept
+    : counting_resource{std::pmr::get_default_resource()} {}
+
+counting_resource::counting_resource(std::pmr::memory_resource* upstream) noexcept
+    : upstream_{upstream} {}
+
+//--------------------------------------------------------------------------------------------------
+// do_allocate
+//--------------------------------------------------------------------------------------------------
+void* counting_resource::do_allocate(size_t bytes, size_t alignment) noexcept {
+  bytes_allocated_ += bytes;
+  return upstream_->allocate(bytes, alignment);
+}
+
+//--------------------------------------------------------------------------------------------------
+// do_deallocate
+//--------------------------------------------------------------------------------------------------
+void counting_resource::do_deallocate(void* ptr, size_t bytes, size_t alignment) noexcept {
+  bytes_deallocated_ += bytes;
+  upstream_->deallocate(ptr, bytes, alignment);
+}
+
+//--------------------------------------------------------------------------------------------------
+// do_is_equal
+//--------------------------------------------------------------------------------------------------
+bool counting_resource::do_is_equal(const std::pmr::memory_resource& other) const noexcept {
+  return this == &other;
+}
+} // namespace sxt::memr

--- a/sxt/memory/resource/counting_resource.h
+++ b/sxt/memory/resource/counting_resource.h
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory_resource>
+
+namespace sxt::memr {
+//--------------------------------------------------------------------------------------------------
+// counting_resource
+//--------------------------------------------------------------------------------------------------
+class counting_resource final : public std::pmr::memory_resource {
+public:
+  counting_resource() noexcept;
+
+  explicit counting_resource(std::pmr::memory_resource* upstream) noexcept;
+
+  size_t bytes_allocated() const noexcept { return bytes_allocated_; }
+
+  size_t bytes_deallocated() const noexcept { return bytes_deallocated_; }
+
+private:
+  std::pmr::memory_resource* upstream_;
+  size_t bytes_allocated_ = 0;
+  size_t bytes_deallocated_ = 0;
+
+  void* do_allocate(size_t bytes, size_t alignment) noexcept override;
+
+  void do_deallocate(void* ptr, size_t bytes, size_t alignment) noexcept override;
+
+  bool do_is_equal(const std::pmr::memory_resource& other) const noexcept override;
+};
+} // namespace sxt::memr


### PR DESCRIPTION
# Rationale for this change

Winking out can make code simpler and faster when used correctly. See https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0089r1.pdf for reference.

This PR adds a memory resource suitable for winked out host or device allocations.

# What changes are included in this PR?

* Adds chained_resource that tracks allocations and deallocates everything upon destruction.
* Adds counting_resource as a tool for testing custom resources.

# Are these changes tested?

Yes
