### PR TITLE
feat: add cmov, invert, pow, and square components to field25 operation package (PROOF-778)

### DIFF
--- a/sxt/field25/operation/BUILD
+++ b/sxt/field25/operation/BUILD
@@ -21,6 +21,44 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "cmov",
+    impl_deps = [
+        "//sxt/field25/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/constant:zero",
+        "//sxt/field25/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "invert",
+    impl_deps = [
+        ":pow_vartime",
+        "//sxt/field25/property:zero",
+        "//sxt/field25/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        ":mul",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/base/test:unit_test",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/random:element",
+        "//sxt/field25/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
     name = "mul",
     impl_deps = [
         "//sxt/base/field:arithmetic_utility",
@@ -54,6 +92,44 @@ sxt_cc_component(
         "//sxt/base/test:unit_test",
         "//sxt/field25/base:constants",
         "//sxt/field25/constant:zero",
+        "//sxt/field25/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "pow_vartime",
+    impl_deps = [
+        ":mul",
+        ":square",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field25/type:element",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "square",
+    impl_deps = [
+        "//sxt/base/field:arithmetic_utility",
+        "//sxt/field25/base:reduce",
+        "//sxt/field25/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        ":mul",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/base/test:unit_test",
+        "//sxt/field25/random:element",
         "//sxt/field25/type:element",
     ],
     deps = [

--- a/sxt/field25/operation/cmov.cc
+++ b/sxt/field25/operation/cmov.cc
@@ -22,7 +22,7 @@ namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // cmov
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE void cmov(f12t::element& f, const f12t::element& g, unsigned int b) noexcept {
+CUDA_CALLABLE void cmov(f25t::element& f, const f25t::element& g, unsigned int b) noexcept {
   const uint64_t mask = static_cast<uint64_t>(-static_cast<uint64_t>(b));
   for (size_t i = 0; i < g.num_limbs_v; ++i) {
     f[i] = f[i] ^ (mask & (f[i] ^ g[i]));

--- a/sxt/field25/operation/cmov.cc
+++ b/sxt/field25/operation/cmov.cc
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field25/operation/cmov.h"
+
+#include "sxt/field25/type/element.h"
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// cmov
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE void cmov(f12t::element& f, const f12t::element& g, unsigned int b) noexcept {
+  const uint64_t mask = static_cast<uint64_t>(-static_cast<uint64_t>(b));
+  for (size_t i = 0; i < g.num_limbs_v; ++i) {
+    f[i] = f[i] ^ (mask & (f[i] ^ g[i]));
+  }
+}
+} // namespace sxt::f25o

--- a/sxt/field25/operation/cmov.h
+++ b/sxt/field25/operation/cmov.h
@@ -32,5 +32,5 @@ namespace sxt::f25o {
  *
  Preconditions: b in {0,1}.
  */
-CUDA_CALLABLE void cmov(f12t::element& f, const f12t::element& g, unsigned int b) noexcept;
+CUDA_CALLABLE void cmov(f25t::element& f, const f25t::element& g, unsigned int b) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/cmov.h
+++ b/sxt/field25/operation/cmov.h
@@ -30,7 +30,7 @@ namespace sxt::f25o {
  * Replace (f,g) with (g,g) if b == 1.
  * Replace (f,g) with (f,g) if b == 0.
  *
- Preconditions: b in {0,1}.
+ * Preconditions: b in {0,1}.
  */
 CUDA_CALLABLE void cmov(f25t::element& f, const f25t::element& g, unsigned int b) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/cmov.h
+++ b/sxt/field25/operation/cmov.h
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f25t {
+class element;
+}
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// cmov
+//--------------------------------------------------------------------------------------------------
+/**
+ * Replace (f,g) with (g,g) if b == 1.
+ * Replace (f,g) with (f,g) if b == 0.
+ *
+ Preconditions: b in {0,1}.
+ */
+CUDA_CALLABLE void cmov(f12t::element& f, const f12t::element& g, unsigned int b) noexcept;
+} // namespace sxt::f25o

--- a/sxt/field25/operation/cmov.t.cc
+++ b/sxt/field25/operation/cmov.t.cc
@@ -14,23 +14,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/field12/operation/cmov.h"
+#include "sxt/field25/operation/cmov.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/one.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("cmov correctly moves field elements") {
-  f12t::element h{f12cn::zero_v};
-  f12t::element g{f12cn::zero_v};
+  f25t::element h{f25cn::zero_v};
+  f25t::element g{f25cn::zero_v};
 
-  cmov(h, f12cn::one_v, 1);
-  cmov(g, f12cn::one_v, 0);
+  cmov(h, f25cn::one_v, 1);
+  cmov(g, f25cn::one_v, 0);
 
-  REQUIRE(h == f12cn::one_v);
-  REQUIRE(g == f12cn::zero_v);
+  REQUIRE(h == f25cn::one_v);
+  REQUIRE(g == f25cn::zero_v);
 }

--- a/sxt/field25/operation/cmov.t.cc
+++ b/sxt/field25/operation/cmov.t.cc
@@ -1,0 +1,36 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field12/operation/cmov.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f25o;
+
+TEST_CASE("cmov correctly moves field elements") {
+  f12t::element h{f12cn::zero_v};
+  f12t::element g{f12cn::zero_v};
+
+  cmov(h, f12cn::one_v, 1);
+  cmov(g, f12cn::one_v, 0);
+
+  REQUIRE(h == f12cn::one_v);
+  REQUIRE(g == f12cn::zero_v);
+}

--- a/sxt/field25/operation/invert.cc
+++ b/sxt/field25/operation/invert.cc
@@ -1,0 +1,48 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field25/operation/invert.h"
+
+#include "sxt/field25/operation/pow_vartime.h"
+#include "sxt/field25/property/zero.h"
+#include "sxt/field25/type/element.h"
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// invert
+//--------------------------------------------------------------------------------------------------
+/**
+ * Computes the multiplicative inverse of this field element,
+ * returning FALSE in the case that this element is zero.
+ */
+CUDA_CALLABLE bool invert(f12t::element& h, const f12t::element& f) noexcept {
+  constexpr f12t::element g(0xb9feffffffffaaa9, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
+                            0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a);
+
+  f12o::pow_vartime(h, f, g);
+
+  return f12p::is_zero(h);
+}
+} // namespace sxt::f25o

--- a/sxt/field25/operation/invert.cc
+++ b/sxt/field25/operation/invert.cc
@@ -36,13 +36,15 @@ namespace sxt::f25o {
 /**
  * Computes the multiplicative inverse of this field element,
  * returning FALSE in the case that this element is zero.
+ * A finite field of order p is a cyclic group of order p-1.
+ * Therefore, for any f in Fp: f^{-1} == f^{p-2}.
  */
-CUDA_CALLABLE bool invert(f12t::element& h, const f12t::element& f) noexcept {
-  constexpr f12t::element g(0xb9feffffffffaaa9, 0x1eabfffeb153ffff, 0x6730d2a0f6b0f624,
-                            0x64774b84f38512bf, 0x4b1ba7b6434bacd7, 0x1a0111ea397fe69a);
+CUDA_CALLABLE bool invert(f25t::element& h, const f25t::element& f) noexcept {
+  constexpr f25t::element p_v_minus_2{0x3c208c16d87cfd45, 0x97816a916871ca8d, 0xb85045b68181585d,
+                                      0x30644e72e131a029};
 
-  f12o::pow_vartime(h, f, g);
+  f25o::pow_vartime(h, f, p_v_minus_2);
 
-  return f12p::is_zero(h);
+  return f25p::is_zero(h);
 }
 } // namespace sxt::f25o

--- a/sxt/field25/operation/invert.h
+++ b/sxt/field25/operation/invert.h
@@ -1,0 +1,30 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f25t {
+class element;
+}
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// invert
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE bool invert(f12t::element& h, const f12t::element& f) noexcept;
+} // namespace sxt::f25o

--- a/sxt/field25/operation/invert.h
+++ b/sxt/field25/operation/invert.h
@@ -26,5 +26,5 @@ namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // invert
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE bool invert(f12t::element& h, const f12t::element& f) noexcept;
+CUDA_CALLABLE bool invert(f25t::element& h, const f25t::element& f) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/invert.t.cc
+++ b/sxt/field25/operation/invert.t.cc
@@ -14,58 +14,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Adopted from zkcrypto/bls12_381
- *
- * Copyright (c) 2021
- * Sean Bowe <ewillbefull@gmail.com>
- * Jack Grigg <thestr4d@gmail.com>
- *
- * See third_party/license/zkcrypto.LICENSE
- */
 #include "sxt/field25/operation/invert.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/constant/one.h"
 #include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("inversion") {
-  SECTION("of a pre-computed value multiplied by its inverse is equal to one in Montogomery form") {
-    constexpr f12t::element a{0x4fb9be8a496563c1, 0x98a27a4674c765e1, 0x8475a3d548b133fe,
-                              0xdbeb89b089f08299, 0x5c1fb7a3c186887f, 0x13db2e403f66ba22};
+  SECTION("of a random field element multiplied by its inverse is equal to one") {
+    f25t::element a;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(a, rng);
 
-    f12t::element a_inv;
+    f25t::element a_inv;
     auto is_zero = invert(a_inv, a);
     REQUIRE(!is_zero);
 
-    f12t::element ret_mul;
+    f25t::element ret_mul;
     mul(ret_mul, a, a_inv);
-    REQUIRE(ret_mul == f12cn::one_v);
-  }
-
-  SECTION("of pre-computed values returns expected value") {
-    constexpr f12t::element a{0x43b43a5078ac2076, 0x1ce0763046f8962b, 0x724a5276486d735c,
-                              0x6f05c2a6282d48fd, 0x2095bd5bb4ca9331, 0x03b35b3894b0f7da};
-    constexpr f12t::element expected{0x69ecd7040952148f, 0x985ccc2022190f55, 0xe19bba36a9ad2f41,
-                                     0x19bb16c95219dbd8, 0x14dcacfdfb478693, 0x115ff58afff9a8e1};
-
-    f12t::element ret;
-    auto is_zero = invert(ret, a);
-
-    REQUIRE(!is_zero);
-    REQUIRE(expected == ret);
-  }
-
-  SECTION("of zero returns the a flag indicating the value is zero") {
-    constexpr f12t::element a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-
-    f12t::element ret;
-    auto is_zero = invert(ret, a);
-
-    REQUIRE(is_zero);
+    REQUIRE(ret_mul == f25cn::one_v);
   }
 }

--- a/sxt/field25/operation/invert.t.cc
+++ b/sxt/field25/operation/invert.t.cc
@@ -1,0 +1,71 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field25/operation/invert.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f25o;
+
+TEST_CASE("inversion") {
+  SECTION("of a pre-computed value multiplied by its inverse is equal to one in Montogomery form") {
+    constexpr f12t::element a{0x4fb9be8a496563c1, 0x98a27a4674c765e1, 0x8475a3d548b133fe,
+                              0xdbeb89b089f08299, 0x5c1fb7a3c186887f, 0x13db2e403f66ba22};
+
+    f12t::element a_inv;
+    auto is_zero = invert(a_inv, a);
+    REQUIRE(!is_zero);
+
+    f12t::element ret_mul;
+    mul(ret_mul, a, a_inv);
+    REQUIRE(ret_mul == f12cn::one_v);
+  }
+
+  SECTION("of pre-computed values returns expected value") {
+    constexpr f12t::element a{0x43b43a5078ac2076, 0x1ce0763046f8962b, 0x724a5276486d735c,
+                              0x6f05c2a6282d48fd, 0x2095bd5bb4ca9331, 0x03b35b3894b0f7da};
+    constexpr f12t::element expected{0x69ecd7040952148f, 0x985ccc2022190f55, 0xe19bba36a9ad2f41,
+                                     0x19bb16c95219dbd8, 0x14dcacfdfb478693, 0x115ff58afff9a8e1};
+
+    f12t::element ret;
+    auto is_zero = invert(ret, a);
+
+    REQUIRE(!is_zero);
+    REQUIRE(expected == ret);
+  }
+
+  SECTION("of zero returns the a flag indicating the value is zero") {
+    constexpr f12t::element a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+
+    f12t::element ret;
+    auto is_zero = invert(ret, a);
+
+    REQUIRE(is_zero);
+  }
+}

--- a/sxt/field25/operation/pow_vartime.cc
+++ b/sxt/field25/operation/pow_vartime.cc
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field25/operation/pow_vartime.h"
+
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/operation/square.h"
+#include "sxt/field25/type/element.h"
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// pow_vartime
+//--------------------------------------------------------------------------------------------------
+/**
+ * Although this is labeled "vartime", it is only variable time with respect to the exponent.
+ */
+CUDA_CALLABLE
+void pow_vartime(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
+  f12t::element res = f12cn::one_v;
+
+  for (int i = 5; i >= 0; --i) {
+    f12t::element res_tmp;
+    for (int j = 63; j >= 0; --j) {
+      square(res_tmp, res);
+      res = res_tmp;
+      if (((g[i] >> j) & 1) == 1) {
+        mul(res_tmp, f, res);
+        res = res_tmp;
+      }
+    }
+  }
+
+  h = res;
+}
+} // namespace sxt::f25o

--- a/sxt/field25/operation/pow_vartime.cc
+++ b/sxt/field25/operation/pow_vartime.cc
@@ -38,11 +38,11 @@ namespace sxt::f25o {
  * Although this is labeled "vartime", it is only variable time with respect to the exponent.
  */
 CUDA_CALLABLE
-void pow_vartime(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept {
-  f12t::element res = f12cn::one_v;
+void pow_vartime(f25t::element& h, const f25t::element& f, const f25t::element& g) noexcept {
+  f25t::element res = f25cn::one_v;
 
-  for (int i = 5; i >= 0; --i) {
-    f12t::element res_tmp;
+  for (int i = 3; i >= 0; --i) {
+    f25t::element res_tmp;
     for (int j = 63; j >= 0; --j) {
       square(res_tmp, res);
       res = res_tmp;

--- a/sxt/field25/operation/pow_vartime.h
+++ b/sxt/field25/operation/pow_vartime.h
@@ -27,5 +27,5 @@ namespace sxt::f25o {
 // pow_vartime
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void pow_vartime(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept;
+void pow_vartime(f25t::element& h, const f25t::element& f, const f25t::element& g) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/pow_vartime.h
+++ b/sxt/field25/operation/pow_vartime.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f25t {
+class element;
+}
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// pow_vartime
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void pow_vartime(f12t::element& h, const f12t::element& f, const f12t::element& g) noexcept;
+} // namespace sxt::f25o

--- a/sxt/field25/operation/pow_vartime.t.cc
+++ b/sxt/field25/operation/pow_vartime.t.cc
@@ -26,13 +26,13 @@ using namespace sxt::f25o;
 
 TEST_CASE("pow_varitime") {
   SECTION("of pre-computed values returns expected value") {
-    constexpr f12t::element a{0xaa270000000cfff3, 0x53cc0032fc34000a, 0x478fe97a6b0a807f,
-                              0xb1d37ebee6ba24d7, 0x8ec9733bbf78ab2f, 0x09d645513d83de7e};
-    constexpr f12t::element b{0xee7fbfffffffeaab, 0x07aaffffac54ffff, 0xd9cc34a83dac3d89,
-                              0xd91dd2e13ce144af, 0x92c6e9ed90d2eb35, 0x0680447a8e5ff9a6};
-    constexpr f12t::element expected{0x87ebfffffff9555c, 0x656fffe5da8ffffa, 0xfd0749345d33ad2,
-                                     0xd951e663066576f4, 0xde291a3d41e980d3, 0x815664c7dfe040d};
-    f12t::element ret;
+    constexpr f25t::element a{0xb92e567e0e2f6f1e, 0xc1d6653f0e1b09b, 0x6e52b0b322cdbd45,
+                              0x18c27d738c4b7477};
+    constexpr f25t::element b{0x3c208c16d87cfd45, 0x97816a916871ca8d, 0xb85045b68181585d,
+                              0x30644e72e131a029};
+    constexpr f25t::element expected{0xb513f9d751f64c03, 0x3f7b2093dcebd1f, 0x42276bfa13f711b8,
+                                     0x10b1e99cf9afc988};
+    f25t::element ret;
 
     pow_vartime(ret, a, b);
 

--- a/sxt/field25/operation/pow_vartime.t.cc
+++ b/sxt/field25/operation/pow_vartime.t.cc
@@ -1,0 +1,41 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field25/operation/pow_vartime.h"
+
+#include <iostream>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field25/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f25o;
+
+TEST_CASE("pow_varitime") {
+  SECTION("of pre-computed values returns expected value") {
+    constexpr f12t::element a{0xaa270000000cfff3, 0x53cc0032fc34000a, 0x478fe97a6b0a807f,
+                              0xb1d37ebee6ba24d7, 0x8ec9733bbf78ab2f, 0x09d645513d83de7e};
+    constexpr f12t::element b{0xee7fbfffffffeaab, 0x07aaffffac54ffff, 0xd9cc34a83dac3d89,
+                              0xd91dd2e13ce144af, 0x92c6e9ed90d2eb35, 0x0680447a8e5ff9a6};
+    constexpr f12t::element expected{0x87ebfffffff9555c, 0x656fffe5da8ffffa, 0xfd0749345d33ad2,
+                                     0xd951e663066576f4, 0xde291a3d41e980d3, 0x815664c7dfe040d};
+    f12t::element ret;
+
+    pow_vartime(ret, a, b);
+
+    REQUIRE(expected == ret);
+  }
+}

--- a/sxt/field25/operation/square.cc
+++ b/sxt/field25/operation/square.cc
@@ -1,0 +1,98 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/field25/operation/square.h"
+
+#include "sxt/base/field/arithmetic_utility.h"
+#include "sxt/field25/base/reduce.h"
+#include "sxt/field25/type/element.h"
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// square
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void square(f12t::element& h, const f12t::element& f) noexcept {
+  uint64_t t[12] = {};
+  uint64_t carry{0};
+
+  basfld::mac(t[1], carry, 0, f[0], f[1]);
+  basfld::mac(t[2], carry, 0, f[0], f[2]);
+  basfld::mac(t[3], carry, 0, f[0], f[3]);
+  basfld::mac(t[4], carry, 0, f[0], f[4]);
+  basfld::mac(t[5], carry, 0, f[0], f[5]);
+  t[6] = carry;
+  carry = 0;
+
+  basfld::mac(t[3], carry, t[3], f[1], f[2]);
+  basfld::mac(t[4], carry, t[4], f[1], f[3]);
+  basfld::mac(t[5], carry, t[5], f[1], f[4]);
+  basfld::mac(t[6], carry, t[6], f[1], f[5]);
+  t[7] = carry;
+  carry = 0;
+
+  basfld::mac(t[5], carry, t[5], f[2], f[3]);
+  basfld::mac(t[6], carry, t[6], f[2], f[4]);
+  basfld::mac(t[7], carry, t[7], f[2], f[5]);
+  t[8] = carry;
+  carry = 0;
+
+  basfld::mac(t[7], carry, t[7], f[3], f[4]);
+  basfld::mac(t[8], carry, t[8], f[3], f[5]);
+  t[9] = carry;
+  carry = 0;
+
+  basfld::mac(t[9], carry, t[9], f[4], f[5]);
+  t[10] = carry;
+  carry = 0;
+
+  t[11] = t[10] >> 63;
+  t[10] = (t[10] << 1) | (t[9] >> 63);
+  t[9] = (t[9] << 1) | (t[8] >> 63);
+  t[8] = (t[8] << 1) | (t[7] >> 63);
+  t[7] = (t[7] << 1) | (t[6] >> 63);
+  t[6] = (t[6] << 1) | (t[5] >> 63);
+  t[5] = (t[5] << 1) | (t[4] >> 63);
+  t[4] = (t[4] << 1) | (t[3] >> 63);
+  t[3] = (t[3] << 1) | (t[2] >> 63);
+  t[2] = (t[2] << 1) | (t[1] >> 63);
+  t[1] = t[1] << 1;
+
+  basfld::mac(t[0], carry, 0, f[0], f[0]);
+  basfld::adc(t[1], carry, t[1], 0, carry);
+  basfld::mac(t[2], carry, t[2], f[1], f[1]);
+  basfld::adc(t[3], carry, t[3], 0, carry);
+  basfld::mac(t[4], carry, t[4], f[2], f[2]);
+  basfld::adc(t[5], carry, t[5], 0, carry);
+  basfld::mac(t[6], carry, t[6], f[3], f[3]);
+  basfld::adc(t[7], carry, t[7], 0, carry);
+  basfld::mac(t[8], carry, t[8], f[4], f[4]);
+  basfld::adc(t[9], carry, t[9], 0, carry);
+  basfld::mac(t[10], carry, t[10], f[5], f[5]);
+  basfld::adc(t[11], carry, t[11], 0, carry);
+
+  f12b::reduce(h.data(), t);
+}
+} // namespace sxt::f25o

--- a/sxt/field25/operation/square.cc
+++ b/sxt/field25/operation/square.cc
@@ -34,45 +34,30 @@ namespace sxt::f25o {
 // square
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void square(f12t::element& h, const f12t::element& f) noexcept {
-  uint64_t t[12] = {};
+void square(f25t::element& h, const f25t::element& f) noexcept {
+  uint64_t t[8] = {};
   uint64_t carry{0};
 
   basfld::mac(t[1], carry, 0, f[0], f[1]);
   basfld::mac(t[2], carry, 0, f[0], f[2]);
   basfld::mac(t[3], carry, 0, f[0], f[3]);
-  basfld::mac(t[4], carry, 0, f[0], f[4]);
-  basfld::mac(t[5], carry, 0, f[0], f[5]);
-  t[6] = carry;
+  t[4] = carry;
   carry = 0;
 
   basfld::mac(t[3], carry, t[3], f[1], f[2]);
   basfld::mac(t[4], carry, t[4], f[1], f[3]);
-  basfld::mac(t[5], carry, t[5], f[1], f[4]);
-  basfld::mac(t[6], carry, t[6], f[1], f[5]);
-  t[7] = carry;
+  t[5] = carry;
   carry = 0;
 
   basfld::mac(t[5], carry, t[5], f[2], f[3]);
-  basfld::mac(t[6], carry, t[6], f[2], f[4]);
-  basfld::mac(t[7], carry, t[7], f[2], f[5]);
-  t[8] = carry;
+  t[6] = carry;
   carry = 0;
 
   basfld::mac(t[7], carry, t[7], f[3], f[4]);
-  basfld::mac(t[8], carry, t[8], f[3], f[5]);
-  t[9] = carry;
+  t[7] = carry;
   carry = 0;
 
-  basfld::mac(t[9], carry, t[9], f[4], f[5]);
-  t[10] = carry;
-  carry = 0;
-
-  t[11] = t[10] >> 63;
-  t[10] = (t[10] << 1) | (t[9] >> 63);
-  t[9] = (t[9] << 1) | (t[8] >> 63);
-  t[8] = (t[8] << 1) | (t[7] >> 63);
-  t[7] = (t[7] << 1) | (t[6] >> 63);
+  t[7] = t[6] >> 63;
   t[6] = (t[6] << 1) | (t[5] >> 63);
   t[5] = (t[5] << 1) | (t[4] >> 63);
   t[4] = (t[4] << 1) | (t[3] >> 63);
@@ -88,11 +73,7 @@ void square(f12t::element& h, const f12t::element& f) noexcept {
   basfld::adc(t[5], carry, t[5], 0, carry);
   basfld::mac(t[6], carry, t[6], f[3], f[3]);
   basfld::adc(t[7], carry, t[7], 0, carry);
-  basfld::mac(t[8], carry, t[8], f[4], f[4]);
-  basfld::adc(t[9], carry, t[9], 0, carry);
-  basfld::mac(t[10], carry, t[10], f[5], f[5]);
-  basfld::adc(t[11], carry, t[11], 0, carry);
 
-  f12b::reduce(h.data(), t);
+  f25b::reduce(h.data(), t);
 }
 } // namespace sxt::f25o

--- a/sxt/field25/operation/square.h
+++ b/sxt/field25/operation/square.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::f25t {
+class element;
+}
+
+namespace sxt::f25o {
+//--------------------------------------------------------------------------------------------------
+// square
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void square(f12t::element& h, const f12t::element& f) noexcept;
+} // namespace sxt::f25o

--- a/sxt/field25/operation/square.h
+++ b/sxt/field25/operation/square.h
@@ -27,5 +27,5 @@ namespace sxt::f25o {
 // square
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void square(f12t::element& h, const f12t::element& f) noexcept;
+void square(f25t::element& h, const f25t::element& f) noexcept;
 } // namespace sxt::f25o

--- a/sxt/field25/operation/square.t.cc
+++ b/sxt/field25/operation/square.t.cc
@@ -16,23 +16,26 @@
  */
 #include "sxt/field25/operation/square.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::f25o;
 
 TEST_CASE("squaring") {
-  SECTION("of a pre-computed value is equal to the multiplication of the same value with itself") {
-    // Random value between 1 and p_v generated using the SAGE library.
-    constexpr f12t::element a{0x5e14fa3f799a1246, 0xd2684f55323a5290, 0x7f05158a2afce436,
-                              0xe52da61b5953ed17, 0x8ed26f9683921f45, 0x03b2ad9ebab772aa};
+  SECTION(
+      "of a random field element is equal to the multiplication of the same value with itself") {
+    f25t::element a;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(a, rng);
 
-    f12t::element ret_square;
+    f25t::element ret_square;
     square(ret_square, a);
 
-    f12t::element ret_mul;
+    f25t::element ret_mul;
     mul(ret_mul, a, a);
 
     REQUIRE(ret_square == ret_mul);

--- a/sxt/field25/operation/square.t.cc
+++ b/sxt/field25/operation/square.t.cc
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/field25/operation/square.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
+
+using namespace sxt;
+using namespace sxt::f25o;
+
+TEST_CASE("squaring") {
+  SECTION("of a pre-computed value is equal to the multiplication of the same value with itself") {
+    // Random value between 1 and p_v generated using the SAGE library.
+    constexpr f12t::element a{0x5e14fa3f799a1246, 0xd2684f55323a5290, 0x7f05158a2afce436,
+                              0xe52da61b5953ed17, 0x8ed26f9683921f45, 0x03b2ad9ebab772aa};
+
+    f12t::element ret_square;
+    square(ret_square, a);
+
+    f12t::element ret_mul;
+    mul(ret_mul, a, a);
+
+    REQUIRE(ret_square == ret_mul);
+  }
+}


### PR DESCRIPTION
# Rationale for this change
In order to support MSM with elements on the `bn254` curve we need to implement the base field `Fq`. This work will introduce cmov, inversion, pow, and square components to the `bn254` base field, `field25`. The components are copied from the the `field12` package, which supports the `bls12-381` curve. The components are updated to support the `bn254` base field, which is four limbs, compared to the six limbs of the `bls12-381` base field.

All non-trivial changes are isolated to [this commit](https://github.com/spaceandtimelabs/blitzar/commit/a663fa8e482fca0c1ebf0f7e5d604a0d5f3e04d5).

# What changes are included in this PR?
- `cmov`, `invert`, `pow_vartime`, and `square` components are copied from `field12` and updated to support four limbs.
- Tests are updated.

# Are these changes tested?
Yes