### PR TITLE
feat: add bn254 G1 curve and type package (PROOF-780)

### DIFF
--- a/sxt/curve_bng1/type/BUILD
+++ b/sxt/curve_bng1/type/BUILD
@@ -1,0 +1,68 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "compressed_element",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "conversion_utility",
+    test_deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":element_affine",
+        ":element_p2",
+        "//sxt/base/container:span",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/base/num:cmov",
+        "//sxt/field12/operation:cmov",
+        "//sxt/field12/operation:invert",
+        "//sxt/field12/operation:mul",
+        "//sxt/field12/type:element",
+    ],
+)
+
+sxt_cc_component(
+    name = "element_affine",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/field12/constant:one",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/type:element",
+    ],
+)
+
+sxt_cc_component(
+    name = "element_p2",
+    impl_deps = [
+        "//sxt/field12/operation:mul",
+        "//sxt/field12/property:zero",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/field12/operation:mul",
+    ],
+    deps = [
+        ":operation_adl_stub",
+        "//sxt/field12/constant:one",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/type:element",
+    ],
+)
+
+sxt_cc_component(
+    name = "operation_adl_stub",
+    with_test = False,
+)

--- a/sxt/curve_bng1/type/BUILD
+++ b/sxt/curve_bng1/type/BUILD
@@ -17,7 +17,10 @@ sxt_cc_component(
     name = "conversion_utility",
     test_deps = [
         "//sxt/base/container:span",
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/random:element",
     ],
     deps = [
         ":element_affine",
@@ -51,8 +54,10 @@ sxt_cc_component(
         "//sxt/field25/property:zero",
     ],
     test_deps = [
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
         "//sxt/field25/operation:mul",
+        "//sxt/field25/random:element",
     ],
     deps = [
         ":operation_adl_stub",

--- a/sxt/curve_bng1/type/BUILD
+++ b/sxt/curve_bng1/type/BUILD
@@ -25,10 +25,10 @@ sxt_cc_component(
         "//sxt/base/container:span",
         "//sxt/base/macro:cuda_callable",
         "//sxt/base/num:cmov",
-        "//sxt/field12/operation:cmov",
-        "//sxt/field12/operation:invert",
-        "//sxt/field12/operation:mul",
-        "//sxt/field12/type:element",
+        "//sxt/field25/operation:cmov",
+        "//sxt/field25/operation:invert",
+        "//sxt/field25/operation:mul",
+        "//sxt/field25/type:element",
     ],
 )
 
@@ -38,27 +38,27 @@ sxt_cc_component(
         "//sxt/base/test:unit_test",
     ],
     deps = [
-        "//sxt/field12/constant:one",
-        "//sxt/field12/constant:zero",
-        "//sxt/field12/type:element",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/constant:zero",
+        "//sxt/field25/type:element",
     ],
 )
 
 sxt_cc_component(
     name = "element_p2",
     impl_deps = [
-        "//sxt/field12/operation:mul",
-        "//sxt/field12/property:zero",
+        "//sxt/field25/operation:mul",
+        "//sxt/field25/property:zero",
     ],
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/field12/operation:mul",
+        "//sxt/field25/operation:mul",
     ],
     deps = [
         ":operation_adl_stub",
-        "//sxt/field12/constant:one",
-        "//sxt/field12/constant:zero",
-        "//sxt/field12/type:element",
+        "//sxt/field25/constant:one",
+        "//sxt/field25/constant:zero",
+        "//sxt/field25/type:element",
     ],
 )
 

--- a/sxt/curve_bng1/type/compressed_element.cc
+++ b/sxt/curve_bng1/type/compressed_element.cc
@@ -14,12 +14,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/type/compressed_element.h"
+#include "sxt/curve_bng1/type/compressed_element.h"
 
 #include <cstring>
 #include <iostream>
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // constructor
 //--------------------------------------------------------------------------------------------------
