### PR TITLE
feat: minor enhancements to container types (PROOF-716)

### DIFF
--- a/sxt/base/container/BUILD
+++ b/sxt/base/container/BUILD
@@ -29,11 +29,11 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "span_utility",
-    deps = [
-        ":span",
-    ],
     test_deps = [
         "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":span",
     ],
 )
 

--- a/sxt/base/container/BUILD
+++ b/sxt/base/container/BUILD
@@ -29,9 +29,11 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "span_utility",
-    with_test = False,
     deps = [
         ":span",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
     ],
 )
 

--- a/sxt/base/container/span.h
+++ b/sxt/base/container/span.h
@@ -39,6 +39,8 @@ namespace sxt::basct {
  */
 template <class T> class span {
 public:
+  using value_type = std::remove_cv_t<T>;
+
   CUDA_CALLABLE
   span() noexcept : size_{0}, data_{nullptr} {}
 

--- a/sxt/base/container/span_utility.h
+++ b/sxt/base/container/span_utility.h
@@ -18,6 +18,7 @@
 
 #include <concepts>
 #include <cstddef>
+#include <memory_resource>
 #include <type_traits>
 
 #include "sxt/base/container/span.h"
@@ -44,5 +45,22 @@ span<T> subspan(Cont&& cont, size_t offset, size_t size) noexcept
   }
 {
   return span<T>{cont}.subspan(offset, size);
+}
+
+//--------------------------------------------------------------------------------------------------
+// winked_span
+//--------------------------------------------------------------------------------------------------
+/**
+ * Convenience function for winked-out allocations.
+ *
+ * Note: Be sure to use this with a compatible allocator.
+ * See section 3 of https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0089r1.pdf
+ */
+template <class T>
+span<T> winked_span(std::pmr::polymorphic_allocator<> alloc, size_t size) noexcept {
+  return {
+      static_cast<T*>(alloc.allocate_bytes(size * sizeof(T), alignof(T))),
+      size,
+  };
 }
 } // namespace sxt::basct

--- a/sxt/base/container/span_utility.t.cc
+++ b/sxt/base/container/span_utility.t.cc
@@ -1,0 +1,19 @@
+#include "sxt/base/container/span_utility.h"
+
+#include <numeric>
+
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::basct;
+
+TEST_CASE("we can make winked allocations") {
+  std::pmr::monotonic_buffer_resource alloc;
+
+  {
+    auto sx = sxt::basct::winked_span<int>(&alloc, 3);
+    std::iota(sx.begin(), sx.end(), 0);
+    REQUIRE(sx.size() == 3);
+    REQUIRE(sx[0] == 0);
+    REQUIRE(sx[2] == 2);
+  }
+}

--- a/sxt/base/container/span_utility.t.cc
+++ b/sxt/base/container/span_utility.t.cc
@@ -1,8 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/container/span_utility.h"
 
 #include <numeric>
 
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 using namespace sxt::basct;
 

--- a/sxt/base/type/BUILD
+++ b/sxt/base/type/BUILD
@@ -9,6 +9,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "value_type",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "literal",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/base/type/value_type.cc
+++ b/sxt/base/type/value_type.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/type/value_type.h"

--- a/sxt/base/type/value_type.h
+++ b/sxt/base/type/value_type.h
@@ -1,0 +1,35 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt::bast {
+//--------------------------------------------------------------------------------------------------
+// value_type
+//--------------------------------------------------------------------------------------------------
+template <class T> struct value_type {};
+
+template <class T>
+  requires requires { typename T::value_type; }
+struct value_type<T> {
+  using type = typename T::value_type;
+};
+
+//--------------------------------------------------------------------------------------------------
+// value_type_t
+//--------------------------------------------------------------------------------------------------
+template <class T> using value_type_t = typename value_type<T>::type;
+} // namespace sxt::bast

