### PR TITLE
feat: async memory management (PROOF-716)

### DIFF
--- a/sxt/execution/device/BUILD
+++ b/sxt/execution/device/BUILD
@@ -10,6 +10,7 @@ sxt_cc_component(
         "//sxt/base/device:property",
         "//sxt/base/test:unit_test",
         "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/resource:chained_resource",
         "//sxt/memory/resource:device_resource",
     ],
     deps = [
@@ -22,6 +23,34 @@ sxt_cc_component(
         "//sxt/base/device:pointer_attributes",
         "//sxt/base/device:state",
         "//sxt/base/device:stream",
+        "//sxt/base/type:value_type",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+    ],
+)
+
+sxt_cc_component(
+    name = "device_copy",
+    test_deps = [
+        "//sxt/base/device:active_device_guard",
+        "//sxt/base/device:property",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/resource:chained_resource",
+        "//sxt/memory/resource:device_resource",
+    ],
+    deps = [
+        ":event_future",
+        ":synchronization",
+        "//sxt/base/container:span",
+        "//sxt/base/container:span_utility",
+        "//sxt/base/device:event",
+        "//sxt/base/device:event_utility",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:pointer_attributes",
+        "//sxt/base/device:state",
+        "//sxt/base/device:stream",
+        "//sxt/base/type:value_type",
         "//sxt/execution/async:future",
         "//sxt/memory/management:managed_array",
     ],

--- a/sxt/execution/device/device_copy.cc
+++ b/sxt/execution/device/device_copy.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/device/device_copy.h"

--- a/sxt/execution/device/device_copy.h
+++ b/sxt/execution/device/device_copy.h
@@ -1,0 +1,52 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/container/span_utility.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/state.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/type/value_type.h"
+#include "sxt/execution/device/event_future.h"
+#include "sxt/execution/device/synchronization.h"
+
+namespace sxt::xendv {
+//--------------------------------------------------------------------------------------------------
+// winked_device_copy
+//--------------------------------------------------------------------------------------------------
+template <class Cont, class T = bast::value_type_t<Cont>>
+  requires std::convertible_to<Cont, basct::cspan<T>>
+event_future<basct::span<T>> winked_device_copy(std::pmr::polymorphic_allocator<> alloc,
+                                                const Cont& src) noexcept {
+  if (src.empty()) {
+    return event_future<basct::span<T>>{basct::span<T>{}};
+  }
+  auto res = basct::winked_span<T>(alloc, src.size());
+  basdv::stream stream;
+  basdv::async_copy_to_device(res, src, stream);
+  basdv::event event;
+  basdv::record_event(event, stream);
+  computation_handle handle;
+  handle.add_stream(std::move(stream));
+  auto active_device = basdv::get_device();
+  return event_future<basct::span<T>>{std::move(res), active_device, std::move(event),
+                                      std::move(handle)};
+}
+} // namespace sxt::xendv

--- a/sxt/execution/device/device_copy.t.cc
+++ b/sxt/execution/device/device_copy.t.cc
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/device/device_copy.h"
+
+#include "sxt/base/device/active_device_guard.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/property.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/chained_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+
+using namespace sxt;
+using namespace sxt::xendv;
+
+TEST_CASE("we can copy memory to the active device") {
+  memmg::managed_array<int> data_maybe{memr::get_device_resource()};
+  memmg::managed_array<int> host_data = {1, 2, 3};
+  memr::chained_resource alloc{memr::get_device_resource()};
+
+  SECTION("we handle the empty span") {
+    auto fut = winked_device_copy(&alloc, basct::cspan<int>{});
+    REQUIRE(!fut.event());
+    REQUIRE(fut.value().empty());
+  }
+
+  SECTION("host memory is copied to the device") {
+    auto fut = winked_device_copy(&alloc, host_data);
+    REQUIRE(fut.event());
+    xens::get_scheduler().run();
+    REQUIRE(basdv::is_active_device_pointer(fut.value().data()));
+    REQUIRE(basdv::is_equal_for_testing<int>(fut.value(), host_data));
+  }
+}

--- a/sxt/execution/device/device_copy.t.cc
+++ b/sxt/execution/device/device_copy.t.cc
@@ -29,7 +29,6 @@ using namespace sxt;
 using namespace sxt::xendv;
 
 TEST_CASE("we can copy memory to the active device") {
-  memmg::managed_array<int> data_maybe{memr::get_device_resource()};
   memmg::managed_array<int> host_data = {1, 2, 3};
   memr::chained_resource alloc{memr::get_device_resource()};
 


### PR DESCRIPTION
# Rationale for this change

Add routines to make managing device memory easier.

# What changes are included in this PR?

* extended make_active_device_viewable to support winked allocation
* added a routine for a winked copy of memory to the active device

# Are these changes tested?

Yes