@@ -43,4 +43,4 @@ std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcep
   out << "}";
   return out;
 }
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/compressed_element.cc
+++ b/sxt/curve_bng1/type/compressed_element.cc
@@ -34,9 +34,9 @@ compressed_element::compressed_element(std::initializer_list<uint8_t> values) no
 std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept {
   out << "{";
   auto data = c.data();
-  for (int i = 0; i < 48; ++i) {
+  for (int i = 0; i < 32; ++i) {
     out << static_cast<int>(data[i]);
-    if (i != 48) {
+    if (i != 32) {
       out << ",";
     }
   }

--- a/sxt/curve_bng1/type/compressed_element.cc
+++ b/sxt/curve_bng1/type/compressed_element.cc
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/compressed_element.h"
+
+#include <cstring>
+#include <iostream>
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+compressed_element::compressed_element(std::initializer_list<uint8_t> values) noexcept : data_{} {
+  std::memcpy(static_cast<void*>(data_), static_cast<const void*>(&(*values.begin())),
+              values.size());
+}
+
+//--------------------------------------------------------------------------------------------------
+// opeator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept {
+  out << "{";
+  auto data = c.data();
+  for (int i = 0; i < 48; ++i) {
+    out << static_cast<int>(data[i]);
+    if (i != 48) {
+      out << ",";
+    }
+  }
+  out << "}";
+  return out;
+}
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/compressed_element.h
+++ b/sxt/curve_bng1/type/compressed_element.h
@@ -20,7 +20,7 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // compressed_element
 //--------------------------------------------------------------------------------------------------
@@ -46,4 +46,4 @@ private:
 // opeator<<
 //--------------------------------------------------------------------------------------------------
 std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept;
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/compressed_element.h
+++ b/sxt/curve_bng1/type/compressed_element.h
@@ -1,0 +1,49 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <iosfwd>
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// compressed_element
+//--------------------------------------------------------------------------------------------------
+class compressed_element {
+public:
+  compressed_element() noexcept = default;
+
+  explicit compressed_element(std::initializer_list<uint8_t> values) noexcept;
+
+  CUDA_CALLABLE
+  uint8_t* data() noexcept { return data_; }
+
+  CUDA_CALLABLE
+  const uint8_t* data() const noexcept { return data_; }
+
+  auto operator<=>(const compressed_element&) const noexcept = default;
+
+private:
+  uint8_t data_[48] = {};
+};
+
+//--------------------------------------------------------------------------------------------------
+// opeator<<
+//--------------------------------------------------------------------------------------------------
+std::ostream& operator<<(std::ostream& out, const compressed_element& c) noexcept;
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/compressed_element.h
+++ b/sxt/curve_bng1/type/compressed_element.h
@@ -39,7 +39,7 @@ public:
   auto operator<=>(const compressed_element&) const noexcept = default;
 
 private:
-  uint8_t data_[48] = {};
+  uint8_t data_[32] = {};
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/curve_bng1/type/compressed_element.t.cc
+++ b/sxt/curve_bng1/type/compressed_element.t.cc
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/compressed_element.h"
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt::cg1t;
+
+TEST_CASE("compressed_element is comparable") {
+  compressed_element c1{};
+  compressed_element c2{1, 2};
+  REQUIRE(c1 == c1);
+  REQUIRE(c2 == c2);
+  REQUIRE(c1 != c2);
+}

--- a/sxt/curve_bng1/type/compressed_element.t.cc
+++ b/sxt/curve_bng1/type/compressed_element.t.cc
@@ -14,11 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/type/compressed_element.h"
+#include "sxt/curve_bng1/type/compressed_element.h"
 
 #include "sxt/base/test/unit_test.h"
 
-using namespace sxt::cg1t;
+using namespace sxt::cn1t;
 
 TEST_CASE("compressed_element is comparable") {
   compressed_element c1{};

--- a/sxt/curve_bng1/type/conversion_utility.cc
+++ b/sxt/curve_bng1/type/conversion_utility.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/conversion_utility.h"

--- a/sxt/curve_bng1/type/conversion_utility.cc
+++ b/sxt/curve_bng1/type/conversion_utility.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/type/conversion_utility.h"
+#include "sxt/curve_bng1/type/conversion_utility.h"

--- a/sxt/curve_bng1/type/conversion_utility.h
+++ b/sxt/curve_bng1/type/conversion_utility.h
@@ -1,0 +1,92 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zcash/librustzcash
+ *
+ * Copyright (c) 2017
+ * Zcash Company
+ *
+ * See third_party/license/zcash.LICENSE
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/num/cmov.h"
+#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/operation/cmov.h"
+#include "sxt/field12/operation/invert.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// to_element_affine
+//--------------------------------------------------------------------------------------------------
+/*
+ Converts projective to affine element.
+ */
+CUDA_CALLABLE
+inline void to_element_affine(element_affine& a, const element_p2& p) noexcept {
+  f12t::element z_inv;
+  const bool is_zero{f12o::invert(z_inv, p.Z)};
+  f12o::cmov(z_inv, f12cn::zero_v, is_zero);
+
+  f12t::element x;
+  f12t::element y;
+  f12o::mul(x, p.X, z_inv);
+  f12o::mul(y, p.Y, z_inv);
+
+  a.X = x;
+  a.Y = y;
+  a.infinity = false;
+
+  f12o::cmov(a.X, element_affine::identity().X, is_zero);
+  f12o::cmov(a.Y, element_affine::identity().Y, is_zero);
+  basn::cmov(a.infinity, element_affine::identity().infinity, is_zero);
+}
+
+//--------------------------------------------------------------------------------------------------
+// to_element_p2
+//--------------------------------------------------------------------------------------------------
+/*
+ Converts affine to projective element.
+ */
+CUDA_CALLABLE
+inline void to_element_p2(element_p2& p, const element_affine& a) noexcept {
+  p.X = a.X;
+  p.Y = a.Y;
+  p.Z = f12cn::one_v;
+  f12o::cmov(p.Z, f12cn::zero_v, a.infinity);
+}
+
+//--------------------------------------------------------------------------------------------------
+// batch_to_element_p2
+//--------------------------------------------------------------------------------------------------
+/*
+ Batch converts affine to projective element.
+ */
+CUDA_CALLABLE
+inline void batch_to_element_p2(basct::span<cg1t::element_p2> p,
+                                basct::cspan<cg1t::element_affine> a) noexcept {
+  SXT_DEBUG_ASSERT(a.size() == p.size());
+  for (size_t i = 0; i < a.size(); ++i) {
+    to_element_p2(p[i], a[i]);
+  }
+}
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/conversion_utility.h
+++ b/sxt/curve_bng1/type/conversion_utility.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zcash/librustzcash
  *
  * Copyright (c) 2017
@@ -27,19 +27,19 @@
 #include "sxt/base/container/span.h"
 #include "sxt/base/macro/cuda_callable.h"
 #include "sxt/base/num/cmov.h"
-#include "sxt/curve_g1/type/element_affine.h"
-#include "sxt/curve_g1/type/element_p2.h"
-#include "sxt/field12/operation/cmov.h"
-#include "sxt/field12/operation/invert.h"
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/curve_bng1/type/element_affine.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/operation/cmov.h"
+#include "sxt/field25/operation/invert.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // to_element_affine
 //--------------------------------------------------------------------------------------------------
-/*
- Converts projective to affine element.
+/**
+ * Converts projective to affine element.
  */
 CUDA_CALLABLE
 inline void to_element_affine(element_affine& a, const element_p2& p) noexcept {
@@ -78,8 +78,8 @@ inline void to_element_p2(element_p2& p, const element_affine& a) noexcept {
 //--------------------------------------------------------------------------------------------------
 // batch_to_element_p2
 //--------------------------------------------------------------------------------------------------
-/*
- Batch converts affine to projective element.
+/**
+ * Batch converts affine to projective element.
  */
 CUDA_CALLABLE
 inline void batch_to_element_p2(basct::span<cg1t::element_p2> p,
@@ -89,4 +89,4 @@ inline void batch_to_element_p2(basct::span<cg1t::element_p2> p,
     to_element_p2(p[i], a[i]);
   }
 }
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/conversion_utility.h
+++ b/sxt/curve_bng1/type/conversion_utility.h
@@ -43,36 +43,36 @@ namespace sxt::cn1t {
  */
 CUDA_CALLABLE
 inline void to_element_affine(element_affine& a, const element_p2& p) noexcept {
-  f12t::element z_inv;
-  const bool is_zero{f12o::invert(z_inv, p.Z)};
-  f12o::cmov(z_inv, f12cn::zero_v, is_zero);
+  f25t::element z_inv;
+  const bool is_zero{f25o::invert(z_inv, p.Z)};
+  f25o::cmov(z_inv, f25cn::zero_v, is_zero);
 
-  f12t::element x;
-  f12t::element y;
-  f12o::mul(x, p.X, z_inv);
-  f12o::mul(y, p.Y, z_inv);
+  f25t::element x;
+  f25t::element y;
+  f25o::mul(x, p.X, z_inv);
+  f25o::mul(y, p.Y, z_inv);
 
   a.X = x;
   a.Y = y;
   a.infinity = false;
 
-  f12o::cmov(a.X, element_affine::identity().X, is_zero);
-  f12o::cmov(a.Y, element_affine::identity().Y, is_zero);
+  f25o::cmov(a.X, element_affine::identity().X, is_zero);
+  f25o::cmov(a.Y, element_affine::identity().Y, is_zero);
   basn::cmov(a.infinity, element_affine::identity().infinity, is_zero);
 }
 
 //--------------------------------------------------------------------------------------------------
 // to_element_p2
 //--------------------------------------------------------------------------------------------------
-/*
- Converts affine to projective element.
+/**
+ * Converts affine to projective element.
  */
 CUDA_CALLABLE
 inline void to_element_p2(element_p2& p, const element_affine& a) noexcept {
   p.X = a.X;
   p.Y = a.Y;
-  p.Z = f12cn::one_v;
-  f12o::cmov(p.Z, f12cn::zero_v, a.infinity);
+  p.Z = f25cn::one_v;
+  f25o::cmov(p.Z, f25cn::zero_v, a.infinity);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -82,8 +82,8 @@ inline void to_element_p2(element_p2& p, const element_affine& a) noexcept {
  * Batch converts affine to projective element.
  */
 CUDA_CALLABLE
-inline void batch_to_element_p2(basct::span<cg1t::element_p2> p,
-                                basct::cspan<cg1t::element_affine> a) noexcept {
+inline void batch_to_element_p2(basct::span<cn1t::element_p2> p,
+                                basct::cspan<cn1t::element_affine> a) noexcept {
   SXT_DEBUG_ASSERT(a.size() == p.size());
   for (size_t i = 0; i < a.size(); ++i) {
     to_element_p2(p[i], a[i]);

--- a/sxt/curve_bng1/type/conversion_utility.t.cc
+++ b/sxt/curve_bng1/type/conversion_utility.t.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zcash/librustzcash
  *
  * Copyright (c) 2017
@@ -22,17 +22,17 @@
  *
  * See third_party/license/zcash.LICENSE
  */
-#include "sxt/curve_g1/type/conversion_utility.h"
+#include "sxt/curve_bng1/type/conversion_utility.h"
 
 #include "sxt/base/container/span.h"
 #include "sxt/base/test/unit_test.h"
-#include "sxt/curve_g1/type/element_affine.h"
-#include "sxt/curve_g1/type/element_p2.h"
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/curve_bng1/type/element_affine.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::cg1t;
+using namespace sxt::cn1t;
 
 constexpr f12t::element generator_x{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
                                     0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75};

--- a/sxt/curve_bng1/type/conversion_utility.t.cc
+++ b/sxt/curve_bng1/type/conversion_utility.t.cc
@@ -1,0 +1,128 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zcash/librustzcash
+ *
+ * Copyright (c) 2017
+ * Zcash Company
+ *
+ * See third_party/license/zcash.LICENSE
+ */
+#include "sxt/curve_g1/type/conversion_utility.h"
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::cg1t;
+
+constexpr f12t::element generator_x{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
+                                    0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75};
+
+constexpr f12t::element generator_y{0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
+                                    0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a};
+
+constexpr element_p2 generator_projective{generator_x, generator_y, f12cn::one_v};
+constexpr element_p2 identity_projective{element_p2::identity()};
+
+constexpr element_affine generator_affine{generator_x, generator_y, false};
+constexpr element_affine identity_affine{element_affine::identity()};
+
+TEST_CASE("conversion from projective to affine elements") {
+  SECTION("does not change the generator") {
+    element_affine result_affine;
+
+    to_element_affine(result_affine, generator_projective);
+
+    REQUIRE(result_affine == generator_affine);
+  }
+
+  SECTION("does not change the identity") {
+    element_affine result_affine;
+
+    to_element_affine(result_affine, identity_projective);
+
+    REQUIRE(result_affine == identity_affine);
+  }
+
+  SECTION("does not change a projected generator coordinate") {
+    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
+                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+
+    f12t::element gpx_z;
+    f12t::element gpy_z;
+    f12o::mul(gpx_z, generator_projective.X, z);
+    f12o::mul(gpy_z, generator_projective.Y, z);
+    element_p2 projective_pt{gpx_z, gpy_z, z};
+
+    element_affine affine_pt;
+
+    to_element_affine(affine_pt, projective_pt);
+
+    REQUIRE(affine_pt == generator_affine);
+  }
+}
+
+TEST_CASE("conversion from affine to projective elements") {
+  SECTION("does not change the generator") {
+    element_p2 result_projective;
+
+    to_element_p2(result_projective, generator_affine);
+
+    REQUIRE(result_projective == generator_projective);
+  }
+
+  SECTION("does not change the identity") {
+    element_p2 result_projective;
+
+    to_element_p2(result_projective, identity_affine);
+
+    REQUIRE(result_projective == identity_projective);
+  }
+}
+
+TEST_CASE("batch conversion from affine to projective elements") {
+  SECTION("does not change the generator") {
+    std::vector<element_p2> res_vec{element_p2{}, element_p2{}};
+    basct::span<element_p2> results{res_vec};
+    const std::vector<element_affine> gen_vec{generator_affine, generator_affine};
+    basct::cspan<element_affine> generators{gen_vec};
+
+    batch_to_element_p2(results, generators);
+
+    REQUIRE(results.size() == 2);
+    REQUIRE(results[0] == generator_projective);
+    REQUIRE(results[1] == generator_projective);
+  }
+
+  SECTION("does not change the identity") {
+    std::vector<element_p2> res_vec{element_p2{}, element_p2{}};
+    basct::span<element_p2> results{res_vec};
+    const std::vector<element_affine> gen_vec{identity_affine, identity_affine};
+    basct::cspan<element_affine> generators{gen_vec};
+
+    batch_to_element_p2(results, generators);
+
+    REQUIRE(results.size() == 2);
+    REQUIRE(results[0] == identity_projective);
+    REQUIRE(results[1] == identity_projective);
+  }
+}

--- a/sxt/curve_bng1/type/conversion_utility.t.cc
+++ b/sxt/curve_bng1/type/conversion_utility.t.cc
@@ -25,22 +25,23 @@
 #include "sxt/curve_bng1/type/conversion_utility.h"
 
 #include "sxt/base/container/span.h"
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/curve_bng1/type/element_affine.h"
 #include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/constant/one.h"
 #include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
 using namespace sxt::cn1t;
 
-constexpr f12t::element generator_x{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
-                                    0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75};
+constexpr f25t::element generator_x{f25cn::one_v};
+constexpr f25t::element generator_y{0xa6ba871b8b1e1b3a, 0x14f1d651eb8e167b, 0xccdd46def0f28c58,
+                                    0x1c14ef83340fbe5e};
 
-constexpr f12t::element generator_y{0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
-                                    0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a};
-
-constexpr element_p2 generator_projective{generator_x, generator_y, f12cn::one_v};
+constexpr element_p2 generator_projective{generator_x, generator_y, f25cn::one_v};
 constexpr element_p2 identity_projective{element_p2::identity()};
 
 constexpr element_affine generator_affine{generator_x, generator_y, false};
@@ -64,13 +65,14 @@ TEST_CASE("conversion from projective to affine elements") {
   }
 
   SECTION("does not change a projected generator coordinate") {
-    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
-                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+    f25t::element z;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(z, rng);
 
-    f12t::element gpx_z;
-    f12t::element gpy_z;
-    f12o::mul(gpx_z, generator_projective.X, z);
-    f12o::mul(gpy_z, generator_projective.Y, z);
+    f25t::element gpx_z;
+    f25t::element gpy_z;
+    f25o::mul(gpx_z, generator_projective.X, z);
+    f25o::mul(gpy_z, generator_projective.Y, z);
     element_p2 projective_pt{gpx_z, gpy_z, z};
 
     element_affine affine_pt;

--- a/sxt/curve_bng1/type/element_affine.cc
+++ b/sxt/curve_bng1/type/element_affine.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_bng1/type/element_affine.h"

--- a/sxt/curve_bng1/type/element_affine.cc
+++ b/sxt/curve_bng1/type/element_affine.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/element_affine.h"

--- a/sxt/curve_bng1/type/element_affine.h
+++ b/sxt/curve_bng1/type/element_affine.h
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -25,19 +25,19 @@
  */
 #pragma once
 
-#include "sxt/field12/constant/one.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // element_affine
 //--------------------------------------------------------------------------------------------------
 /**
- This is an element of G1 represented in the affine coordinate space.
- It is ideal to keep elements in this representation to reduce memory usage and
- improve performance through the use of mixed curve model arithmetic.
- Values of `G1Affine` are guaranteed to be in the q-order subgroup.
+ * This is an element of G1 represented in the affine coordinate space.
+ * It is ideal to keep elements in this representation to reduce memory usage and
+ * improve performance through the use of mixed curve model arithmetic.
+ * Values of `G1Affine` are guaranteed to be in the q-order subgroup.
  */
 struct element_affine {
   f12t::element X;
@@ -50,4 +50,4 @@ struct element_affine {
 
   bool operator==(const element_affine& rhs) const noexcept = default;
 };
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/element_affine.h
+++ b/sxt/curve_bng1/type/element_affine.h
@@ -40,12 +40,12 @@ namespace sxt::cn1t {
  * Values of `G1Affine` are guaranteed to be in the q-order subgroup.
  */
 struct element_affine {
-  f12t::element X;
-  f12t::element Y;
+  f25t::element X;
+  f25t::element Y;
   uint8_t infinity;
 
   static constexpr element_affine identity() noexcept {
-    return element_affine{f12cn::zero_v, f12cn::one_v, true};
+    return element_affine{f25cn::zero_v, f25cn::one_v, true};
   }
 
   bool operator==(const element_affine& rhs) const noexcept = default;

--- a/sxt/curve_bng1/type/element_affine.h
+++ b/sxt/curve_bng1/type/element_affine.h
@@ -1,0 +1,53 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#pragma once
+
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// element_affine
+//--------------------------------------------------------------------------------------------------
+/**
+ This is an element of G1 represented in the affine coordinate space.
+ It is ideal to keep elements in this representation to reduce memory usage and
+ improve performance through the use of mixed curve model arithmetic.
+ Values of `G1Affine` are guaranteed to be in the q-order subgroup.
+ */
+struct element_affine {
+  f12t::element X;
+  f12t::element Y;
+  uint8_t infinity;
+
+  static constexpr element_affine identity() noexcept {
+    return element_affine{f12cn::zero_v, f12cn::one_v, true};
+  }
+
+  bool operator==(const element_affine& rhs) const noexcept = default;
+};
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/element_affine.t.cc
+++ b/sxt/curve_bng1/type/element_affine.t.cc
@@ -34,13 +34,12 @@ using namespace sxt::cn1t;
 
 TEST_CASE("affine element equality") {
   SECTION("can distinguish the generator from the identity") {
-    constexpr element_affine a{{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
-                                0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75},
-                               {0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
-                                0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a},
-                               false};
+    constexpr element_affine a{
+        f25cn::one_v,
+        {0xa6ba871b8b1e1b3a, 0x14f1d651eb8e167b, 0xccdd46def0f28c58, 0x1c14ef83340fbe5e},
+        false};
 
-    constexpr element_affine b{f12cn::zero_v, f12cn::one_v, true};
+    constexpr element_affine b{f25cn::zero_v, f25cn::one_v, true};
 
     REQUIRE(a == a);
     REQUIRE(b == b);

--- a/sxt/curve_bng1/type/element_affine.t.cc
+++ b/sxt/curve_bng1/type/element_affine.t.cc
@@ -1,0 +1,50 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/type/element_affine.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+
+using namespace sxt;
+using namespace sxt::cg1t;
+
+TEST_CASE("affine element equality") {
+  SECTION("can distinguish the generator from the identity") {
+    constexpr element_affine a{{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
+                                0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75},
+                               {0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
+                                0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a},
+                               false};
+
+    constexpr element_affine b{f12cn::zero_v, f12cn::one_v, true};
+
+    REQUIRE(a == a);
+    REQUIRE(b == b);
+    REQUIRE(a != b);
+    REQUIRE(b != a);
+  }
+}

--- a/sxt/curve_bng1/type/element_affine.t.cc
+++ b/sxt/curve_bng1/type/element_affine.t.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,14 +23,14 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_bng1/type/element_affine.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/one.h"
-#include "sxt/field12/constant/zero.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/constant/zero.h"
 
 using namespace sxt;
-using namespace sxt::cg1t;
+using namespace sxt::cn1t;
 
 TEST_CASE("affine element equality") {
   SECTION("can distinguish the generator from the identity") {

--- a/sxt/curve_bng1/type/element_p2.cc
+++ b/sxt/curve_bng1/type/element_p2.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,13 +23,13 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/curve_bng1/type/element_p2.h"
 
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/property/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/property/zero.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // unset_marker_v
 //--------------------------------------------------------------------------------------------------
@@ -48,10 +48,10 @@ bool is_marked(const element_p2& e) noexcept { return e.Z[5] != unset_marker_v; 
 //--------------------------------------------------------------------------------------------------
 // operator==
 //--------------------------------------------------------------------------------------------------
-/*
- Returns true if either both points are at infinity or neither point is at infinity,
- and the coordinates are the same.
-*/
+/**
+ * Returns true if either both points are at infinity or neither point is at infinity,
+ * and the coordinates are the same.
+ */
 bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept {
   f12t::element x1;
   f12t::element x2;
@@ -70,4 +70,4 @@ bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept {
   return (lhs_is_zero && rhs_is_zero) ||
          ((!lhs_is_zero) && (!rhs_is_zero) && (x1 == x2) && (y1 == y2));
 }
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/element_p2.cc
+++ b/sxt/curve_bng1/type/element_p2.cc
@@ -1,0 +1,73 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/type/element_p2.h"
+
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/property/zero.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// unset_marker_v
+//--------------------------------------------------------------------------------------------------
+static constexpr uint64_t unset_marker_v = static_cast<uint64_t>(-1);
+
+//--------------------------------------------------------------------------------------------------
+// mark
+//--------------------------------------------------------------------------------------------------
+void mark(element_p2& e) noexcept { e.Z[5] = unset_marker_v; }
+
+//--------------------------------------------------------------------------------------------------
+// is_marked
+//--------------------------------------------------------------------------------------------------
+bool is_marked(const element_p2& e) noexcept { return e.Z[5] != unset_marker_v; }
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+/*
+ Returns true if either both points are at infinity or neither point is at infinity,
+ and the coordinates are the same.
+*/
+bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept {
+  f12t::element x1;
+  f12t::element x2;
+  f12t::element y1;
+  f12t::element y2;
+
+  f12o::mul(x1, lhs.X, rhs.Z);
+  f12o::mul(x2, rhs.X, lhs.Z);
+
+  f12o::mul(y1, lhs.Y, rhs.Z);
+  f12o::mul(y2, rhs.Y, lhs.Z);
+
+  const auto lhs_is_zero = f12p::is_zero(lhs.Z);
+  const auto rhs_is_zero = f12p::is_zero(rhs.Z);
+
+  return (lhs_is_zero && rhs_is_zero) ||
+         ((!lhs_is_zero) && (!rhs_is_zero) && (x1 == x2) && (y1 == y2));
+}
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/element_p2.cc
+++ b/sxt/curve_bng1/type/element_p2.cc
@@ -38,12 +38,12 @@ static constexpr uint64_t unset_marker_v = static_cast<uint64_t>(-1);
 //--------------------------------------------------------------------------------------------------
 // mark
 //--------------------------------------------------------------------------------------------------
-void mark(element_p2& e) noexcept { e.Z[5] = unset_marker_v; }
+void mark(element_p2& e) noexcept { e.Z[3] = unset_marker_v; }
 
 //--------------------------------------------------------------------------------------------------
 // is_marked
 //--------------------------------------------------------------------------------------------------
-bool is_marked(const element_p2& e) noexcept { return e.Z[5] != unset_marker_v; }
+bool is_marked(const element_p2& e) noexcept { return e.Z[3] != unset_marker_v; }
 
 //--------------------------------------------------------------------------------------------------
 // operator==
@@ -53,19 +53,19 @@ bool is_marked(const element_p2& e) noexcept { return e.Z[5] != unset_marker_v; 
  * and the coordinates are the same.
  */
 bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept {
-  f12t::element x1;
-  f12t::element x2;
-  f12t::element y1;
-  f12t::element y2;
+  f25t::element x1;
+  f25t::element x2;
+  f25t::element y1;
+  f25t::element y2;
 
-  f12o::mul(x1, lhs.X, rhs.Z);
-  f12o::mul(x2, rhs.X, lhs.Z);
+  f25o::mul(x1, lhs.X, rhs.Z);
+  f25o::mul(x2, rhs.X, lhs.Z);
 
-  f12o::mul(y1, lhs.Y, rhs.Z);
-  f12o::mul(y2, rhs.Y, lhs.Z);
+  f25o::mul(y1, lhs.Y, rhs.Z);
+  f25o::mul(y2, rhs.Y, lhs.Z);
 
-  const auto lhs_is_zero = f12p::is_zero(lhs.Z);
-  const auto rhs_is_zero = f12p::is_zero(rhs.Z);
+  const auto lhs_is_zero = f25p::is_zero(lhs.Z);
+  const auto rhs_is_zero = f25p::is_zero(rhs.Z);
 
   return (lhs_is_zero && rhs_is_zero) ||
          ((!lhs_is_zero) && (!rhs_is_zero) && (x1 == x2) && (y1 == y2));

--- a/sxt/curve_bng1/type/element_p2.h
+++ b/sxt/curve_bng1/type/element_p2.h
@@ -1,0 +1,62 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/curve_g1/type/operation_adl_stub.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// element_p2
+//--------------------------------------------------------------------------------------------------
+/*
+ Projective coordinates (X,Y,Z). Represents the Affine coordinate point (X/Z,Y/Z).
+ Homogeneous form Y^2 * Z = X^3 + (4 * Z^3).
+ */
+struct element_p2 : cg1o::operation_adl_stub {
+  element_p2() noexcept = default;
+
+  constexpr element_p2(const f12t::element& X, const f12t::element& Y,
+                       const f12t::element& Z) noexcept
+      : X{X}, Y{Y}, Z{Z} {}
+
+  f12t::element X;
+  f12t::element Y;
+  f12t::element Z;
+
+  static constexpr element_p2 identity() noexcept {
+    return element_p2{f12cn::zero_v, f12cn::one_v, f12cn::zero_v};
+  }
+};
+
+//--------------------------------------------------------------------------------------------------
+// mark
+//--------------------------------------------------------------------------------------------------
+void mark(element_p2& e) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// is_marked
+//--------------------------------------------------------------------------------------------------
+bool is_marked(const element_p2& e) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// operator==
+//--------------------------------------------------------------------------------------------------
+bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept;
+} // namespace sxt::cg1t

--- a/sxt/curve_bng1/type/element_p2.h
+++ b/sxt/curve_bng1/type/element_p2.h
@@ -16,18 +16,18 @@
  */
 #pragma once
 
-#include "sxt/curve_g1/type/operation_adl_stub.h"
-#include "sxt/field12/constant/one.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/curve_bng1/type/operation_adl_stub.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 //--------------------------------------------------------------------------------------------------
 // element_p2
 //--------------------------------------------------------------------------------------------------
-/*
- Projective coordinates (X,Y,Z). Represents the Affine coordinate point (X/Z,Y/Z).
- Homogeneous form Y^2 * Z = X^3 + (4 * Z^3).
+/**
+ * Projective coordinates (X,Y,Z). Represents the Affine coordinate point (X/Z,Y/Z).
+ * Homogeneous form Y^2 * Z = X^3 + (4 * Z^3).
  */
 struct element_p2 : cg1o::operation_adl_stub {
   element_p2() noexcept = default;
@@ -59,4 +59,4 @@ bool is_marked(const element_p2& e) noexcept;
 // operator==
 //--------------------------------------------------------------------------------------------------
 bool operator==(const element_p2& lhs, const element_p2& rhs) noexcept;
-} // namespace sxt::cg1t
+} // namespace sxt::cn1t

--- a/sxt/curve_bng1/type/element_p2.h
+++ b/sxt/curve_bng1/type/element_p2.h
@@ -29,19 +29,19 @@ namespace sxt::cn1t {
  * Projective coordinates (X,Y,Z). Represents the Affine coordinate point (X/Z,Y/Z).
  * Homogeneous form Y^2 * Z = X^3 + (4 * Z^3).
  */
-struct element_p2 : cg1o::operation_adl_stub {
+struct element_p2 : cn1o::operation_adl_stub {
   element_p2() noexcept = default;
 
-  constexpr element_p2(const f12t::element& X, const f12t::element& Y,
-                       const f12t::element& Z) noexcept
+  constexpr element_p2(const f25t::element& X, const f25t::element& Y,
+                       const f25t::element& Z) noexcept
       : X{X}, Y{Y}, Z{Z} {}
 
-  f12t::element X;
-  f12t::element Y;
-  f12t::element Z;
+  f25t::element X;
+  f25t::element Y;
+  f25t::element Z;
 
   static constexpr element_p2 identity() noexcept {
-    return element_p2{f12cn::zero_v, f12cn::one_v, f12cn::zero_v};
+    return element_p2{f25cn::zero_v, f25cn::one_v, f25cn::zero_v};
   }
 };
 

--- a/sxt/curve_bng1/type/element_p2.t.cc
+++ b/sxt/curve_bng1/type/element_p2.t.cc
@@ -1,0 +1,67 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/type/element_p2.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::cg1t;
+
+TEST_CASE("projective element equality") {
+  SECTION("can distinguish the generator from the identity") {
+    constexpr element_p2 a{{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
+                            0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75},
+                           {0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
+                            0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a},
+                           f12cn::one_v};
+    constexpr element_p2 b{f12cn::zero_v, f12cn::one_v, f12cn::zero_v};
+
+    REQUIRE(a == a);
+    REQUIRE(b == b);
+    REQUIRE(a != b);
+    REQUIRE(b != a);
+
+    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
+                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+
+    f12t::element ax_z;
+    f12o::mul(ax_z, a.X, z);
+
+    f12t::element ay_z;
+    f12o::mul(ay_z, a.Y, z);
+
+    element_p2 c{ax_z, ay_z, z};
+
+    REQUIRE(a == c);
+    REQUIRE(b != c);
+    REQUIRE(c == a);
+    REQUIRE(c != b);
+  }
+}

--- a/sxt/curve_bng1/type/element_p2.t.cc
+++ b/sxt/curve_bng1/type/element_p2.t.cc
@@ -25,10 +25,12 @@
  */
 #include "sxt/curve_bng1/type/element_p2.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/field25/constant/one.h"
 #include "sxt/field25/constant/zero.h"
 #include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
@@ -36,26 +38,27 @@ using namespace sxt::cn1t;
 
 TEST_CASE("projective element equality") {
   SECTION("can distinguish the generator from the identity") {
-    constexpr element_p2 a{{0x5cb38790fd530c16, 0x7817fc679976fff5, 0x154f95c7143ba1c1,
-                            0xf0ae6acdf3d0e747, 0xedce6ecc21dbf440, 0x120177419e0bfb75},
-                           {0xbaac93d50ce72271, 0x8c22631a7918fd8e, 0xdd595f13570725ce,
-                            0x51ac582950405194, 0x0e1c8c3fad0059c0, 0x0bbc3efc5008a26a},
-                           f12cn::one_v};
-    constexpr element_p2 b{f12cn::zero_v, f12cn::one_v, f12cn::zero_v};
+    constexpr element_p2 a{
+        f25cn::one_v,
+        {0xa6ba871b8b1e1b3a, 0x14f1d651eb8e167b, 0xccdd46def0f28c58, 0x1c14ef83340fbe5e},
+        f25cn::one_v};
+    constexpr element_p2 b{element_p2::identity()};
 
     REQUIRE(a == a);
     REQUIRE(b == b);
     REQUIRE(a != b);
     REQUIRE(b != a);
 
-    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
-                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+    // Project the generator with a random field element.
+    f25t::element z;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(z, rng);
 
-    f12t::element ax_z;
-    f12o::mul(ax_z, a.X, z);
+    f25t::element ax_z;
+    f25o::mul(ax_z, a.X, z);
 
-    f12t::element ay_z;
-    f12o::mul(ay_z, a.Y, z);
+    f25t::element ay_z;
+    f25o::mul(ay_z, a.Y, z);
 
     element_p2 c{ax_z, ay_z, z};
 

--- a/sxt/curve_bng1/type/element_p2.t.cc
+++ b/sxt/curve_bng1/type/element_p2.t.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,16 +23,16 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/curve_bng1/type/element_p2.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/field12/constant/one.h"
-#include "sxt/field12/constant/zero.h"
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/field25/constant/one.h"
+#include "sxt/field25/constant/zero.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::cg1t;
+using namespace sxt::cn1t;
 
 TEST_CASE("projective element equality") {
   SECTION("can distinguish the generator from the identity") {

--- a/sxt/curve_bng1/type/operation_adl_stub.cc
+++ b/sxt/curve_bng1/type/operation_adl_stub.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/type/operation_adl_stub.h"

--- a/sxt/curve_bng1/type/operation_adl_stub.cc
+++ b/sxt/curve_bng1/type/operation_adl_stub.cc
@@ -14,4 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/type/operation_adl_stub.h"
+#include "sxt/curve_bng1/type/operation_adl_stub.h"

--- a/sxt/curve_bng1/type/operation_adl_stub.h
+++ b/sxt/curve_bng1/type/operation_adl_stub.h
@@ -16,7 +16,7 @@
  */
 #pragma once
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // operation_adl_stub
 //--------------------------------------------------------------------------------------------------
@@ -25,4 +25,4 @@ namespace sxt::cg1o {
  * will participate in ADL.
  */
 struct operation_adl_stub {};
-}; // namespace sxt::cg1o
+}; // namespace sxt::cn1o

--- a/sxt/curve_bng1/type/operation_adl_stub.h
+++ b/sxt/curve_bng1/type/operation_adl_stub.h
@@ -1,0 +1,28 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// operation_adl_stub
+//--------------------------------------------------------------------------------------------------
+/**
+ * A stub class that can be inherited so that functions in the cg1o namespace
+ * will participate in ADL.
+ */
+struct operation_adl_stub {};
+}; // namespace sxt::cg1o

--- a/sxt/curve_bng1/type/operation_adl_stub.h
+++ b/sxt/curve_bng1/type/operation_adl_stub.h
@@ -21,7 +21,7 @@ namespace sxt::cn1o {
 // operation_adl_stub
 //--------------------------------------------------------------------------------------------------
 /**
- * A stub class that can be inherited so that functions in the cg1o namespace
+ * A stub class that can be inherited so that functions in the cn1o namespace
  * will participate in ADL.
  */
 struct operation_adl_stub {};


### PR DESCRIPTION
# Rationale for this change
In order to support MSM with `G1` elements on the `bn254` curve we need to implement a curve package. This work introduces the `bn254` `G1` curve and type package along with the type components. The components are copied from the `curve_g1/type` package, which supports the `bls12-381` curve. The components are updated to support the `bn254` base field, which is four limbs, compared to the six limbs of the `bls12-381` base field.

Non-trivial changes are isolated to [this commit](https://github.com/spaceandtimelabs/blitzar/commit/03c4ab339cfaea047babf3c90b06595126946656).

# What changes are included in this PR?
- A new package to support the `bn256` `G1` curve, `curve_bng1`, is added to the `sxt` package group.
- A `type` package and components are copied from the `curve_g1/type` package.
- The components in the `curve_bng1/type` package are updated to support four limbs.

# Are these changes tested?
Yes