### PR TITLE
feat: add field25 operation package and add, mul, neg, and sub components (PROOF 778)

### DIFF
--- a/sxt/field25/operation/BUILD
+++ b/sxt/field25/operation/BUILD
@@ -6,8 +6,10 @@ load(
 sxt_cc_component(
     name = "add",
     test_deps = [
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
         "//sxt/field25/constant:zero",
+        "//sxt/field25/random:element",
     ],
     deps = [
         "//sxt/base/field:arithmetic_utility",
@@ -27,8 +29,12 @@ sxt_cc_component(
     ],
     is_cuda = True,
     test_deps = [
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
+        "//sxt/field25/base:constants",
+        "//sxt/field25/base:montgomery",
         "//sxt/field25/constant:zero",
+        "//sxt/field25/random:element",
         "//sxt/field25/type:element",
     ],
     deps = [
@@ -47,6 +53,7 @@ sxt_cc_component(
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field25/base:constants",
+        "//sxt/field25/constant:zero",
         "//sxt/field25/type:element",
     ],
     deps = [
@@ -57,8 +64,10 @@ sxt_cc_component(
 sxt_cc_component(
     name = "sub",
     test_deps = [
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
         "//sxt/field25/constant:zero",
+        "//sxt/field25/random:element",
     ],
     deps = [
         ":add",

--- a/sxt/field25/operation/BUILD
+++ b/sxt/field25/operation/BUILD
@@ -1,0 +1,69 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "add",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/constant:zero",
+    ],
+    deps = [
+        "//sxt/base/field:arithmetic_utility",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/base:constants",
+        "//sxt/field12/base:subtract_p",
+        "//sxt/field12/type:element",
+    ],
+)
+
+sxt_cc_component(
+    name = "mul",
+    impl_deps = [
+        "//sxt/base/field:arithmetic_utility",
+        "//sxt/field12/base:reduce",
+        "//sxt/field12/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "neg",
+    impl_deps = [
+        "//sxt/base/field:arithmetic_utility",
+        "//sxt/field12/base:constants",
+        "//sxt/field12/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/base:constants",
+        "//sxt/field12/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "sub",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/constant:zero",
+    ],
+    deps = [
+        ":add",
+        ":neg",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/type:element",
+    ],
+)

--- a/sxt/field25/operation/BUILD
+++ b/sxt/field25/operation/BUILD
@@ -7,14 +7,14 @@ sxt_cc_component(
     name = "add",
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/constant:zero",
+        "//sxt/field25/constant:zero",
     ],
     deps = [
         "//sxt/base/field:arithmetic_utility",
         "//sxt/base/macro:cuda_callable",
-        "//sxt/field12/base:constants",
-        "//sxt/field12/base:subtract_p",
-        "//sxt/field12/type:element",
+        "//sxt/field25/base:constants",
+        "//sxt/field25/base:subtract_p",
+        "//sxt/field25/type:element",
     ],
 )
 
@@ -22,14 +22,14 @@ sxt_cc_component(
     name = "mul",
     impl_deps = [
         "//sxt/base/field:arithmetic_utility",
-        "//sxt/field12/base:reduce",
-        "//sxt/field12/type:element",
+        "//sxt/field25/base:reduce",
+        "//sxt/field25/type:element",
     ],
     is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/constant:zero",
-        "//sxt/field12/type:element",
+        "//sxt/field25/constant:zero",
+        "//sxt/field25/type:element",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
@@ -40,14 +40,14 @@ sxt_cc_component(
     name = "neg",
     impl_deps = [
         "//sxt/base/field:arithmetic_utility",
-        "//sxt/field12/base:constants",
-        "//sxt/field12/type:element",
+        "//sxt/field25/base:constants",
+        "//sxt/field25/type:element",
     ],
     is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/base:constants",
-        "//sxt/field12/type:element",
+        "//sxt/field25/base:constants",
+        "//sxt/field25/type:element",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
@@ -58,12 +58,12 @@ sxt_cc_component(
     name = "sub",
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/constant:zero",
+        "//sxt/field25/constant:zero",
     ],
     deps = [
         ":add",
         ":neg",
         "//sxt/base/macro:cuda_callable",
-        "//sxt/field12/type:element",
+        "//sxt/field25/type:element",
     ],
 )

--- a/sxt/field25/operation/add.cc
+++ b/sxt/field25/operation/add.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/operation/add.h"
+#include "sxt/field25/operation/add.h"

--- a/sxt/field25/operation/add.cc
+++ b/sxt/field25/operation/add.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/operation/add.h"

--- a/sxt/field25/operation/add.h
+++ b/sxt/field25/operation/add.h
@@ -1,0 +1,54 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/field/arithmetic_utility.h"
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/field12/base/constants.h"
+#include "sxt/field12/base/subtract_p.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// add
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE inline void add(f12t::element& h, const f12t::element& f,
+                              const f12t::element& g) noexcept {
+  uint64_t h_tmp[6] = {};
+  uint64_t carry{0};
+
+  basfld::adc(h_tmp[0], carry, f[0], g[0], carry);
+  basfld::adc(h_tmp[1], carry, f[1], g[1], carry);
+  basfld::adc(h_tmp[2], carry, f[2], g[2], carry);
+  basfld::adc(h_tmp[3], carry, f[3], g[3], carry);
+  basfld::adc(h_tmp[4], carry, f[4], g[4], carry);
+  basfld::adc(h_tmp[5], carry, f[5], g[5], carry);
+
+  f12b::subtract_p(h.data(), h_tmp);
+}
+} // namespace sxt::f12o

--- a/sxt/field25/operation/add.h
+++ b/sxt/field25/operation/add.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -29,11 +29,11 @@
 
 #include "sxt/base/field/arithmetic_utility.h"
 #include "sxt/base/macro/cuda_callable.h"
-#include "sxt/field12/base/constants.h"
-#include "sxt/field12/base/subtract_p.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/base/constants.h"
+#include "sxt/field25/base/subtract_p.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // add
 //--------------------------------------------------------------------------------------------------
@@ -51,4 +51,4 @@ CUDA_CALLABLE inline void add(f12t::element& h, const f12t::element& f,
 
   f12b::subtract_p(h.data(), h_tmp);
 }
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/add.h
+++ b/sxt/field25/operation/add.h
@@ -37,18 +37,16 @@ namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // add
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE inline void add(f12t::element& h, const f12t::element& f,
-                              const f12t::element& g) noexcept {
-  uint64_t h_tmp[6] = {};
+CUDA_CALLABLE inline void add(f25t::element& h, const f25t::element& f,
+                              const f25t::element& g) noexcept {
+  uint64_t h_tmp[4] = {};
   uint64_t carry{0};
 
   basfld::adc(h_tmp[0], carry, f[0], g[0], carry);
   basfld::adc(h_tmp[1], carry, f[1], g[1], carry);
   basfld::adc(h_tmp[2], carry, f[2], g[2], carry);
   basfld::adc(h_tmp[3], carry, f[3], g[3], carry);
-  basfld::adc(h_tmp[4], carry, f[4], g[4], carry);
-  basfld::adc(h_tmp[5], carry, f[5], g[5], carry);
 
-  f12b::subtract_p(h.data(), h_tmp);
+  f25b::subtract_p(h.data(), h_tmp);
 }
 } // namespace sxt::f25o

--- a/sxt/field25/operation/add.t.cc
+++ b/sxt/field25/operation/add.t.cc
@@ -16,48 +16,66 @@
  */
 #include "sxt/field25/operation/add.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/constant/zero.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("addition") {
-  SECTION("of pre-computed value and zero returns pre-computed value") {
-    // Random values between 1 and p_v generated using the SAGE library.
-    constexpr f12t::element a{0xa18bb998ebd63ed4, 0xf9376579bd7313fb, 0x7c8e20c46f387e01,
-                              0xfd64e34f83253657, 0x69f877012e12b25a, 0x9e91aa07f8a1e24};
+  SECTION("of a random field element and zero returns the random field element") {
+    f25t::element a;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(a, rng);
 
-    f12t::element ret;
-    add(ret, a, f12cn::zero_v);
+    f25t::element ret;
+
+    add(ret, a, f25cn::zero_v);
 
     REQUIRE(a == ret);
   }
 
   SECTION("of pre-computed values returns expected value") {
-    // Random values between 1 and p_v generated using the SAGE library.
-    constexpr f12t::element a{0xd13cd59bb4634e05, 0x0f2509b85592e56f, 0x651937e06008a619,
-                              0x64d5bd872b39c8a7, 0x841f0f8892fa4f10, 0x78048ec7ecc6399};
-    constexpr f12t::element b{0x16c9e69b4dea3f04, 0xf0a6ec99d0b1f9be, 0x22bb437b9b63365f,
-                              0x1c46c6dd44489804, 0x10f8e4ed03d5659a, 0x14fe816ddb9e6192};
-    constexpr f12t::element expected{0x2e07bc37024de25e, 0xe11ff65374f0df2e, 0x20a3a8bb04bae654,
-                                     0x1ca538df7bfd4dec, 0x49fc4cbf538407d3, 0x27db87020eade91};
+    // Random bn254 base field elements generated using the SAGE library.
+    constexpr f25t::element a{0x1149c21473b043fd, 0x5610b2a5c08c7ecf, 0xc9e31f2d914c45b5,
+                              0x066031eb7a3ca7fd};
+    constexpr f25t::element b{0x13f757e660d431b8, 0x8a86bc6a237b60d5, 0x6f91e11522e9b96d,
+                              0x10ce4233724f624b};
+    constexpr f25t::element expected{0x254119fad48475b5, 0xe0976f0fe407dfa4, 0x39750042b435ff22,
+                                     0x172e741eec8c0a49};
+    f25t::element ret;
 
-    f12t::element ret;
+    add(ret, a, b);
+
+    REQUIRE(expected == ret);
+  }
+
+  SECTION("of a pre-computed value the modulus minus one returns expected value") {
+    // Random bn254 base field element generated using the SAGE library.
+    constexpr f25t::element a{0x1149c21473b043fd, 0x5610b2a5c08c7ecf, 0xc9e31f2d914c45b5,
+                              0x066031eb7a3ca7fd};
+    constexpr f25t::element b{0x3c208c16d87cfd46, 0x97816a916871ca8d, 0xb85045b68181585d,
+                              0x30644e72e131a029};
+    constexpr f25t::element expected{0x1149c21473b043fc, 0x5610b2a5c08c7ecf, 0xc9e31f2d914c45b5,
+                                     0x066031eb7a3ca7fd};
+    f25t::element ret;
+
     add(ret, a, b);
 
     REQUIRE(expected == ret);
   }
 
   SECTION("of the modulus minus one and one returns zero") {
-    constexpr f12t::element a{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
-                              0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
-    constexpr f12t::element b{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
+    constexpr f25t::element a{0x3c208c16d87cfd46, 0x97816a916871ca8d, 0xb85045b68181585d,
+                              0x30644e72e131a029};
+    constexpr f25t::element b{1, 0, 0, 0};
+    f25t::element ret;
 
-    f12t::element ret;
     add(ret, a, b);
 
-    REQUIRE(f12cn::zero_v == ret);
+    REQUIRE(f25cn::zero_v == ret);
   }
 }

--- a/sxt/field25/operation/add.t.cc
+++ b/sxt/field25/operation/add.t.cc
@@ -1,0 +1,63 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/operation/add.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f12o;
+
+TEST_CASE("addition") {
+  SECTION("of pre-computed value and zero returns pre-computed value") {
+    // Random values between 1 and p_v generated using the SAGE library.
+    constexpr f12t::element a{0xa18bb998ebd63ed4, 0xf9376579bd7313fb, 0x7c8e20c46f387e01,
+                              0xfd64e34f83253657, 0x69f877012e12b25a, 0x9e91aa07f8a1e24};
+
+    f12t::element ret;
+    add(ret, a, f12cn::zero_v);
+
+    REQUIRE(a == ret);
+  }
+
+  SECTION("of pre-computed values returns expected value") {
+    // Random values between 1 and p_v generated using the SAGE library.
+    constexpr f12t::element a{0xd13cd59bb4634e05, 0x0f2509b85592e56f, 0x651937e06008a619,
+                              0x64d5bd872b39c8a7, 0x841f0f8892fa4f10, 0x78048ec7ecc6399};
+    constexpr f12t::element b{0x16c9e69b4dea3f04, 0xf0a6ec99d0b1f9be, 0x22bb437b9b63365f,
+                              0x1c46c6dd44489804, 0x10f8e4ed03d5659a, 0x14fe816ddb9e6192};
+    constexpr f12t::element expected{0x2e07bc37024de25e, 0xe11ff65374f0df2e, 0x20a3a8bb04bae654,
+                                     0x1ca538df7bfd4dec, 0x49fc4cbf538407d3, 0x27db87020eade91};
+
+    f12t::element ret;
+    add(ret, a, b);
+
+    REQUIRE(expected == ret);
+  }
+
+  SECTION("of the modulus minus one and one returns zero") {
+    constexpr f12t::element a{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
+                              0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+    constexpr f12t::element b{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
+
+    f12t::element ret;
+    add(ret, a, b);
+
+    REQUIRE(f12cn::zero_v == ret);
+  }
+}

--- a/sxt/field25/operation/add.t.cc
+++ b/sxt/field25/operation/add.t.cc
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/operation/add.h"
+#include "sxt/field25/operation/add.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::f12o;
+using namespace sxt::f25o;
 
 TEST_CASE("addition") {
   SECTION("of pre-computed value and zero returns pre-computed value") {

--- a/sxt/field25/operation/mul.cc
+++ b/sxt/field25/operation/mul.cc
@@ -34,63 +34,37 @@ namespace sxt::f25o {
 // mul
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
-  uint64_t t[12] = {};
+void mul(f25t::element& h, const f25t::element& f, const f25t::element& g) noexcept {
+  uint64_t t[8] = {};
   uint64_t carry{0};
 
   basfld::mac(t[0], carry, 0, f[0], g[0]);
   basfld::mac(t[1], carry, 0, f[0], g[1]);
   basfld::mac(t[2], carry, 0, f[0], g[2]);
   basfld::mac(t[3], carry, 0, f[0], g[3]);
-  basfld::mac(t[4], carry, 0, f[0], g[4]);
-  basfld::mac(t[5], carry, 0, f[0], g[5]);
-  t[6] = carry;
+  t[4] = carry;
   carry = 0;
 
   basfld::mac(t[1], carry, t[1], f[1], g[0]);
   basfld::mac(t[2], carry, t[2], f[1], g[1]);
   basfld::mac(t[3], carry, t[3], f[1], g[2]);
   basfld::mac(t[4], carry, t[4], f[1], g[3]);
-  basfld::mac(t[5], carry, t[5], f[1], g[4]);
-  basfld::mac(t[6], carry, t[6], f[1], g[5]);
-  t[7] = carry;
+  t[5] = carry;
   carry = 0;
 
   basfld::mac(t[2], carry, t[2], f[2], g[0]);
   basfld::mac(t[3], carry, t[3], f[2], g[1]);
   basfld::mac(t[4], carry, t[4], f[2], g[2]);
   basfld::mac(t[5], carry, t[5], f[2], g[3]);
-  basfld::mac(t[6], carry, t[6], f[2], g[4]);
-  basfld::mac(t[7], carry, t[7], f[2], g[5]);
-  t[8] = carry;
+  t[6] = carry;
   carry = 0;
 
   basfld::mac(t[3], carry, t[3], f[3], g[0]);
   basfld::mac(t[4], carry, t[4], f[3], g[1]);
   basfld::mac(t[5], carry, t[5], f[3], g[2]);
   basfld::mac(t[6], carry, t[6], f[3], g[3]);
-  basfld::mac(t[7], carry, t[7], f[3], g[4]);
-  basfld::mac(t[8], carry, t[8], f[3], g[5]);
-  t[9] = carry;
-  carry = 0;
+  t[7] = carry;
 
-  basfld::mac(t[4], carry, t[4], f[4], g[0]);
-  basfld::mac(t[5], carry, t[5], f[4], g[1]);
-  basfld::mac(t[6], carry, t[6], f[4], g[2]);
-  basfld::mac(t[7], carry, t[7], f[4], g[3]);
-  basfld::mac(t[8], carry, t[8], f[4], g[4]);
-  basfld::mac(t[9], carry, t[9], f[4], g[5]);
-  t[10] = carry;
-  carry = 0;
-
-  basfld::mac(t[5], carry, t[5], f[5], g[0]);
-  basfld::mac(t[6], carry, t[6], f[5], g[1]);
-  basfld::mac(t[7], carry, t[7], f[5], g[2]);
-  basfld::mac(t[8], carry, t[8], f[5], g[3]);
-  basfld::mac(t[9], carry, t[9], f[5], g[4]);
-  basfld::mac(t[10], carry, t[10], f[5], g[5]);
-  t[11] = carry;
-
-  f12b::reduce(h.data(), t);
+  f25b::reduce(h.data(), t);
 }
 } // namespace sxt::f25o

--- a/sxt/field25/operation/mul.cc
+++ b/sxt/field25/operation/mul.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,13 +23,13 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/field12/operation/mul.h"
+#include "sxt/field25/operation/mul.h"
 
 #include "sxt/base/field/arithmetic_utility.h"
-#include "sxt/field12/base/reduce.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/base/reduce.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // mul
 //--------------------------------------------------------------------------------------------------
@@ -93,4 +93,4 @@ void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexc
 
   f12b::reduce(h.data(), t);
 }
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/mul.cc
+++ b/sxt/field25/operation/mul.cc
@@ -1,0 +1,96 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/operation/mul.h"
+
+#include "sxt/base/field/arithmetic_utility.h"
+#include "sxt/field12/base/reduce.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// mul
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
+  uint64_t t[12] = {};
+  uint64_t carry{0};
+
+  basfld::mac(t[0], carry, 0, f[0], g[0]);
+  basfld::mac(t[1], carry, 0, f[0], g[1]);
+  basfld::mac(t[2], carry, 0, f[0], g[2]);
+  basfld::mac(t[3], carry, 0, f[0], g[3]);
+  basfld::mac(t[4], carry, 0, f[0], g[4]);
+  basfld::mac(t[5], carry, 0, f[0], g[5]);
+  t[6] = carry;
+  carry = 0;
+
+  basfld::mac(t[1], carry, t[1], f[1], g[0]);
+  basfld::mac(t[2], carry, t[2], f[1], g[1]);
+  basfld::mac(t[3], carry, t[3], f[1], g[2]);
+  basfld::mac(t[4], carry, t[4], f[1], g[3]);
+  basfld::mac(t[5], carry, t[5], f[1], g[4]);
+  basfld::mac(t[6], carry, t[6], f[1], g[5]);
+  t[7] = carry;
+  carry = 0;
+
+  basfld::mac(t[2], carry, t[2], f[2], g[0]);
+  basfld::mac(t[3], carry, t[3], f[2], g[1]);
+  basfld::mac(t[4], carry, t[4], f[2], g[2]);
+  basfld::mac(t[5], carry, t[5], f[2], g[3]);
+  basfld::mac(t[6], carry, t[6], f[2], g[4]);
+  basfld::mac(t[7], carry, t[7], f[2], g[5]);
+  t[8] = carry;
+  carry = 0;
+
+  basfld::mac(t[3], carry, t[3], f[3], g[0]);
+  basfld::mac(t[4], carry, t[4], f[3], g[1]);
+  basfld::mac(t[5], carry, t[5], f[3], g[2]);
+  basfld::mac(t[6], carry, t[6], f[3], g[3]);
+  basfld::mac(t[7], carry, t[7], f[3], g[4]);
+  basfld::mac(t[8], carry, t[8], f[3], g[5]);
+  t[9] = carry;
+  carry = 0;
+
+  basfld::mac(t[4], carry, t[4], f[4], g[0]);
+  basfld::mac(t[5], carry, t[5], f[4], g[1]);
+  basfld::mac(t[6], carry, t[6], f[4], g[2]);
+  basfld::mac(t[7], carry, t[7], f[4], g[3]);
+  basfld::mac(t[8], carry, t[8], f[4], g[4]);
+  basfld::mac(t[9], carry, t[9], f[4], g[5]);
+  t[10] = carry;
+  carry = 0;
+
+  basfld::mac(t[5], carry, t[5], f[5], g[0]);
+  basfld::mac(t[6], carry, t[6], f[5], g[1]);
+  basfld::mac(t[7], carry, t[7], f[5], g[2]);
+  basfld::mac(t[8], carry, t[8], f[5], g[3]);
+  basfld::mac(t[9], carry, t[9], f[5], g[4]);
+  basfld::mac(t[10], carry, t[10], f[5], g[5]);
+  t[11] = carry;
+
+  f12b::reduce(h.data(), t);
+}
+} // namespace sxt::f12o

--- a/sxt/field25/operation/mul.h
+++ b/sxt/field25/operation/mul.h
@@ -18,14 +18,14 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::f12t {
+namespace sxt::f25t {
 class element;
 }
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // mul
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
 void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept;
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/mul.h
+++ b/sxt/field25/operation/mul.h
@@ -27,5 +27,5 @@ namespace sxt::f25o {
 // mul
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept;
+void mul(f25t::element& h, const f25t::element& f, const f25t::element& g) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/mul.h
+++ b/sxt/field25/operation/mul.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f12t {
+class element;
+}
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// mul
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void mul(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept;
+} // namespace sxt::f12o

--- a/sxt/field25/operation/mul.t.cc
+++ b/sxt/field25/operation/mul.t.cc
@@ -14,43 +14,49 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Adopted from zkcrypto/bls12_381
- *
- * Copyright (c) 2021
- * Sean Bowe <ewillbefull@gmail.com>
- * Jack Grigg <thestr4d@gmail.com>
- *
- * See third_party/license/zkcrypto.LICENSE
- */
 #include "sxt/field25/operation/mul.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
+#include "sxt/field25/base/constants.h"
+#include "sxt/field25/base/montgomery.h"
 #include "sxt/field25/constant/zero.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("multiplication") {
-  SECTION("of a pre-computed value and zero returns zero") {
-    constexpr f12t::element a{0x14fd599a70a077d8, 0xf10f187e64b9426d, 0x8ee7d30c9b4bab84,
-                              0x1bcd1f840d3ed0f0, 0xcd14c6f310abdc3d, 0x69d558ed64d6a25f};
-    f12t::element ret;
+  SECTION("of a random field element and zero returns zero") {
+    f25t::element a;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(a, rng);
+    f25t::element ret;
 
-    mul(ret, a, f12cn::zero_v);
+    mul(ret, a, f25cn::zero_v);
 
-    REQUIRE(ret == f12cn::zero_v);
+    REQUIRE(ret == f25cn::zero_v);
+  }
+
+  SECTION("of one with itself returns one") {
+    constexpr f25t::element one{f25b::r_v.data()};
+    f25t::element ret;
+
+    mul(ret, one, one);
+
+    REQUIRE(one == ret);
   }
 
   SECTION("of pre-computed values returns expected value") {
-    constexpr f12t::element a{0x0397a38320170cd4, 0x734c1b2c9e761d30, 0x5ed255ad9a48beb5,
-                              0x095a3c6b22a7fcfc, 0x2294ce75d4e26a27, 0x13338bd870011ebb};
-    constexpr f12t::element b{0xb9c3c7c5b1196af7, 0x2580e2086ce335c1, 0xf49aed3d8a57ef42,
-                              0x41f281e49846e878, 0xe0762346c38452ce, 0x0652e89326e57dc0};
-    constexpr f12t::element expected{0xf96ef3d711ab5355, 0xe8d459ea00f148dd, 0x53f7354a5f00fa78,
-                                     0x9e34a4f3125c5f83, 0x3fbe0c47ca74c19e, 0x01b06a8bbd4adfe4};
-    f12t::element ret;
+    // Random bn254 base field element generated using the SAGE library.
+    constexpr f25t::element a{0x5d19786fd5f59520, 0xa80980aec93386cf, 0x6f49109c5fb69712,
+                              0x19803c04269ae364};
+    constexpr f25t::element b{0x0746f2e0932048bf, 0xc05bea62ab71831e, 0x1342f6ebbc9497e9,
+                              0x12b50c2429b1a851};
+    constexpr f25t::element expected{0x241cac338ef8e513, 0x98220ca91953d8c1, 0x0bf0a5fd342762a0,
+                                     0x0e616e612ed86a67};
+    f25t::element ret;
 
     mul(ret, a, b);
 

--- a/sxt/field25/operation/mul.t.cc
+++ b/sxt/field25/operation/mul.t.cc
@@ -1,0 +1,59 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/operation/mul.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f12o;
+
+TEST_CASE("multiplication") {
+  SECTION("of a pre-computed value and zero returns zero") {
+    constexpr f12t::element a{0x14fd599a70a077d8, 0xf10f187e64b9426d, 0x8ee7d30c9b4bab84,
+                              0x1bcd1f840d3ed0f0, 0xcd14c6f310abdc3d, 0x69d558ed64d6a25f};
+    f12t::element ret;
+
+    mul(ret, a, f12cn::zero_v);
+
+    REQUIRE(ret == f12cn::zero_v);
+  }
+
+  SECTION("of pre-computed values returns expected value") {
+    constexpr f12t::element a{0x0397a38320170cd4, 0x734c1b2c9e761d30, 0x5ed255ad9a48beb5,
+                              0x095a3c6b22a7fcfc, 0x2294ce75d4e26a27, 0x13338bd870011ebb};
+    constexpr f12t::element b{0xb9c3c7c5b1196af7, 0x2580e2086ce335c1, 0xf49aed3d8a57ef42,
+                              0x41f281e49846e878, 0xe0762346c38452ce, 0x0652e89326e57dc0};
+    constexpr f12t::element expected{0xf96ef3d711ab5355, 0xe8d459ea00f148dd, 0x53f7354a5f00fa78,
+                                     0x9e34a4f3125c5f83, 0x3fbe0c47ca74c19e, 0x01b06a8bbd4adfe4};
+    f12t::element ret;
+
+    mul(ret, a, b);
+
+    REQUIRE(expected == ret);
+  }
+}

--- a/sxt/field25/operation/mul.t.cc
+++ b/sxt/field25/operation/mul.t.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,14 +23,14 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/field12/operation/mul.h"
+#include "sxt/field25/operation/mul.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::f12o;
+using namespace sxt::f25o;
 
 TEST_CASE("multiplication") {
   SECTION("of a pre-computed value and zero returns zero") {

--- a/sxt/field25/operation/neg.cc
+++ b/sxt/field25/operation/neg.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,13 +23,13 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/field12/operation/neg.h"
+#include "sxt/field25/operation/neg.h"
 
 #include "sxt/base/field/arithmetic_utility.h"
-#include "sxt/field12/base/constants.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/base/constants.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
@@ -53,4 +53,4 @@ void neg(f12t::element& h, const f12t::element& f) noexcept {
     h[i] = d[i] & mask;
   }
 }
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/neg.cc
+++ b/sxt/field25/operation/neg.cc
@@ -34,22 +34,20 @@ namespace sxt::f25o {
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(f12t::element& h, const f12t::element& f) noexcept {
-  uint64_t d[6] = {};
+void neg(f25t::element& h, const f25t::element& f) noexcept {
+  uint64_t d[4] = {};
   uint64_t borrow{0};
 
-  basfld::sbb(d[0], borrow, f12b::p_v[0], f[0]);
-  basfld::sbb(d[1], borrow, f12b::p_v[1], f[1]);
-  basfld::sbb(d[2], borrow, f12b::p_v[2], f[2]);
-  basfld::sbb(d[3], borrow, f12b::p_v[3], f[3]);
-  basfld::sbb(d[4], borrow, f12b::p_v[4], f[4]);
-  basfld::sbb(d[5], borrow, f12b::p_v[5], f[5]);
+  basfld::sbb(d[0], borrow, f25b::p_v[0], f[0]);
+  basfld::sbb(d[1], borrow, f25b::p_v[1], f[1]);
+  basfld::sbb(d[2], borrow, f25b::p_v[2], f[2]);
+  basfld::sbb(d[3], borrow, f25b::p_v[3], f[3]);
 
-  // Let's use a mask if `self` was zero, which would mean
+  // Let's use a mask if f was zero, which would mean
   // the result of the subtraction is p.
-  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3] | f[4] | f[5]) == 0)} - uint64_t{1};
+  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3]) == 0)} - uint64_t{1};
 
-  for (int i = 0; i < 6; ++i) {
+  for (size_t i = 0; i < f.num_limbs_v; ++i) {
     h[i] = d[i] & mask;
   }
 }

--- a/sxt/field25/operation/neg.cc
+++ b/sxt/field25/operation/neg.cc
@@ -1,0 +1,56 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/operation/neg.h"
+
+#include "sxt/base/field/arithmetic_utility.h"
+#include "sxt/field12/base/constants.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// neg
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void neg(f12t::element& h, const f12t::element& f) noexcept {
+  uint64_t d[6] = {};
+  uint64_t borrow{0};
+
+  basfld::sbb(d[0], borrow, f12b::p_v[0], f[0]);
+  basfld::sbb(d[1], borrow, f12b::p_v[1], f[1]);
+  basfld::sbb(d[2], borrow, f12b::p_v[2], f[2]);
+  basfld::sbb(d[3], borrow, f12b::p_v[3], f[3]);
+  basfld::sbb(d[4], borrow, f12b::p_v[4], f[4]);
+  basfld::sbb(d[5], borrow, f12b::p_v[5], f[5]);
+
+  // Let's use a mask if `self` was zero, which would mean
+  // the result of the subtraction is p.
+  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3] | f[4] | f[5]) == 0)} - uint64_t{1};
+
+  for (int i = 0; i < 6; ++i) {
+    h[i] = d[i] & mask;
+  }
+}
+} // namespace sxt::f12o

--- a/sxt/field25/operation/neg.h
+++ b/sxt/field25/operation/neg.h
@@ -27,5 +27,5 @@ namespace sxt::f25o {
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(f12t::element& h, const f12t::element& f) noexcept;
+void neg(f25t::element& h, const f25t::element& f) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/neg.h
+++ b/sxt/field25/operation/neg.h
@@ -18,14 +18,14 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::f12t {
+namespace sxt::f25t {
 class element;
 }
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
 void neg(f12t::element& h, const f12t::element& f) noexcept;
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/neg.h
+++ b/sxt/field25/operation/neg.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f12t {
+class element;
+}
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// neg
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void neg(f12t::element& h, const f12t::element& f) noexcept;
+} // namespace sxt::f12o

--- a/sxt/field25/operation/neg.t.cc
+++ b/sxt/field25/operation/neg.t.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,14 +23,14 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/field12/operation/neg.h"
+#include "sxt/field25/operation/neg.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/base/constants.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/base/constants.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::f12o;
+using namespace sxt::f25o;
 
 TEST_CASE("negation") {
   SECTION("of zero and the modulus are equal") {

--- a/sxt/field25/operation/neg.t.cc
+++ b/sxt/field25/operation/neg.t.cc
@@ -14,19 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Adopted from zkcrypto/bls12_381
- *
- * Copyright (c) 2021
- * Sean Bowe <ewillbefull@gmail.com>
- * Jack Grigg <thestr4d@gmail.com>
- *
- * See third_party/license/zkcrypto.LICENSE
- */
 #include "sxt/field25/operation/neg.h"
 
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/base/constants.h"
+#include "sxt/field25/constant/zero.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
@@ -34,23 +26,20 @@ using namespace sxt::f25o;
 
 TEST_CASE("negation") {
   SECTION("of zero and the modulus are equal") {
-    constexpr f12t::element zero{0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    constexpr f12t::element modulus{f12b::p_v.data()};
-    f12t::element ret_zero;
-    f12t::element ret_modulus;
+    f25t::element ret_zero;
+    f25t::element ret_modulus;
 
-    neg(ret_zero, zero);
-    neg(ret_modulus, modulus);
+    neg(ret_zero, f25cn::zero_v);
+    neg(ret_modulus, f25b::p_v.data());
 
     REQUIRE(ret_zero == ret_modulus);
   }
 
   SECTION("of the modulus minus one is one") {
-    constexpr f12t::element modulus_minus_one{0xb9feffffffffaaaa, 0x1eabfffeb153ffff,
-                                              0x6730d2a0f6b0f624, 0x64774b84f38512bf,
-                                              0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
-    constexpr f12t::element one{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
-    f12t::element ret;
+    constexpr f25t::element modulus_minus_one{0x3c208c16d87cfd46, 0x97816a916871ca8d,
+                                              0xb85045b68181585d, 0x30644e72e131a029};
+    constexpr f25t::element one{1, 0, 0, 0};
+    f25t::element ret;
 
     neg(ret, modulus_minus_one);
 
@@ -58,11 +47,12 @@ TEST_CASE("negation") {
   }
 
   SECTION("of a pre-computed value is expected") {
-    constexpr f12t::element a{0x5360bb5978678032, 0x7dd275ae799e128e, 0x5c5b5071ce4f4dcf,
-                              0xcdb21f93078dbb3e, 0xc32365c5e73f474a, 0x115a2a5489babe5b};
-    constexpr f12t::element expected{0x669e44a687982a79, 0xa0d98a5037b5ed71, 0x0ad5822f2861a854,
-                                     0x96c52bf1ebf75781, 0x87f841f05c0c658c, 0x08a6e795afc5283e};
-    f12t::element ret;
+    // Random bn254 base field element generated using the SAGE library.
+    constexpr f25t::element a{0x1149c21473b043fd, 0x5610b2a5c08c7ecf, 0xc9e31f2d914c45b5,
+                              0x066031eb7a3ca7fd};
+    constexpr f25t::element expected{0x2ad6ca0264ccb94a, 0x4170b7eba7e54bbe, 0xee6d2688f03512a8,
+                                     0x2a041c8766f4f82b};
+    f25t::element ret;
 
     neg(ret, a);
 

--- a/sxt/field25/operation/neg.t.cc
+++ b/sxt/field25/operation/neg.t.cc
@@ -1,0 +1,71 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field12/operation/neg.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/base/constants.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f12o;
+
+TEST_CASE("negation") {
+  SECTION("of zero and the modulus are equal") {
+    constexpr f12t::element zero{0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    constexpr f12t::element modulus{f12b::p_v.data()};
+    f12t::element ret_zero;
+    f12t::element ret_modulus;
+
+    neg(ret_zero, zero);
+    neg(ret_modulus, modulus);
+
+    REQUIRE(ret_zero == ret_modulus);
+  }
+
+  SECTION("of the modulus minus one is one") {
+    constexpr f12t::element modulus_minus_one{0xb9feffffffffaaaa, 0x1eabfffeb153ffff,
+                                              0x6730d2a0f6b0f624, 0x64774b84f38512bf,
+                                              0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+    constexpr f12t::element one{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
+    f12t::element ret;
+
+    neg(ret, modulus_minus_one);
+
+    REQUIRE(ret == one);
+  }
+
+  SECTION("of a pre-computed value is expected") {
+    constexpr f12t::element a{0x5360bb5978678032, 0x7dd275ae799e128e, 0x5c5b5071ce4f4dcf,
+                              0xcdb21f93078dbb3e, 0xc32365c5e73f474a, 0x115a2a5489babe5b};
+    constexpr f12t::element expected{0x669e44a687982a79, 0xa0d98a5037b5ed71, 0x0ad5822f2861a854,
+                                     0x96c52bf1ebf75781, 0x87f841f05c0c658c, 0x08a6e795afc5283e};
+    f12t::element ret;
+
+    neg(ret, a);
+
+    REQUIRE(expected == ret);
+  }
+}

--- a/sxt/field25/operation/sub.cc
+++ b/sxt/field25/operation/sub.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/operation/sub.h"

--- a/sxt/field25/operation/sub.cc
+++ b/sxt/field25/operation/sub.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/operation/sub.h"
+#include "sxt/field25/operation/sub.h"

--- a/sxt/field25/operation/sub.h
+++ b/sxt/field25/operation/sub.h
@@ -38,9 +38,9 @@ namespace sxt::f25o {
  * h = f - g
  */
 CUDA_CALLABLE
-inline void sub(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
-  f12t::element neg_g;
-  f12o::neg(neg_g, g);
-  f12o::add(h, f, neg_g);
+inline void sub(f25t::element& h, const f25t::element& f, const f25t::element& g) noexcept {
+  f25t::element neg_g;
+  f25o::neg(neg_g, g);
+  f25o::add(h, f, neg_g);
 }
 } // namespace sxt::f25o

--- a/sxt/field25/operation/sub.h
+++ b/sxt/field25/operation/sub.h
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/field12/operation/add.h"
+#include "sxt/field12/operation/neg.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::f12o {
+//--------------------------------------------------------------------------------------------------
+// sub
+//--------------------------------------------------------------------------------------------------
+/*
+ h = f - g
+*/
+CUDA_CALLABLE
+inline void sub(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
+  f12t::element neg_g;
+  f12o::neg(neg_g, g);
+  f12o::add(h, f, neg_g);
+}
+} // namespace sxt::f12o

--- a/sxt/field25/operation/sub.h
+++ b/sxt/field25/operation/sub.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -26,21 +26,21 @@
 #pragma once
 
 #include "sxt/base/macro/cuda_callable.h"
-#include "sxt/field12/operation/add.h"
-#include "sxt/field12/operation/neg.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/operation/add.h"
+#include "sxt/field25/operation/neg.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::f12o {
+namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // sub
 //--------------------------------------------------------------------------------------------------
-/*
- h = f - g
-*/
+/**
+ * h = f - g
+ */
 CUDA_CALLABLE
 inline void sub(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
   f12t::element neg_g;
   f12o::neg(neg_g, g);
   f12o::add(h, f, neg_g);
 }
-} // namespace sxt::f12o
+} // namespace sxt::f25o

--- a/sxt/field25/operation/sub.t.cc
+++ b/sxt/field25/operation/sub.t.cc
@@ -1,0 +1,63 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/operation/sub.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f12o;
+
+TEST_CASE("subtraction") {
+  SECTION("of pre-computed value and zero returns pre-computed value") {
+    // Random values between 1 and p_v generated using the SAGE library.
+    constexpr f12t::element a{0xd841a79826bf52bd, 0xf03e2c871b72b39f, 0x3e0849ec3694f61f,
+                              0x9f2941b0ba71fbae, 0xdc01791735636ad0, 0x16049d32722cd303};
+
+    f12t::element ret;
+    sub(ret, a, f12cn::zero_v);
+
+    REQUIRE(a == ret);
+  }
+
+  SECTION("of pre-computed values returns expected value") {
+    // Random values between 1 and p_v generated using the SAGE library.
+    constexpr f12t::element a{0x3a67dc4bfd86d199, 0x131d9f2a59475351, 0xa4277d44c833b67a,
+                              0x21ea1c79f6aedd93, 0x3fadab0c84079145, 0x179af60bd96d6d51};
+    constexpr f12t::element b{0xff30f3d15bd9e635, 0x9565c755ac959535, 0x836b6466e8730b6a,
+                              0x9e9f141d4b78bb12, 0x265d74738f87c381, 0x0a3adb6a76b8e291};
+    constexpr f12t::element expected{0x3b36e87aa1aceb64, 0x7db7d7d4acb1be1b, 0x20bc18dddfc0ab0f,
+                                     0x834b085cab362281, 0x19503698f47fcdc3, 0xd601aa162b48ac0};
+
+    f12t::element ret;
+    sub(ret, a, b);
+
+    REQUIRE(expected == ret);
+  }
+
+  SECTION("of zero and one returns the modulus minus one") {
+    constexpr f12t::element b{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
+    constexpr f12t::element expected{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
+                                     0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+
+    f12t::element ret;
+    sub(ret, f12cn::zero_v, b);
+
+    REQUIRE(expected == ret);
+  }
+}

--- a/sxt/field25/operation/sub.t.cc
+++ b/sxt/field25/operation/sub.t.cc
@@ -16,47 +16,50 @@
  */
 #include "sxt/field25/operation/sub.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/constant/zero.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("subtraction") {
-  SECTION("of pre-computed value and zero returns pre-computed value") {
-    // Random values between 1 and p_v generated using the SAGE library.
-    constexpr f12t::element a{0xd841a79826bf52bd, 0xf03e2c871b72b39f, 0x3e0849ec3694f61f,
-                              0x9f2941b0ba71fbae, 0xdc01791735636ad0, 0x16049d32722cd303};
+  SECTION("of a random field element and zero returns the random field element") {
+    f25t::element a;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(a, rng);
 
-    f12t::element ret;
-    sub(ret, a, f12cn::zero_v);
+    f25t::element ret;
+
+    sub(ret, a, f25cn::zero_v);
 
     REQUIRE(a == ret);
   }
 
   SECTION("of pre-computed values returns expected value") {
-    // Random values between 1 and p_v generated using the SAGE library.
-    constexpr f12t::element a{0x3a67dc4bfd86d199, 0x131d9f2a59475351, 0xa4277d44c833b67a,
-                              0x21ea1c79f6aedd93, 0x3fadab0c84079145, 0x179af60bd96d6d51};
-    constexpr f12t::element b{0xff30f3d15bd9e635, 0x9565c755ac959535, 0x836b6466e8730b6a,
-                              0x9e9f141d4b78bb12, 0x265d74738f87c381, 0x0a3adb6a76b8e291};
-    constexpr f12t::element expected{0x3b36e87aa1aceb64, 0x7db7d7d4acb1be1b, 0x20bc18dddfc0ab0f,
-                                     0x834b085cab362281, 0x19503698f47fcdc3, 0xd601aa162b48ac0};
+    // Random bn254 base field element generated using the SAGE library.
+    constexpr f25t::element a{0x5277392d1dd1c9b6, 0xd4128bfefd8e4cf5, 0xa7d5b7f3662a0ee9,
+                              0x0994b748e9d2dbe7};
+    constexpr f25t::element b{0x9412b919732aa7c6, 0x714691531e314d76, 0xcf45bbcd6cf10aa2,
+                              0x1295b5038773df78};
+    constexpr f25t::element expected{0xfa850c2a83241f37, 0xfa4d653d47ceca0b, 0x90e041dc7aba5ca4,
+                                     0x276350b843909c98};
+    f25t::element ret;
 
-    f12t::element ret;
     sub(ret, a, b);
 
     REQUIRE(expected == ret);
   }
 
   SECTION("of zero and one returns the modulus minus one") {
-    constexpr f12t::element b{0x1, 0x0, 0x0, 0x0, 0x0, 0x0};
-    constexpr f12t::element expected{0xb9feffffffffaaaa, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
-                                     0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a};
+    constexpr f25t::element b{1, 0, 0, 0};
+    constexpr f25t::element expected{0x3c208c16d87cfd46, 0x97816a916871ca8d, 0xb85045b68181585d,
+                                     0x30644e72e131a029};
+    f25t::element ret;
 
-    f12t::element ret;
-    sub(ret, f12cn::zero_v, b);
+    sub(ret, f25cn::zero_v, b);
 
     REQUIRE(expected == ret);
   }

--- a/sxt/field25/operation/sub.t.cc
+++ b/sxt/field25/operation/sub.t.cc
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/operation/sub.h"
+#include "sxt/field25/operation/sub.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::f12o;
+using namespace sxt::f25o;
 
 TEST_CASE("subtraction") {
   SECTION("of pre-computed value and zero returns pre-computed value") {


### PR DESCRIPTION
# Rationale for this change
In order to support MSM with elements on the `bn254` curve we need to implement the base field `Fq`. This work will introduce the `operation` package and addition, multiplication, negation, and subtraction components to the `bn254` base field, `field25`. The components are copied from the the `field12` package, which supports the `bls12-381` curve. The components are updated to support the `bn254` base field, which is four limbs, compared to the six limbs of the `bls12-381` base field.

All non-trivial changes are isolated to [this commit](https://github.com/spaceandtimelabs/blitzar/commit/4950c8d9468a5073a3f9bf5b64e2af7a200c967d).

# What changes are included in this PR?
- `field25/operation` is copied from `field12/operation`.
- `add`, `mul`, `neg`, and `sub` components are copied from `field12` and updated to support four limbs.
- Tests are updated.

# Are these changes tested?
Yes