### PR TITLE
feat: add field25 type package (PROOF-775)

### DIFF
--- a/sxt/field25/type/BUILD
+++ b/sxt/field25/type/BUILD
@@ -1,0 +1,32 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "element",
+    impl_deps = [
+        "//sxt/field12/base:byte_conversion",
+        "//sxt/field12/base:reduce",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/base:constants",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "literal",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":element",
+        "//sxt/base/type:literal",
+        "//sxt/field12/base:byte_conversion",
+    ],
+)

--- a/sxt/field25/type/BUILD
+++ b/sxt/field25/type/BUILD
@@ -6,13 +6,13 @@ load(
 sxt_cc_component(
     name = "element",
     impl_deps = [
-        "//sxt/field12/base:byte_conversion",
-        "//sxt/field12/base:reduce",
+        "//sxt/field25/base:byte_conversion",
+        "//sxt/field25/base:reduce",
     ],
     is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/base:constants",
+        "//sxt/field25/base:constants",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
@@ -27,6 +27,6 @@ sxt_cc_component(
     deps = [
         ":element",
         "//sxt/base/type:literal",
-        "//sxt/field12/base:byte_conversion",
+        "//sxt/field25/base:byte_conversion",
     ],
 )

--- a/sxt/field25/type/element.cc
+++ b/sxt/field25/type/element.cc
@@ -1,0 +1,70 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/type/element.h"
+
+#include <array>
+#include <iomanip>
+
+#include "sxt/field12/base/byte_conversion.h"
+#include "sxt/field12/base/reduce.h"
+
+namespace sxt::f12t {
+//--------------------------------------------------------------------------------------------------
+// print_impl
+//--------------------------------------------------------------------------------------------------
+static std::ostream& print_impl(std::ostream& out, const std::array<uint8_t, 48>& bytes,
+                                int start) noexcept {
+  out << std::hex << static_cast<int>(bytes[start]);
+  for (int i = start; i-- > 0;) {
+    out << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(bytes[i]);
+  }
+  out << "_f12";
+  return out;
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const element& e) noexcept {
+  std::array<uint8_t, 48> bytes = {};
+  f12b::to_bytes_le(bytes.data(), e.data());
+  auto flags = out.flags();
+  out << "0x";
+  for (int i = 48; i-- > 0;) {
+    if (bytes[i] != 0) {
+      print_impl(out, bytes, i);
+      out.flags(flags);
+      return out;
+    }
+  }
+  out << "0_f12";
+  out.flags(flags);
+  return out;
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept {
+  for (size_t i = 0; i < element::num_limbs_v; ++i) {
+    if (lhs[i] != rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
+} // namespace sxt::f12t

--- a/sxt/field25/type/element.cc
+++ b/sxt/field25/type/element.cc
@@ -14,15 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/type/element.h"
 
 #include <array>
 #include <iomanip>
 
-#include "sxt/field12/base/byte_conversion.h"
-#include "sxt/field12/base/reduce.h"
+#include "sxt/field25/base/byte_conversion.h"
+#include "sxt/field25/base/reduce.h"
 
-namespace sxt::f12t {
+namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 // print_impl
 //--------------------------------------------------------------------------------------------------
@@ -67,4 +67,4 @@ CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept {
   }
   return true;
 }
-} // namespace sxt::f12t
+} // namespace sxt::f25t

--- a/sxt/field25/type/element.cc
+++ b/sxt/field25/type/element.cc
@@ -26,13 +26,13 @@ namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 // print_impl
 //--------------------------------------------------------------------------------------------------
-static std::ostream& print_impl(std::ostream& out, const std::array<uint8_t, 48>& bytes,
+static std::ostream& print_impl(std::ostream& out, const std::array<uint8_t, 32>& bytes,
                                 int start) noexcept {
   out << std::hex << static_cast<int>(bytes[start]);
   for (int i = start; i-- > 0;) {
     out << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(bytes[i]);
   }
-  out << "_f12";
+  out << "_f25";
   return out;
 }
 
@@ -40,18 +40,18 @@ static std::ostream& print_impl(std::ostream& out, const std::array<uint8_t, 48>
 // operator<<
 //--------------------------------------------------------------------------------------------------
 std::ostream& operator<<(std::ostream& out, const element& e) noexcept {
-  std::array<uint8_t, 48> bytes = {};
-  f12b::to_bytes_le(bytes.data(), e.data());
+  std::array<uint8_t, 32> bytes = {};
+  f25b::to_bytes_le(bytes.data(), e.data());
   auto flags = out.flags();
   out << "0x";
-  for (int i = 48; i-- > 0;) {
+  for (int i = 32; i-- > 0;) {
     if (bytes[i] != 0) {
       print_impl(out, bytes, i);
       out.flags(flags);
       return out;
     }
   }
-  out << "0_f12";
+  out << "0_f25";
   out.flags(flags);
   return out;
 }

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -1,0 +1,69 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+#include <iosfwd>
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f12t {
+//--------------------------------------------------------------------------------------------------
+// element
+//--------------------------------------------------------------------------------------------------
+class element {
+public:
+  static constexpr size_t num_limbs_v = 6;
+
+  element() noexcept = default;
+
+  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5,
+                                  uint64_t x6) noexcept
+      : data_{x1, x2, x3, x4, x5, x6} {}
+
+  CUDA_CALLABLE constexpr element(const uint64_t x[6]) noexcept
+      : data_{x[0], x[1], x[2], x[3], x[4], x[5]} {}
+
+  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
+    return data_[index];
+  }
+
+  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+
+  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+
+  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+
+private:
+  uint64_t data_[num_limbs_v];
+};
+
+//--------------------------------------------------------------------------------------------------
+// operator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const element& e) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// operator!=
+//--------------------------------------------------------------------------------------------------
+inline bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
+} // namespace sxt::f12t

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -27,16 +27,14 @@ namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 class element {
 public:
-  static constexpr size_t num_limbs_v = 6;
+  static constexpr size_t num_limbs_v = 4;
 
   element() noexcept = default;
 
-  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5,
-                                  uint64_t x6) noexcept
-      : data_{x1, x2, x3, x4, x5, x6} {}
+  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4) noexcept
+      : data_{x1, x2, x3, x4} {}
 
-  CUDA_CALLABLE constexpr element(const uint64_t x[6]) noexcept
-      : data_{x[0], x[1], x[2], x[3], x[4], x[5]} {}
+  CUDA_CALLABLE constexpr element(const uint64_t x[4]) noexcept : data_{x[0], x[1], x[2], x[3]} {}
 
   CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
     return data_[index];

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -21,7 +21,7 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::f12t {
+namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 // element
 //--------------------------------------------------------------------------------------------------
@@ -66,4 +66,4 @@ CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept;
 // operator!=
 //--------------------------------------------------------------------------------------------------
 inline bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
-} // namespace sxt::f12t
+} // namespace sxt::f25t

--- a/sxt/field25/type/element.t.cc
+++ b/sxt/field25/type/element.t.cc
@@ -14,15 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/type/element.h"
 
 #include <sstream>
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/base/constants.h"
+#include "sxt/field25/base/constants.h"
 
 using namespace sxt;
-using namespace sxt::f12t;
+using namespace sxt::f25t;
 
 TEST_CASE("element conversion") {
   std::ostringstream oss;

--- a/sxt/field25/type/element.t.cc
+++ b/sxt/field25/type/element.t.cc
@@ -1,0 +1,64 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/type/element.h"
+
+#include <sstream>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/base/constants.h"
+
+using namespace sxt;
+using namespace sxt::f12t;
+
+TEST_CASE("element conversion") {
+  std::ostringstream oss;
+
+  SECTION("of zero prints as zero") {
+    element e{0, 0, 0, 0, 0, 0};
+    oss << e;
+    REQUIRE(oss.str() == "0x0_f12");
+  }
+
+  SECTION("of one in Montgomery form prints as one") {
+    element e{0x760900000002fffd, 0xebf4000bc40c0002, 0x5f48985753c758ba,
+              0x77ce585370525745, 0x5c071a97a256ec6d, 0x15f65ec3fa80e493};
+    oss << e;
+    REQUIRE(oss.str() == "0x1_f12");
+  }
+
+  SECTION("of the modulus prints as zero") {
+    element e(f12b::p_v.data());
+    oss << e;
+    REQUIRE(oss.str() == "0x0_f12");
+  }
+
+  SECTION("of the modulus minus one prints a pre-computed value") {
+    element e{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
+              0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+    oss << e;
+    REQUIRE(oss.str() == "0x5024ae85084d9b05dbd438f06fc594c4cdfa0709adc84d632f22927e21b885b9ecaed89"
+                         "d8bb0503c52b7da6c7f4628b_f12");
+  }
+
+  SECTION("of a pre-computed value returns a pre-computed value") {
+    const uint64_t e_array[6] = {0, 1, 2, 3, 4, 5};
+    element e{e_array};
+    oss << e;
+    REQUIRE(oss.str() == "0x55cb35bae0c5253c1f42d6d581fc0f94780c21ab9af0f38e8699a7f484af974311fee26"
+                         "c2fec135aadf4b21a3346b64_f12");
+  }
+}

--- a/sxt/field25/type/element.t.cc
+++ b/sxt/field25/type/element.t.cc
@@ -28,37 +28,26 @@ TEST_CASE("element conversion") {
   std::ostringstream oss;
 
   SECTION("of zero prints as zero") {
-    element e{0, 0, 0, 0, 0, 0};
+    element e{0, 0, 0, 0};
     oss << e;
-    REQUIRE(oss.str() == "0x0_f12");
+    REQUIRE(oss.str() == "0x0_f25");
   }
 
   SECTION("of one in Montgomery form prints as one") {
-    element e{0x760900000002fffd, 0xebf4000bc40c0002, 0x5f48985753c758ba,
-              0x77ce585370525745, 0x5c071a97a256ec6d, 0x15f65ec3fa80e493};
+    element e(f25b::r_v.data());
     oss << e;
-    REQUIRE(oss.str() == "0x1_f12");
+    REQUIRE(oss.str() == "0x1_f25");
   }
 
   SECTION("of the modulus prints as zero") {
-    element e(f12b::p_v.data());
+    element e(f25b::p_v.data());
     oss << e;
-    REQUIRE(oss.str() == "0x0_f12");
+    REQUIRE(oss.str() == "0x0_f25");
   }
 
-  SECTION("of the modulus minus one prints a pre-computed value") {
-    element e{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
-              0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+  SECTION("of r2_v is r_v") {
+    element e(f25b::r2_v.data());
     oss << e;
-    REQUIRE(oss.str() == "0x5024ae85084d9b05dbd438f06fc594c4cdfa0709adc84d632f22927e21b885b9ecaed89"
-                         "d8bb0503c52b7da6c7f4628b_f12");
-  }
-
-  SECTION("of a pre-computed value returns a pre-computed value") {
-    const uint64_t e_array[6] = {0, 1, 2, 3, 4, 5};
-    element e{e_array};
-    oss << e;
-    REQUIRE(oss.str() == "0x55cb35bae0c5253c1f42d6d581fc0f94780c21ab9af0f38e8699a7f484af974311fee26"
-                         "c2fec135aadf4b21a3346b64_f12");
+    REQUIRE(oss.str() == "0xe0a77c19a07df2f666ea36f7879462c0a78eb28f5c70b3dd35d438dc58f0d9d_f25");
   }
 }

--- a/sxt/field25/type/literal.cc
+++ b/sxt/field25/type/literal.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/type/literal.h"

--- a/sxt/field25/type/literal.cc
+++ b/sxt/field25/type/literal.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/type/literal.h"
+#include "sxt/field25/type/literal.h"

--- a/sxt/field25/type/literal.h
+++ b/sxt/field25/type/literal.h
@@ -19,10 +19,10 @@
 #include <array>
 
 #include "sxt/base/type/literal.h"
-#include "sxt/field12/base/byte_conversion.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/base/byte_conversion.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::f12t {
+namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 // _f12
 //--------------------------------------------------------------------------------------------------
@@ -34,4 +34,4 @@ template <char... Chars> element operator"" _f12() noexcept {
   f12b::from_bytes_le(is_below, res.data(), reinterpret_cast<const uint8_t*>(bytes.data()));
   return res;
 }
-} // namespace sxt::f12t
+} // namespace sxt::f25t

--- a/sxt/field25/type/literal.h
+++ b/sxt/field25/type/literal.h
@@ -24,14 +24,14 @@
 
 namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
-// _f12
+// _f25
 //--------------------------------------------------------------------------------------------------
-template <char... Chars> element operator"" _f12() noexcept {
-  std::array<uint64_t, 6> bytes = {};
-  bast::parse_literal<6, Chars...>(bytes);
+template <char... Chars> element operator"" _f25() noexcept {
+  std::array<uint64_t, 4> bytes = {};
+  bast::parse_literal<4, Chars...>(bytes);
   element res;
   bool is_below;
-  f12b::from_bytes_le(is_below, res.data(), reinterpret_cast<const uint8_t*>(bytes.data()));
+  f25b::from_bytes_le(is_below, res.data(), reinterpret_cast<const uint8_t*>(bytes.data()));
   return res;
 }
 } // namespace sxt::f25t

--- a/sxt/field25/type/literal.h
+++ b/sxt/field25/type/literal.h
@@ -1,0 +1,37 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <array>
+
+#include "sxt/base/type/literal.h"
+#include "sxt/field12/base/byte_conversion.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12t {
+//--------------------------------------------------------------------------------------------------
+// _f12
+//--------------------------------------------------------------------------------------------------
+template <char... Chars> element operator"" _f12() noexcept {
+  std::array<uint64_t, 6> bytes = {};
+  bast::parse_literal<6, Chars...>(bytes);
+  element res;
+  bool is_below;
+  f12b::from_bytes_le(is_below, res.data(), reinterpret_cast<const uint8_t*>(bytes.data()));
+  return res;
+}
+} // namespace sxt::f12t

--- a/sxt/field25/type/literal.t.cc
+++ b/sxt/field25/type/literal.t.cc
@@ -25,34 +25,38 @@ using namespace sxt::f25t;
 TEST_CASE("literal element printing") {
   std::ostringstream oss;
 
-  SECTION("of zero prints 0x0_f12") {
-    oss << 0x0_f12;
-    REQUIRE(oss.str() == "0x0_f12");
+  SECTION("of zero prints 0x0_f25") {
+    oss << 0x0_f25;
+    REQUIRE(oss.str() == "0x0_f25");
   }
 
-  SECTION("of one prints 0x1_f12") {
-    oss << 0x1_f12;
-    REQUIRE(oss.str() == "0x1_f12");
+  SECTION("of one prints 0x1_f25") {
+    oss << 0x1_f25;
+    REQUIRE(oss.str() == "0x1_f25");
   }
 
-  SECTION("of 10 prints 0xa_f12") {
-    oss << 0xa_f12;
-    REQUIRE(oss.str() == "0xa_f12");
+  SECTION("of 10 prints 0xa_f25") {
+    oss << 0xa_f25;
+    REQUIRE(oss.str() == "0xa_f25");
   }
 
-  SECTION("of 16 prints 0x10_f12") {
-    oss << 0x10_f12;
-    REQUIRE(oss.str() == "0x10_f12");
+  SECTION("of 16 prints 0x10_f25") {
+    oss << 0x10_f25;
+    REQUIRE(oss.str() == "0x10_f25");
   }
 
-  SECTION("of the modulus prints 0x0_f12") {
-    oss << 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_f12;
-    REQUIRE(oss.str() == "0x0_f12");
+  SECTION("of the modulus prints 0x0_f25") {
+    oss << 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47_f25;
+    REQUIRE(oss.str() == "0x0_f25");
   }
 
   SECTION("of the modulus minus one prints a pre-computed value") {
-    oss << 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaaa_f12;
-    REQUIRE(oss.str() == "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfff"
-                         "eb153ffffb9feffffffffaaaa_f12");
+    oss << 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_f25;
+    REQUIRE(oss.str() == "0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd46_f25");
+  }
+
+  SECTION("of the modulus plus one prints as one") {
+    oss << 0x30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd48_f25;
+    REQUIRE(oss.str() == "0x1_f25");
   }
 }

--- a/sxt/field25/type/literal.t.cc
+++ b/sxt/field25/type/literal.t.cc
@@ -14,13 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/type/literal.h"
+#include "sxt/field25/type/literal.h"
 
 #include <sstream>
 
 #include "sxt/base/test/unit_test.h"
 
-using namespace sxt::f12t;
+using namespace sxt::f25t;
 
 TEST_CASE("literal element printing") {
   std::ostringstream oss;

--- a/sxt/field25/type/literal.t.cc
+++ b/sxt/field25/type/literal.t.cc
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/type/literal.h"
+
+#include <sstream>
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt::f12t;
+
+TEST_CASE("literal element printing") {
+  std::ostringstream oss;
+
+  SECTION("of zero prints 0x0_f12") {
+    oss << 0x0_f12;
+    REQUIRE(oss.str() == "0x0_f12");
+  }
+
+  SECTION("of one prints 0x1_f12") {
+    oss << 0x1_f12;
+    REQUIRE(oss.str() == "0x1_f12");
+  }
+
+  SECTION("of 10 prints 0xa_f12") {
+    oss << 0xa_f12;
+    REQUIRE(oss.str() == "0xa_f12");
+  }
+
+  SECTION("of 16 prints 0x10_f12") {
+    oss << 0x10_f12;
+    REQUIRE(oss.str() == "0x10_f12");
+  }
+
+  SECTION("of the modulus prints 0x0_f12") {
+    oss << 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab_f12;
+    REQUIRE(oss.str() == "0x0_f12");
+  }
+
+  SECTION("of the modulus minus one prints a pre-computed value") {
+    oss << 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaaa_f12;
+    REQUIRE(oss.str() == "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfff"
+                         "eb153ffffb9feffffffffaaaa_f12");
+  }
+}


### PR DESCRIPTION
# Rationale for this change
In order to support MSM with elements on the `bn254` curve we need to implement the base field `Fq`. This work will introduce the type package and components to the `bn254` base field, `field25`. The components are copied from the the `field12/type` package, which supports the `bls12-381` curve. The components are updated to support the `bn254` base field, which is four limbs, compared to the six limbs of the `bls12-381` base field.

The only non-trivial code change, which updated the limbs from six to four, is isolated to [this commit](https://github.com/spaceandtimelabs/blitzar/commit/6f02083b4609741640cc801b8e43fceeb5fa756e).

# What changes are included in this PR?
- The `element` and `literal` components are copied from the `field12/type` package and updated to support the four limbs.

# Are these changes tested?
Yes