### PR TITLE
ci: migrate to use nix (PROOF-537)

### DIFF
--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -44,13 +44,8 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-        # TODO(rnburn): Two test cases fail
-        #    - //cbindings:inner_product_proof.t
-        #    - //sxt/multiexp/multiproduct_gpu:kernel.t
-        # The first times out and the second gives errors in the CI
-        # environment but not the nix environment with more up-to-date versions
-        # of LLVM and the cuda toolkit. I'm disabling the tests for now but will
-        # revist after the CI environment is updated.
+        # TODO(rnburn): //cbindings:inner_product_proof.t fails because it
+        # takes too long ... I'm disabling for now
       - name: Run cpp tests
         run: >
           nix develop --command \

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -32,13 +32,14 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Run check
+      - name: Run cpp tests
         run: >
           nix develop --command bazel test //...
 
   test-cpp-compute-sanitizer:
     name: C++ code with compute sanitizer
     runs-on: self-hosted
+    timeout-minutes: 600
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -52,35 +53,32 @@ jobs:
         # revist after the CI environment is updated.
       - name: Run cpp tests
         run: >
-          docker run 
-          --rm -e TEST_TMPDIR=/root/.cache_bazel 
-          -v $HOME/.cache_bazel_test:/root/.cache_bazel 
-          -v "$PWD":/src:ro -w /src --gpus all 
-          --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 
-          /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test --run_under /src_tmp/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t -//sxt/multiexp/multiproduct_gpu:kernel.t"
+          nix develop --command \
+            bazel test --run_under /src_tmp/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
           
   test-cpp-opt:
     name: C++ code with optimizations
     runs-on: self-hosted
+    timeout-minutes: 600
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-          # Note: Certain tests crashes nvlink
-          #       See https://developer.nvidia.com/bugs/4288496
-          #       As a simple workaround, I'm disabling for now
       - name: Run cpp tests with optimization flags on
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel_opt -v $HOME/.cache_bazel_test_opt:/root/.cache_bazel_opt -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test -c opt //..."
+        run: >
+          nix develop --command bazel test -c opt //...
 
   test-cpp-asan:
     name: C++ code with address sanitizer
     runs-on: self-hosted
+    timeout-minutes: 600
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
       
       - name: Run cpp-asan tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test_asan:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test --config=asan //..."
+        run: >
+          nix develop --command bazel test --config=asan opt //...
 
   test-rust:
     name: Rust Sys Crate

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -44,12 +44,18 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-        # TODO(rnburn): //cbindings:inner_product_proof.t fails because it
-        # takes too long ... I'm disabling for now
+        # TODO(rnburn): Two test cases fail
+        #    - //cbindings:inner_product_proof.t
+        #    - //sxt/multiexp/multiproduct_gpu:kernel.t
+        # The first times out and the second gives errors in the CI
+        # environment but not the nix environment with more up-to-date versions
+        # of LLVM and the cuda toolkit. I'm disabling the tests for now but will
+        # revist after the CI environment is updated.
       - name: Run cpp tests
         run: >
           nix develop --command \
-            bazel test --jobs=1 --run_under $PWD/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
+            bazel test --jobs=1 --run_under $PWD/tools/cuda/compute_sanitizer_wrapper.sh //... -- \
+               -//cbindings:inner_product_proof.t -//sxt/multiexp/multiproduct_gpu:kernel.t
           
   test-cpp-opt:
     name: C++ code with optimizations

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run cpp tests
         run: >
           nix develop --command \
-            bazel test --run_under /src_tmp/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
+            bazel test --run_under $PWD/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
           
   test-cpp-opt:
     name: C++ code with optimizations
@@ -73,7 +73,7 @@ jobs:
       
       - name: Run cpp-asan tests
         run: >
-          nix develop --command bazel test --config=asan opt //...
+          nix develop --command bazel test --config=asan //...
 
   test-rust:
     name: Rust Sys Crate

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run cpp tests
         run: >
           nix develop --command \
-            bazel test --run_under $PWD/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
+            bazel test --jobs=1 --run_under $PWD/tools/cuda/compute_sanitizer_wrapper.sh //... -- -//cbindings:inner_product_proof.t 
           
   test-cpp-opt:
     name: C++ code with optimizations
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run cpp tests with optimization flags on
         run: >
-          nix develop --command bazel test -c opt //...
+          nix develop --command bazel test --jobs=1 -c opt //...
 
   test-cpp-asan:
     name: C++ code with address sanitizer

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -27,12 +27,14 @@ jobs:
   test-cpp:
     name: C++ code
     runs-on: self-hosted
+    timeout-minutes: 600
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
 
-      - name: Run cpp tests
-        run: docker run --rm -e TEST_TMPDIR=/root/.cache_bazel -v $HOME/.cache_bazel_test:/root/.cache_bazel -v "$PWD":/src:ro -w /src --gpus all --privileged spaceandtimelabs/blitzar:12.2.0-cuda-1.71.1-rust-1 /bin/bash -c "cp -av /src/ /src_tmp/; cd /src_tmp; bazel test //..."
+      - name: Run check
+        run: >
+          nix develop --command bazel test //...
 
   test-cpp-compute-sanitizer:
     name: C++ code with compute sanitizer

--- a/flake.lock
+++ b/flake.lock
@@ -16,9 +16,26 @@
         "type": "github"
       }
     },
+    "nixpkgsDrv": {
+      "locked": {
+        "lastModified": 1702312524,
+        "narHash": "sha256-gkZJRDBUCpTPBvQk25G0B7vfbpEYM5s5OZqghkjZsnE=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a9bf124c46ef298113270b1f84a164865987a91c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgsDrv": "nixpkgsDrv"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,15 +3,27 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgsDrv.url = "github:nixos/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, }:
+  outputs = { self, nixpkgs, nixpkgsDrv }:
     let
       system = "x86_64-linux";
+      pkgsDrv = import nixpkgsDrv {
+        inherit system; 
+        config.allowUnfree = true;
+        config.cudaSupport = true;
+      };
+      driverOverlay = final: prev: {
+        cudaDrivers = pkgsDrv.linuxPackages.nvidia_x11;
+      };
       pkgs = import nixpkgs { 
         inherit system; 
         config.allowUnfree = true;
         config.cudaSupport = true;
+        overlays = [
+          driverOverlay
+        ];
       };
       shell = import ./nix/shell.nix { inherit pkgs; };
     in

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -15,7 +15,7 @@ mkShell {
   ];
   LD_LIBRARY_PATH = lib.makeLibraryPath [
     "/usr/lib/wsl"
-    linuxPackages.nvidia_x11
+    cudaDrivers
   ];
   shellHook = ''
   '';


### PR DESCRIPTION
# Rationale for this change

Migrates most of the CI jobs to use nix. There's still the rust test and the release script to migrate.

# What changes are included in this PR?

* Switch ci jobs from docker to nix

# Are these changes tested?

Tests run in CI.
