### PR TITLE
feat: support commitments of signed 128-bit integers (PROOF-772)

### DIFF
--- a/sxt/base/num/BUILD
+++ b/sxt/base/num/BUILD
@@ -4,6 +4,17 @@ load(
 )
 
 sxt_cc_component(
+    name = "abs",
+    test_deps = [
+      "//sxt/base/type:int",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
     name = "cmov",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/base/num/BUILD
+++ b/sxt/base/num/BUILD
@@ -6,8 +6,8 @@ load(
 sxt_cc_component(
     name = "abs",
     test_deps = [
-      "//sxt/base/type:int",
         "//sxt/base/test:unit_test",
+        "//sxt/base/type:int",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",

--- a/sxt/base/num/abs.cc
+++ b/sxt/base/num/abs.cc
@@ -1,0 +1,1 @@
+#include "sxt/base/num/abs.h"

--- a/sxt/base/num/abs.cc
+++ b/sxt/base/num/abs.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/num/abs.h"

--- a/sxt/base/num/abs.h
+++ b/sxt/base/num/abs.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <cmath>
@@ -12,8 +28,7 @@ namespace sxt::basn {
 /**
  * Support abs for integral types larger than 128 bits.
  */
-template <std::signed_integral T>
-CUDA_CALLABLE T abs(T x) noexcept {
+template <std::signed_integral T> CUDA_CALLABLE T abs(T x) noexcept {
   if constexpr (sizeof(T) <= 8) {
     return std::abs(x);
   }

--- a/sxt/base/num/abs.h
+++ b/sxt/base/num/abs.h
@@ -32,13 +32,7 @@ template <std::signed_integral T> CUDA_CALLABLE T abs(T x) noexcept {
   if constexpr (sizeof(T) <= 8) {
     return std::abs(x);
   }
-
-  // Note: There's probably a better way to do this that avoids branching, but
-  // this is an ok place to start from.
-  if (x < 0) {
-    return -x;
-  } else {
-    return x;
-  }
+  auto mul = static_cast<int>(x > 0) * 2 - 1;
+  return mul * x;
 }
 } // namespace sxt::basn

--- a/sxt/base/num/abs.h
+++ b/sxt/base/num/abs.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cmath>
+#include <concepts>
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::basn {
+//--------------------------------------------------------------------------------------------------
+// abs
+//--------------------------------------------------------------------------------------------------
+/**
+ * Support abs for integral types larger than 128 bits.
+ */
+template <std::signed_integral T>
+CUDA_CALLABLE T abs(T x) noexcept {
+  if constexpr (sizeof(T) <= 8) {
+    return std::abs(x);
+  }
+
+  // Note: There's probably a better way to do this that avoids branching, but
+  // this is an ok place to start from.
+  if (x < 0) {
+    return -x;
+  } else {
+    return x;
+  }
+}
+} // namespace sxt::basn

--- a/sxt/base/num/abs.t.cc
+++ b/sxt/base/num/abs.t.cc
@@ -1,0 +1,19 @@
+#include "sxt/base/num/abs.h"
+
+#include "sxt/base/type/int.h"
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::basn;
+
+TEST_CASE("we can compute the absolute value of numbers") {
+  SECTION("we can compute the absolute value of numbers up to 8 bytes") {
+    REQUIRE(abs(1) == 1);
+    REQUIRE(abs(-1) == 1);
+    REQUIRE(abs(-1ll) == 1ll);
+  }
+
+  SECTION("we can compute the absolute value of numbers larger than 8 bytes") {
+    int128_t x = -1;
+    REQUIRE(abs(x) == 1);
+  }
+}

--- a/sxt/base/num/abs.t.cc
+++ b/sxt/base/num/abs.t.cc
@@ -30,7 +30,9 @@ TEST_CASE("we can compute the absolute value of numbers") {
   }
 
   SECTION("we can compute the absolute value of numbers larger than 8 bytes") {
-    int128_t x = -1;
-    REQUIRE(abs(x) == 1);
+    REQUIRE(abs(int128_t{-1}) == 1);
+    REQUIRE(abs(int128_t{1}) == 1);
+    REQUIRE(abs(int128_t{-2}) == 2);
+    REQUIRE(abs(int128_t{2}) == 2);
   }
 }

--- a/sxt/base/num/abs.t.cc
+++ b/sxt/base/num/abs.t.cc
@@ -1,7 +1,24 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/num/abs.h"
 
-#include "sxt/base/type/int.h"
 #include "sxt/base/test/unit_test.h"
+#include "sxt/base/type/int.h"
+
 using namespace sxt;
 using namespace sxt::basn;
 

--- a/sxt/base/type/int.h
+++ b/sxt/base/type/int.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 
 using uint128_t = __uint128_t;
+using int128_t = __int128_t;
 
 namespace sxt::bast {
 //--------------------------------------------------------------------------------------------------
@@ -42,6 +43,10 @@ template <> struct sized_int_t_impl<32> {
 
 template <> struct sized_int_t_impl<64> {
   using type = int64_t;
+};
+
+template <> struct sized_int_t_impl<128> {
+  using type = int128_t;
 };
 } // namespace detail
 

--- a/sxt/multiexp/pippenger/BUILD
+++ b/sxt/multiexp/pippenger/BUILD
@@ -45,6 +45,7 @@ sxt_cc_component(
     name = "exponent_aggregates_computation",
     impl_deps = [
         ":exponent_aggregates",
+        "//sxt/base/num:abs",
         "//sxt/base/num:constexpr_switch",
         "//sxt/base/num:ceil_log2",
         "//sxt/base/num:power2_equality",
@@ -72,6 +73,7 @@ sxt_cc_component(
         "//sxt/base/container:blob_array",
         "//sxt/base/container:span_utility",
         "//sxt/base/container:stack_array",
+        "//sxt/base/num:abs",
         "//sxt/base/num:divide_up",
         "//sxt/multiexp/base:digit_utility",
         "//sxt/multiexp/base:exponent_sequence",
@@ -129,6 +131,7 @@ sxt_cc_component(
     name = "multiproduct_decomposition_kernel",
     impl_deps = [
         "//sxt/base/error:assert",
+        "//sxt/base/num:abs",
         "//sxt/base/num:divide_up",
         "//sxt/base/num:constexpr_switch",
         "//sxt/base/num:ceil_log2",

--- a/sxt/multiexp/test/BUILD
+++ b/sxt/multiexp/test/BUILD
@@ -18,6 +18,7 @@ sxt_cc_component(
     name = "curve21_arithmetic",
     impl_deps = [
         "//sxt/base/container:stack_array",
+        "//sxt/base/num:abs",
         "//sxt/base/num:constexpr_switch",
         "//sxt/base/num:ceil_log2",
         "//sxt/base/type:int",

--- a/sxt/multiexp/test/curve21_arithmetic.cc
+++ b/sxt/multiexp/test/curve21_arithmetic.cc
@@ -22,6 +22,7 @@
 
 #include "sxt/base/container/stack_array.h"
 #include "sxt/base/error/assert.h"
+#include "sxt/base/num/abs.h"
 #include "sxt/base/num/ceil_log2.h"
 #include "sxt/base/num/constexpr_switch.h"
 #include "sxt/base/type/int.h"
@@ -44,13 +45,13 @@ static void read_exponent(c21t::element_p3& e, basct::span<uint8_t>& exponent,
   if (!static_cast<bool>(sequence.is_signed)) {
     return;
   }
-  basn::constexpr_switch<4>(
+  basn::constexpr_switch<5>(
       basn::ceil_log2(element_nbytes),
       [&]<unsigned NumBytesLg2>(std::integral_constant<unsigned, NumBytesLg2>) noexcept {
         static constexpr auto NumBytes = 1ull << NumBytesLg2;
         bast::sized_int_t<NumBytes * 8> x{};
         std::copy_n(exponent.begin(), element_nbytes, reinterpret_cast<uint8_t*>(&x));
-        auto abs_x = std::abs(x);
+        auto abs_x = basn::abs(x);
         if (x == abs_x) {
           return;
         }

--- a/sxt/multiexp/test/multiexponentiation.cc
+++ b/sxt/multiexp/test/multiexponentiation.cc
@@ -416,7 +416,7 @@ void exercise_multiexponentiation_fn(std::mt19937& rng, multiexponentiation_fn f
     };
     size_t index = 0;
     for (int i = 0; i < 10; ++i) {
-      auto num_bytes = 1ull << (i % 4);
+      auto num_bytes = 1ull << (i % 5);
       descriptor.min_exponent_num_bytes = num_bytes;
       descriptor.max_exponent_num_bytes = num_bytes;
       mtxrn::generate_random_multiexponentiation(generators, sequences, &resource, rng, descriptor);


### PR DESCRIPTION
# Rationale for this change

Support commitments of signed 128-bit integers.

# What changes are included in this PR?

* added a custom `abs` function that works on 128-bit integers
* refactored host and GPU code to work on 128-bit integers

# Are these changes tested?

Yes. I extended the multiexponentiation tests to cover cases with signed 128-bit integers.
