### PR TITLE
chore: fix unused variable warning

### DIFF
--- a/sxt/proof/inner_product/cpu_driver.cc
+++ b/sxt/proof/inner_product/cpu_driver.cc
@@ -104,7 +104,6 @@ std::unique_ptr<workspace>
 cpu_driver::make_workspace(const proof_descriptor& descriptor,
                            basct::cspan<s25t::element> a_vector) const noexcept {
   auto n = a_vector.size();
-  auto np_half = descriptor.g_vector.size() / 2;
   SXT_DEBUG_ASSERT(n > 1);
 
   auto res = std::make_unique<workspace>();


### PR DESCRIPTION
# Rationale for this change
Fix clang warning about an unused variable.

# What changes are included in this PR?
- `np_half` is removed from `sxt/proof/inner_product/cpu_driver.cc`

# Are these changes tested?
Yes