--- a/sxt/base/type/value_type.h
+++ b/sxt/base/type/value_type.h
@@ -27,8 +27,7 @@ namespace sxt::bast {
  */
 template <class T> struct value_type {};
 
-template <class T>
-struct value_type<T*> {
+template <class T> struct value_type<T*> {
   using type = std::remove_cv_t<T>;
 };
 
@@ -36,8 +35,7 @@ template <class T>
   requires std::is_array_v<T>
 struct value_type<T> : value_type<std::decay_t<T>> {};
 
-template <class T>
-struct value_type<const T> : value_type<std::decay_t<T>> {};
+template <class T> struct value_type<const T> : value_type<std::decay_t<T>> {};
 
 template <class T>
   requires requires { typename T::value_type; }

--- a/sxt/base/type/value_type.h
+++ b/sxt/base/type/value_type.h
@@ -16,16 +16,39 @@
  */
 #pragma once
 
+#include <type_traits>
+
 namespace sxt::bast {
 //--------------------------------------------------------------------------------------------------
 // value_type
 //--------------------------------------------------------------------------------------------------
+/**
+ * Mirror https://en.cppreference.com/w/cpp/experimental/ranges/iterator/value_type
+ */
 template <class T> struct value_type {};
+
+template <class T>
+struct value_type<T*> {
+  using type = std::remove_cv_t<T>;
+};
+
+template <class T>
+  requires std::is_array_v<T>
+struct value_type<T> : value_type<std::decay_t<T>> {};
+
+template <class T>
+struct value_type<const T> : value_type<std::decay_t<T>> {};
 
 template <class T>
   requires requires { typename T::value_type; }
 struct value_type<T> {
   using type = typename T::value_type;
+};
+
+template <class T>
+  requires requires { typename T::element_type; }
+struct value_type<T> {
+  using type = typename T::element_type;
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/base/type/value_type.t.cc
+++ b/sxt/base/type/value_type.t.cc
@@ -29,5 +29,9 @@ TEST_CASE("we can get the value type of containers") {
     REQUIRE(std::is_same_v<value_type_t<std::vector<int>>, int>);
   }
 
+  SECTION("we handle a const container") {
+    REQUIRE(std::is_same_v<value_type_t<const std::vector<int>>, int>);
+  }
+
   SECTION("we handle an array") { REQUIRE(std::is_same_v<value_type_t<int[6]>, int>); }
 }

--- a/sxt/base/type/value_type.t.cc
+++ b/sxt/base/type/value_type.t.cc
@@ -29,7 +29,5 @@ TEST_CASE("we can get the value type of containers") {
     REQUIRE(std::is_same_v<value_type_t<std::vector<int>>, int>);
   }
 
-  SECTION("we handle an array") {
-    REQUIRE(std::is_same_v<value_type_t<int[6]>, int>);
-  }
+  SECTION("we handle an array") { REQUIRE(std::is_same_v<value_type_t<int[6]>, int>); }
 }

--- a/sxt/base/type/value_type.t.cc
+++ b/sxt/base/type/value_type.t.cc
@@ -25,5 +25,11 @@ using namespace sxt;
 using namespace sxt::bast;
 
 TEST_CASE("we can get the value type of containers") {
-  REQUIRE(std::is_same_v<value_type_t<std::vector<int>>, int>);
+  SECTION("we handle a simple container") {
+    REQUIRE(std::is_same_v<value_type_t<std::vector<int>>, int>);
+  }
+
+  SECTION("we handle an array") {
+    REQUIRE(std::is_same_v<value_type_t<int[6]>, int>);
+  }
 }

--- a/sxt/base/type/value_type.t.cc
+++ b/sxt/base/type/value_type.t.cc
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/type/value_type.h"
+
+#include <type_traits>
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::bast;
+
+TEST_CASE("we can get the value type of containers") {
+  REQUIRE(std::is_same_v<value_type_t<std::vector<int>>, int>);
+}

--- a/sxt/memory/management/managed_array.h
+++ b/sxt/memory/management/managed_array.h
@@ -115,6 +115,7 @@ template <class T> class managed_array {
 
 public:
   using allocator_type = basm::alloc_t;
+  using value_type = T;
 
   // constructor
   managed_array() noexcept = default;


### PR DESCRIPTION
# Rationale for this change

Minor enhancements to make our containers more align with standard library containers and easier to work with.

# What changes are included in this PR?

* Add value_type as a member to our container classes.
* Add bast::value_type_t alias to retrieve the value type of a container.
* Add winked_span to make it easier to make winked allocations.

# Are these changes tested?

Yes
