### PR TITLE
feat: add, neg, and scalar_multiply components are added to bn254 G1 curve package (PROOF-739)

### DIFF
--- a/sxt/curve_bng1/operation/BUILD
+++ b/sxt/curve_bng1/operation/BUILD
@@ -4,6 +4,33 @@ load(
 )
 
 sxt_cc_component(
+    name = "add",
+    impl_deps = [
+        ":cmov",
+        "//sxt/curve_g1/property:identity",
+        "//sxt/curve_g1/type:element_affine",
+    ],
+    is_cuda = True,
+    test_deps = [
+        ":double",
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_g1/constant:generator",
+        "//sxt/curve_g1/property:curve",
+        "//sxt/curve_g1/property:identity",
+        "//sxt/curve_g1/type:element_affine",
+        "//sxt/field12/type:element",
+    ],
+    deps = [
+        ":mul_by_3b",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/curve_g1/type:element_p2",
+        "//sxt/field12/operation:add",
+        "//sxt/field12/operation:mul",
+        "//sxt/field12/operation:sub",
+    ],
+)
+
+sxt_cc_component(
     name = "cmov",
     impl_deps = [
         "//sxt/curve_bng1/type:element_affine",
@@ -61,6 +88,44 @@ sxt_cc_component(
         "//sxt/field25/constant:one",
         "//sxt/field25/type:element",
         "//sxt/field25/type:literal",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "neg",
+    impl_deps = [
+        "//sxt/curve_g1/type:element_p2",
+        "//sxt/field12/operation:cmov",
+        "//sxt/field12/operation:neg",
+        "//sxt/field12/type:element",
+    ],
+    is_cuda = True,
+    test_deps = [
+        ":add",
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_g1/constant:generator",
+        "//sxt/curve_g1/type:element_p2",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
+    name = "scalar_multiply",
+    impl_deps = [
+        ":add",
+        ":double",
+        "//sxt/curve_g1/type:element_p2",
+    ],
+    is_cuda = True,
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_g1/constant:generator",
+        "//sxt/curve_g1/type:element_p2",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",

--- a/sxt/curve_bng1/operation/BUILD
+++ b/sxt/curve_bng1/operation/BUILD
@@ -7,26 +7,26 @@ sxt_cc_component(
     name = "add",
     impl_deps = [
         ":cmov",
-        "//sxt/curve_g1/property:identity",
-        "//sxt/curve_g1/type:element_affine",
+        "//sxt/curve_bng1/property:identity",
+        "//sxt/curve_bng1/type:element_affine",
     ],
     is_cuda = True,
     test_deps = [
         ":double",
         "//sxt/base/test:unit_test",
-        "//sxt/curve_g1/constant:generator",
-        "//sxt/curve_g1/property:curve",
-        "//sxt/curve_g1/property:identity",
-        "//sxt/curve_g1/type:element_affine",
-        "//sxt/field12/type:element",
+        "//sxt/curve_bng1/constant:generator",
+        "//sxt/curve_bng1/property:curve",
+        "//sxt/curve_bng1/property:identity",
+        "//sxt/curve_bng1/type:element_affine",
+        "//sxt/field25/type:element",
     ],
     deps = [
         ":mul_by_3b",
         "//sxt/base/macro:cuda_callable",
-        "//sxt/curve_g1/type:element_p2",
-        "//sxt/field12/operation:add",
-        "//sxt/field12/operation:mul",
-        "//sxt/field12/operation:sub",
+        "//sxt/curve_bng1/type:element_p2",
+        "//sxt/field25/operation:add",
+        "//sxt/field25/operation:mul",
+        "//sxt/field25/operation:sub",
     ],
 )
 
@@ -97,17 +97,17 @@ sxt_cc_component(
 sxt_cc_component(
     name = "neg",
     impl_deps = [
-        "//sxt/curve_g1/type:element_p2",
-        "//sxt/field12/operation:cmov",
-        "//sxt/field12/operation:neg",
-        "//sxt/field12/type:element",
+        "//sxt/curve_bng1/type:element_p2",
+        "//sxt/field25/operation:cmov",
+        "//sxt/field25/operation:neg",
+        "//sxt/field25/type:element",
     ],
     is_cuda = True,
     test_deps = [
         ":add",
         "//sxt/base/test:unit_test",
-        "//sxt/curve_g1/constant:generator",
-        "//sxt/curve_g1/type:element_p2",
+        "//sxt/curve_bng1/constant:generator",
+        "//sxt/curve_bng1/type:element_p2",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
@@ -119,13 +119,13 @@ sxt_cc_component(
     impl_deps = [
         ":add",
         ":double",
-        "//sxt/curve_g1/type:element_p2",
+        "//sxt/curve_bng1/type:element_p2",
     ],
     is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
-        "//sxt/curve_g1/constant:generator",
-        "//sxt/curve_g1/type:element_p2",
+        "//sxt/curve_bng1/constant:generator",
+        "//sxt/curve_bng1/type:element_p2",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",

--- a/sxt/curve_bng1/operation/BUILD
+++ b/sxt/curve_bng1/operation/BUILD
@@ -13,11 +13,13 @@ sxt_cc_component(
     is_cuda = True,
     test_deps = [
         ":double",
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
         "//sxt/curve_bng1/constant:generator",
         "//sxt/curve_bng1/property:curve",
         "//sxt/curve_bng1/property:identity",
         "//sxt/curve_bng1/type:element_affine",
+        "//sxt/field25/random:element",
         "//sxt/field25/type:element",
     ],
     deps = [
@@ -123,6 +125,8 @@ sxt_cc_component(
     ],
     is_cuda = True,
     test_deps = [
+        ":add",
+        ":double",
         "//sxt/base/test:unit_test",
         "//sxt/curve_bng1/constant:generator",
         "//sxt/curve_bng1/type:element_p2",

--- a/sxt/curve_bng1/operation/add.cc
+++ b/sxt/curve_bng1/operation/add.cc
@@ -34,41 +34,41 @@ namespace sxt::cn1o {
 // add
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_affine& q) noexcept {
-  f12t::element t0, t1, t2, t3, t4;
-  f12t::element x3, y3, z3;
+void add(cn1t::element_p2& h, const cn1t::element_p2& p, const cn1t::element_affine& q) noexcept {
+  f25t::element t0, t1, t2, t3, t4;
+  f25t::element x3, y3, z3;
 
-  f12o::mul(t0, p.X, q.X);
-  f12o::mul(t1, p.Y, q.Y);
-  f12o::add(t3, q.X, q.Y);
-  f12o::add(t4, p.X, p.Y);
-  f12o::mul(t3, t3, t4);
-  f12o::add(t4, t0, t1);
-  f12o::sub(t3, t3, t4);
-  f12o::mul(t4, q.Y, p.Z);
-  f12o::add(t4, t4, p.Y);
-  f12o::mul(y3, q.X, p.Z);
-  f12o::add(y3, y3, p.X);
-  f12o::add(x3, t0, t0);
-  f12o::add(t0, x3, t0);
+  f25o::mul(t0, p.X, q.X);
+  f25o::mul(t1, p.Y, q.Y);
+  f25o::add(t3, q.X, q.Y);
+  f25o::add(t4, p.X, p.Y);
+  f25o::mul(t3, t3, t4);
+  f25o::add(t4, t0, t1);
+  f25o::sub(t3, t3, t4);
+  f25o::mul(t4, q.Y, p.Z);
+  f25o::add(t4, t4, p.Y);
+  f25o::mul(y3, q.X, p.Z);
+  f25o::add(y3, y3, p.X);
+  f25o::add(x3, t0, t0);
+  f25o::add(t0, x3, t0);
   mul_by_3b(t2, p.Z);
-  f12o::add(z3, t1, t2);
-  f12o::sub(t1, t1, t2);
+  f25o::add(z3, t1, t2);
+  f25o::sub(t1, t1, t2);
   mul_by_3b(y3, y3);
-  f12o::mul(x3, t4, y3);
-  f12o::mul(t2, t3, t1);
-  f12o::sub(x3, t2, x3);
-  f12o::mul(y3, y3, t0);
-  f12o::mul(t1, t1, z3);
-  f12o::add(y3, t1, y3);
-  f12o::mul(t0, t0, t3);
-  f12o::mul(z3, z3, t4);
-  f12o::add(z3, z3, t0);
+  f25o::mul(x3, t4, y3);
+  f25o::mul(t2, t3, t1);
+  f25o::sub(x3, t2, x3);
+  f25o::mul(y3, y3, t0);
+  f25o::mul(t1, t1, z3);
+  f25o::add(y3, t1, y3);
+  f25o::mul(t0, t0, t3);
+  f25o::mul(z3, z3, t4);
+  f25o::add(z3, z3, t0);
 
   h.X = x3;
   h.Y = y3;
   h.Z = z3;
 
-  cmov(h, p, cg1p::is_identity(q));
+  cmov(h, p, cn1p::is_identity(q));
 }
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/add.cc
+++ b/sxt/curve_bng1/operation/add.cc
@@ -1,0 +1,74 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/operation/add.h"
+
+#include "sxt/curve_g1/operation/cmov.h"
+#include "sxt/curve_g1/property/identity.h"
+#include "sxt/curve_g1/type/element_affine.h"
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// add
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_affine& q) noexcept {
+  f12t::element t0, t1, t2, t3, t4;
+  f12t::element x3, y3, z3;
+
+  f12o::mul(t0, p.X, q.X);
+  f12o::mul(t1, p.Y, q.Y);
+  f12o::add(t3, q.X, q.Y);
+  f12o::add(t4, p.X, p.Y);
+  f12o::mul(t3, t3, t4);
+  f12o::add(t4, t0, t1);
+  f12o::sub(t3, t3, t4);
+  f12o::mul(t4, q.Y, p.Z);
+  f12o::add(t4, t4, p.Y);
+  f12o::mul(y3, q.X, p.Z);
+  f12o::add(y3, y3, p.X);
+  f12o::add(x3, t0, t0);
+  f12o::add(t0, x3, t0);
+  mul_by_3b(t2, p.Z);
+  f12o::add(z3, t1, t2);
+  f12o::sub(t1, t1, t2);
+  mul_by_3b(y3, y3);
+  f12o::mul(x3, t4, y3);
+  f12o::mul(t2, t3, t1);
+  f12o::sub(x3, t2, x3);
+  f12o::mul(y3, y3, t0);
+  f12o::mul(t1, t1, z3);
+  f12o::add(y3, t1, y3);
+  f12o::mul(t0, t0, t3);
+  f12o::mul(z3, z3, t4);
+  f12o::add(z3, z3, t0);
+
+  h.X = x3;
+  h.Y = y3;
+  h.Z = z3;
+
+  cmov(h, p, cg1p::is_identity(q));
+}
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/add.cc
+++ b/sxt/curve_bng1/operation/add.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,13 +23,13 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/operation/add.h"
+#include "sxt/curve_bng1/operation/add.h"
 
-#include "sxt/curve_g1/operation/cmov.h"
-#include "sxt/curve_g1/property/identity.h"
-#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_bng1/operation/cmov.h"
+#include "sxt/curve_bng1/property/identity.h"
+#include "sxt/curve_bng1/type/element_affine.h"
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // add
 //--------------------------------------------------------------------------------------------------
@@ -71,4 +71,4 @@ void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_aff
 
   cmov(h, p, cg1p::is_identity(q));
 }
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/add.h
+++ b/sxt/curve_bng1/operation/add.h
@@ -17,22 +17,22 @@
 #pragma once
 
 #include "sxt/base/macro/cuda_callable.h"
-#include "sxt/curve_g1/operation/mul_by_3b.h"
-#include "sxt/curve_g1/type/element_p2.h"
-#include "sxt/field12/operation/add.h"
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/operation/sub.h"
+#include "sxt/curve_bng1/operation/mul_by_3b.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/operation/add.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/operation/sub.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 struct element_affine;
-} // namespace sxt::cg1t
+}
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // add_inplace
 //--------------------------------------------------------------------------------------------------
-/*
- p = p + q
+/**
+ * p = p + q
  */
 CUDA_CALLABLE inline void add_inplace(cg1t::element_p2& p, const cg1t::element_p2& q) noexcept {
   f12t::element t0, t1, t2, t3, t4;
@@ -76,8 +76,8 @@ CUDA_CALLABLE inline void add_inplace(cg1t::element_p2& p, const cg1t::element_p
 //--------------------------------------------------------------------------------------------------
 // add
 //--------------------------------------------------------------------------------------------------
-/*
- Algorithm 7, https://eprint.iacr.org/2015/1060.pdf
+/**
+ * Algorithm 7, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
 void inline add(cg1t::element_p2& h, const cg1t::element_p2& p,
@@ -89,9 +89,9 @@ void inline add(cg1t::element_p2& h, const cg1t::element_p2& p,
 //--------------------------------------------------------------------------------------------------
 // add
 //--------------------------------------------------------------------------------------------------
-/*
- Algorithm 8, https://eprint.iacr.org/2015/1060.pdf
+/**
+ * Algorithm 8, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
 void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_affine& q) noexcept;
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/add.h
+++ b/sxt/curve_bng1/operation/add.h
@@ -34,43 +34,43 @@ namespace sxt::cn1o {
 /**
  * p = p + q
  */
-CUDA_CALLABLE inline void add_inplace(cg1t::element_p2& p, const cg1t::element_p2& q) noexcept {
-  f12t::element t0, t1, t2, t3, t4;
-  const f12t::element px{p.X};
+CUDA_CALLABLE inline void add_inplace(cn1t::element_p2& p, const cn1t::element_p2& q) noexcept {
+  f25t::element t0, t1, t2, t3, t4;
+  const f25t::element px{p.X};
 
-  f12o::mul(t0, p.X, q.X);
-  f12o::mul(t1, p.Y, q.Y);
-  f12o::mul(t2, p.Z, q.Z);
-  f12o::add(t3, p.X, p.Y);
-  f12o::add(t4, q.X, q.Y);
-  f12o::mul(t3, t3, t4);
-  f12o::add(t4, t0, t1);
-  f12o::sub(t3, t3, t4);
-  f12o::add(t4, p.Y, p.Z);
-  f12o::add(p.X, q.Y, q.Z);
-  f12o::mul(t4, t4, p.X);
-  f12o::add(p.X, t1, t2);
-  f12o::sub(t4, t4, p.X);
-  f12o::add(p.X, px, p.Z);
-  f12o::add(p.Y, q.X, q.Z);
-  f12o::mul(p.X, p.X, p.Y);
-  f12o::add(p.Y, t0, t2);
-  f12o::sub(p.Y, p.X, p.Y);
-  f12o::add(p.X, t0, t0);
-  f12o::add(t0, p.X, t0);
+  f25o::mul(t0, p.X, q.X);
+  f25o::mul(t1, p.Y, q.Y);
+  f25o::mul(t2, p.Z, q.Z);
+  f25o::add(t3, p.X, p.Y);
+  f25o::add(t4, q.X, q.Y);
+  f25o::mul(t3, t3, t4);
+  f25o::add(t4, t0, t1);
+  f25o::sub(t3, t3, t4);
+  f25o::add(t4, p.Y, p.Z);
+  f25o::add(p.X, q.Y, q.Z);
+  f25o::mul(t4, t4, p.X);
+  f25o::add(p.X, t1, t2);
+  f25o::sub(t4, t4, p.X);
+  f25o::add(p.X, px, p.Z);
+  f25o::add(p.Y, q.X, q.Z);
+  f25o::mul(p.X, p.X, p.Y);
+  f25o::add(p.Y, t0, t2);
+  f25o::sub(p.Y, p.X, p.Y);
+  f25o::add(p.X, t0, t0);
+  f25o::add(t0, p.X, t0);
   mul_by_3b(t2, t2);
-  f12o::add(p.Z, t1, t2);
-  f12o::sub(t1, t1, t2);
+  f25o::add(p.Z, t1, t2);
+  f25o::sub(t1, t1, t2);
   mul_by_3b(p.Y, p.Y);
-  f12o::mul(p.X, t4, p.Y);
-  f12o::mul(t2, t3, t1);
-  f12o::sub(p.X, t2, p.X);
-  f12o::mul(p.Y, p.Y, t0);
-  f12o::mul(t1, t1, p.Z);
-  f12o::add(p.Y, t1, p.Y);
-  f12o::mul(t0, t0, t3);
-  f12o::mul(p.Z, p.Z, t4);
-  f12o::add(p.Z, p.Z, t0);
+  f25o::mul(p.X, t4, p.Y);
+  f25o::mul(t2, t3, t1);
+  f25o::sub(p.X, t2, p.X);
+  f25o::mul(p.Y, p.Y, t0);
+  f25o::mul(t1, t1, p.Z);
+  f25o::add(p.Y, t1, p.Y);
+  f25o::mul(t0, t0, t3);
+  f25o::mul(p.Z, p.Z, t4);
+  f25o::add(p.Z, p.Z, t0);
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -80,8 +80,8 @@ CUDA_CALLABLE inline void add_inplace(cg1t::element_p2& p, const cg1t::element_p
  * Algorithm 7, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
-void inline add(cg1t::element_p2& h, const cg1t::element_p2& p,
-                const cg1t::element_p2& q) noexcept {
+void inline add(cn1t::element_p2& h, const cn1t::element_p2& p,
+                const cn1t::element_p2& q) noexcept {
   h = p;
   add_inplace(h, q);
 }
@@ -93,5 +93,5 @@ void inline add(cg1t::element_p2& h, const cg1t::element_p2& p,
  * Algorithm 8, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
-void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_affine& q) noexcept;
+void add(cn1t::element_p2& h, const cn1t::element_p2& p, const cn1t::element_affine& q) noexcept;
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/add.h
+++ b/sxt/curve_bng1/operation/add.h
@@ -1,0 +1,97 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/curve_g1/operation/mul_by_3b.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/operation/add.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/operation/sub.h"
+
+namespace sxt::cg1t {
+struct element_affine;
+} // namespace sxt::cg1t
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// add_inplace
+//--------------------------------------------------------------------------------------------------
+/*
+ p = p + q
+ */
+CUDA_CALLABLE inline void add_inplace(cg1t::element_p2& p, const cg1t::element_p2& q) noexcept {
+  f12t::element t0, t1, t2, t3, t4;
+  const f12t::element px{p.X};
+
+  f12o::mul(t0, p.X, q.X);
+  f12o::mul(t1, p.Y, q.Y);
+  f12o::mul(t2, p.Z, q.Z);
+  f12o::add(t3, p.X, p.Y);
+  f12o::add(t4, q.X, q.Y);
+  f12o::mul(t3, t3, t4);
+  f12o::add(t4, t0, t1);
+  f12o::sub(t3, t3, t4);
+  f12o::add(t4, p.Y, p.Z);
+  f12o::add(p.X, q.Y, q.Z);
+  f12o::mul(t4, t4, p.X);
+  f12o::add(p.X, t1, t2);
+  f12o::sub(t4, t4, p.X);
+  f12o::add(p.X, px, p.Z);
+  f12o::add(p.Y, q.X, q.Z);
+  f12o::mul(p.X, p.X, p.Y);
+  f12o::add(p.Y, t0, t2);
+  f12o::sub(p.Y, p.X, p.Y);
+  f12o::add(p.X, t0, t0);
+  f12o::add(t0, p.X, t0);
+  mul_by_3b(t2, t2);
+  f12o::add(p.Z, t1, t2);
+  f12o::sub(t1, t1, t2);
+  mul_by_3b(p.Y, p.Y);
+  f12o::mul(p.X, t4, p.Y);
+  f12o::mul(t2, t3, t1);
+  f12o::sub(p.X, t2, p.X);
+  f12o::mul(p.Y, p.Y, t0);
+  f12o::mul(t1, t1, p.Z);
+  f12o::add(p.Y, t1, p.Y);
+  f12o::mul(t0, t0, t3);
+  f12o::mul(p.Z, p.Z, t4);
+  f12o::add(p.Z, p.Z, t0);
+}
+
+//--------------------------------------------------------------------------------------------------
+// add
+//--------------------------------------------------------------------------------------------------
+/*
+ Algorithm 7, https://eprint.iacr.org/2015/1060.pdf
+ */
+CUDA_CALLABLE
+void inline add(cg1t::element_p2& h, const cg1t::element_p2& p,
+                const cg1t::element_p2& q) noexcept {
+  h = p;
+  add_inplace(h, q);
+}
+
+//--------------------------------------------------------------------------------------------------
+// add
+//--------------------------------------------------------------------------------------------------
+/*
+ Algorithm 8, https://eprint.iacr.org/2015/1060.pdf
+ */
+CUDA_CALLABLE
+void add(cg1t::element_p2& h, const cg1t::element_p2& p, const cg1t::element_affine& q) noexcept;
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/add.t.cc
+++ b/sxt/curve_bng1/operation/add.t.cc
@@ -14,20 +14,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/operation/add.h"
+#include "sxt/curve_bng1/operation/add.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/curve_g1/constant/generator.h"
-#include "sxt/curve_g1/operation/double.h"
-#include "sxt/curve_g1/property/curve.h"
-#include "sxt/curve_g1/property/identity.h"
-#include "sxt/curve_g1/type/element_affine.h"
-#include "sxt/curve_g1/type/element_p2.h"
-#include "sxt/field12/operation/mul.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/curve_bng1/constant/generator.h"
+#include "sxt/curve_bng1/operation/double.h"
+#include "sxt/curve_bng1/property/curve.h"
+#include "sxt/curve_bng1/property/identity.h"
+#include "sxt/curve_bng1/type/element_affine.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/type/element.h"
 
 using namespace sxt;
-using namespace sxt::cg1o;
+using namespace sxt::cn1o;
 
 TEST_CASE("addition with projective elements") {
   SECTION("keeps the identity on the curve") {

--- a/sxt/curve_bng1/operation/add.t.cc
+++ b/sxt/curve_bng1/operation/add.t.cc
@@ -16,6 +16,7 @@
  */
 #include "sxt/curve_bng1/operation/add.h"
 
+#include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/curve_bng1/constant/generator.h"
 #include "sxt/curve_bng1/operation/double.h"
@@ -24,6 +25,7 @@
 #include "sxt/curve_bng1/type/element_affine.h"
 #include "sxt/curve_bng1/type/element_p2.h"
 #include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
 #include "sxt/field25/type/element.h"
 
 using namespace sxt;
@@ -31,112 +33,116 @@ using namespace sxt::cn1o;
 
 TEST_CASE("addition with projective elements") {
   SECTION("keeps the identity on the curve") {
-    cg1t::element_p2 ret;
-    add(ret, cg1t::element_p2::identity(), cg1t::element_p2::identity());
+    cn1t::element_p2 ret;
+    add(ret, cn1t::element_p2::identity(), cn1t::element_p2::identity());
 
-    REQUIRE(cg1p::is_identity(ret));
-    REQUIRE(cg1p::is_on_curve(ret));
+    REQUIRE(cn1p::is_identity(ret));
+    REQUIRE(cn1p::is_on_curve(ret));
   }
 
   SECTION("is commutative") {
-    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
-                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
-    f12t::element x;
-    f12t::element y;
-    f12o::mul(x, cg1cn::generator_p2_v.X, z);
-    f12o::mul(y, cg1cn::generator_p2_v.Y, z);
-    const cg1t::element_p2 projected_generator{x, y, z};
-    cg1t::element_p2 ret;
+    f25t::element z;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(z, rng);
 
-    add(ret, cg1t::element_p2::identity(), projected_generator);
+    f25t::element x;
+    f25t::element y;
+    f25o::mul(x, cn1cn::generator_p2_v.X, z);
+    f25o::mul(y, cn1cn::generator_p2_v.Y, z);
+    const cn1t::element_p2 projected_generator{x, y, z};
+    cn1t::element_p2 ret;
 
-    REQUIRE(!cg1p::is_identity(ret));
-    REQUIRE(cg1p::is_on_curve(ret));
-    REQUIRE(cg1cn::generator_p2_v == ret);
+    add(ret, cn1t::element_p2::identity(), projected_generator);
+
+    REQUIRE(!cn1p::is_identity(ret));
+    REQUIRE(cn1p::is_on_curve(ret));
+    REQUIRE(cn1cn::generator_p2_v == ret);
 
     // Switch summands
-    add(ret, projected_generator, cg1t::element_p2::identity());
+    add(ret, projected_generator, cn1t::element_p2::identity());
 
-    REQUIRE(!cg1p::is_identity(ret));
-    REQUIRE(cg1p::is_on_curve(ret));
-    REQUIRE(cg1cn::generator_p2_v == ret);
+    REQUIRE(!cn1p::is_identity(ret));
+    REQUIRE(cn1p::is_on_curve(ret));
+    REQUIRE(cn1cn::generator_p2_v == ret);
   }
 
   SECTION("can reproduce doubling results") {
-    cg1t::element_p2 a;
-    cg1t::element_p2 b;
-    cg1t::element_p2 c;
+    cn1t::element_p2 a;
+    cn1t::element_p2 b;
+    cn1t::element_p2 c;
 
-    double_element(a, cg1cn::generator_p2_v); // a = 2g
+    double_element(a, cn1cn::generator_p2_v); // a = 2g
     double_element(a, a);                     // a = 4g
-    double_element(b, cg1cn::generator_p2_v); // b = 2g
+    double_element(b, cn1cn::generator_p2_v); // b = 2g
     add(c, a, b);                             // c = 6g
 
-    cg1t::element_p2 d{cg1cn::generator_p2_v};
+    cn1t::element_p2 d{cn1cn::generator_p2_v};
     for (size_t i = 1; i < 6; ++i) {
-      add(d, d, cg1cn::generator_p2_v);
+      add(d, d, cn1cn::generator_p2_v);
     }
 
-    REQUIRE(!cg1p::is_identity(c));
-    REQUIRE(cg1p::is_on_curve(c));
-    REQUIRE(!cg1p::is_identity(d));
-    REQUIRE(cg1p::is_on_curve(d));
+    REQUIRE(!cn1p::is_identity(c));
+    REQUIRE(cn1p::is_on_curve(c));
+    REQUIRE(!cn1p::is_identity(d));
+    REQUIRE(cn1p::is_on_curve(d));
     REQUIRE(c == d);
   }
 
   SECTION("can be done inplace") {
-    cg1t::element_p2 lhs{cg1t::element_p2::identity()};
-    cg1t::element_p2 rhs{cg1cn::generator_p2_v};
+    cn1t::element_p2 lhs{cn1t::element_p2::identity()};
+    cn1t::element_p2 rhs{cn1cn::generator_p2_v};
 
     add_inplace(lhs, rhs);
 
-    REQUIRE(lhs == cg1cn::generator_p2_v);
+    REQUIRE(lhs == cn1cn::generator_p2_v);
   }
 }
 
 TEST_CASE("addition with mixed elements") {
   SECTION("keeps the identity on the curve") {
-    cg1t::element_p2 ret;
-    add(ret, cg1t::element_p2::identity(), cg1t::element_affine::identity());
+    cn1t::element_p2 ret;
+    add(ret, cn1t::element_p2::identity(), cn1t::element_affine::identity());
 
-    REQUIRE(cg1p::is_identity(ret));
-    REQUIRE(cg1p::is_on_curve(ret));
+    REQUIRE(cn1p::is_identity(ret));
+    REQUIRE(cn1p::is_on_curve(ret));
   }
 
   SECTION("keeps the generator on the curve") {
-    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
-                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
-    f12t::element x;
-    f12t::element y;
-    f12o::mul(x, cg1cn::generator_p2_v.X, z);
-    f12o::mul(y, cg1cn::generator_p2_v.Y, z);
-    const cg1t::element_p2 projected_generator{x, y, z};
-    cg1t::element_p2 ret;
+    f25t::element z;
+    basn::fast_random_number_generator rng{1, 2};
+    f25rn::generate_random_element(z, rng);
 
-    add(ret, projected_generator, cg1t::element_affine::identity());
+    f25t::element x;
+    f25t::element y;
+    f25o::mul(x, cn1cn::generator_p2_v.X, z);
+    f25o::mul(y, cn1cn::generator_p2_v.Y, z);
+    const cn1t::element_p2 projected_generator{x, y, z};
+    cn1t::element_p2 ret;
 
-    REQUIRE(!cg1p::is_identity(ret));
-    REQUIRE(cg1p::is_on_curve(ret));
-    REQUIRE(cg1cn::generator_p2_v == ret);
+    add(ret, projected_generator, cn1t::element_affine::identity());
+
+    REQUIRE(!cn1p::is_identity(ret));
+    REQUIRE(cn1p::is_on_curve(ret));
+    REQUIRE(cn1cn::generator_p2_v == ret);
   }
 
   SECTION("can reproduce doubling results") {
-    cg1t::element_p2 a;
-    cg1t::element_p2 b;
-    cg1t::element_p2 c;
+    cn1t::element_p2 a;
+    cn1t::element_p2 b;
+    cn1t::element_p2 c;
 
-    double_element(a, cg1cn::generator_p2_v); // a = 2g
+    double_element(a, cn1cn::generator_p2_v); // a = 2g
     double_element(a, a);                     // a = 4g
-    double_element(b, cg1cn::generator_p2_v); // b = 2g
+    double_element(b, cn1cn::generator_p2_v); // b = 2g
     add(c, a, b);                             // c = 6g
 
-    cg1t::element_p2 d{cg1cn::generator_p2_v};
+    cn1t::element_p2 d{cn1cn::generator_p2_v};
     for (size_t i = 1; i < 6; ++i) {
-      add(d, d, cg1cn::generator_affine_v);
+      add(d, d, cn1cn::generator_affine_v);
     }
 
-    REQUIRE(!cg1p::is_identity(d));
-    REQUIRE(cg1p::is_on_curve(d));
+    REQUIRE(!cn1p::is_identity(d));
+    REQUIRE(cn1p::is_on_curve(d));
     REQUIRE(c == d);
   }
 }

--- a/sxt/curve_bng1/operation/add.t.cc
+++ b/sxt/curve_bng1/operation/add.t.cc
@@ -1,0 +1,142 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/operation/add.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/constant/generator.h"
+#include "sxt/curve_g1/operation/double.h"
+#include "sxt/curve_g1/property/curve.h"
+#include "sxt/curve_g1/property/identity.h"
+#include "sxt/curve_g1/type/element_affine.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/type/element.h"
+
+using namespace sxt;
+using namespace sxt::cg1o;
+
+TEST_CASE("addition with projective elements") {
+  SECTION("keeps the identity on the curve") {
+    cg1t::element_p2 ret;
+    add(ret, cg1t::element_p2::identity(), cg1t::element_p2::identity());
+
+    REQUIRE(cg1p::is_identity(ret));
+    REQUIRE(cg1p::is_on_curve(ret));
+  }
+
+  SECTION("is commutative") {
+    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
+                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+    f12t::element x;
+    f12t::element y;
+    f12o::mul(x, cg1cn::generator_p2_v.X, z);
+    f12o::mul(y, cg1cn::generator_p2_v.Y, z);
+    const cg1t::element_p2 projected_generator{x, y, z};
+    cg1t::element_p2 ret;
+
+    add(ret, cg1t::element_p2::identity(), projected_generator);
+
+    REQUIRE(!cg1p::is_identity(ret));
+    REQUIRE(cg1p::is_on_curve(ret));
+    REQUIRE(cg1cn::generator_p2_v == ret);
+
+    // Switch summands
+    add(ret, projected_generator, cg1t::element_p2::identity());
+
+    REQUIRE(!cg1p::is_identity(ret));
+    REQUIRE(cg1p::is_on_curve(ret));
+    REQUIRE(cg1cn::generator_p2_v == ret);
+  }
+
+  SECTION("can reproduce doubling results") {
+    cg1t::element_p2 a;
+    cg1t::element_p2 b;
+    cg1t::element_p2 c;
+
+    double_element(a, cg1cn::generator_p2_v); // a = 2g
+    double_element(a, a);                     // a = 4g
+    double_element(b, cg1cn::generator_p2_v); // b = 2g
+    add(c, a, b);                             // c = 6g
+
+    cg1t::element_p2 d{cg1cn::generator_p2_v};
+    for (size_t i = 1; i < 6; ++i) {
+      add(d, d, cg1cn::generator_p2_v);
+    }
+
+    REQUIRE(!cg1p::is_identity(c));
+    REQUIRE(cg1p::is_on_curve(c));
+    REQUIRE(!cg1p::is_identity(d));
+    REQUIRE(cg1p::is_on_curve(d));
+    REQUIRE(c == d);
+  }
+
+  SECTION("can be done inplace") {
+    cg1t::element_p2 lhs{cg1t::element_p2::identity()};
+    cg1t::element_p2 rhs{cg1cn::generator_p2_v};
+
+    add_inplace(lhs, rhs);
+
+    REQUIRE(lhs == cg1cn::generator_p2_v);
+  }
+}
+
+TEST_CASE("addition with mixed elements") {
+  SECTION("keeps the identity on the curve") {
+    cg1t::element_p2 ret;
+    add(ret, cg1t::element_p2::identity(), cg1t::element_affine::identity());
+
+    REQUIRE(cg1p::is_identity(ret));
+    REQUIRE(cg1p::is_on_curve(ret));
+  }
+
+  SECTION("keeps the generator on the curve") {
+    constexpr f12t::element z{0xba7afa1f9a6fe250, 0xfa0f5b595eafe731, 0x3bdc477694c306e7,
+                              0x2149be4b3949fa24, 0x64aa6e0649b2078c, 0x12b108ac33643c3e};
+    f12t::element x;
+    f12t::element y;
+    f12o::mul(x, cg1cn::generator_p2_v.X, z);
+    f12o::mul(y, cg1cn::generator_p2_v.Y, z);
+    const cg1t::element_p2 projected_generator{x, y, z};
+    cg1t::element_p2 ret;
+
+    add(ret, projected_generator, cg1t::element_affine::identity());
+
+    REQUIRE(!cg1p::is_identity(ret));
+    REQUIRE(cg1p::is_on_curve(ret));
+    REQUIRE(cg1cn::generator_p2_v == ret);
+  }
+
+  SECTION("can reproduce doubling results") {
+    cg1t::element_p2 a;
+    cg1t::element_p2 b;
+    cg1t::element_p2 c;
+
+    double_element(a, cg1cn::generator_p2_v); // a = 2g
+    double_element(a, a);                     // a = 4g
+    double_element(b, cg1cn::generator_p2_v); // b = 2g
+    add(c, a, b);                             // c = 6g
+
+    cg1t::element_p2 d{cg1cn::generator_p2_v};
+    for (size_t i = 1; i < 6; ++i) {
+      add(d, d, cg1cn::generator_affine_v);
+    }
+
+    REQUIRE(!cg1p::is_identity(d));
+    REQUIRE(cg1p::is_on_curve(d));
+    REQUIRE(c == d);
+  }
+}

--- a/sxt/curve_bng1/operation/neg.cc
+++ b/sxt/curve_bng1/operation/neg.cc
@@ -1,0 +1,53 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/operation/neg.h"
+
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/field12/operation/cmov.h"
+#include "sxt/field12/operation/neg.h"
+#include "sxt/field12/type/element.h"
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// neg
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept {
+  r.X = p.X;
+  f12o::neg(r.Y, p.Y);
+  r.Z = p.Z;
+}
+
+//--------------------------------------------------------------------------------------------------
+// cneg
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void cneg(cg1t::element_p2& r, unsigned int b) noexcept {
+  f12t::element t;
+  f12o::neg(t, r.Y);
+  f12o::cmov(r.Y, t, b);
+}
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/neg.cc
+++ b/sxt/curve_bng1/operation/neg.cc
@@ -35,9 +35,9 @@ namespace sxt::cn1o {
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept {
+void neg(cn1t::element_p2& r, const cn1t::element_p2& p) noexcept {
   r.X = p.X;
-  f12o::neg(r.Y, p.Y);
+  f25o::neg(r.Y, p.Y);
   r.Z = p.Z;
 }
 
@@ -45,9 +45,9 @@ void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept {
 // cneg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void cneg(cg1t::element_p2& r, unsigned int b) noexcept {
-  f12t::element t;
-  f12o::neg(t, r.Y);
-  f12o::cmov(r.Y, t, b);
+void cneg(cn1t::element_p2& r, unsigned int b) noexcept {
+  f25t::element t;
+  f25o::neg(t, r.Y);
+  f25o::cmov(r.Y, t, b);
 }
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/neg.cc
+++ b/sxt/curve_bng1/operation/neg.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,14 +23,14 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/operation/neg.h"
+#include "sxt/curve_bng1/operation/neg.h"
 
-#include "sxt/curve_g1/type/element_p2.h"
-#include "sxt/field12/operation/cmov.h"
-#include "sxt/field12/operation/neg.h"
-#include "sxt/field12/type/element.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/field25/operation/cmov.h"
+#include "sxt/field25/operation/neg.h"
+#include "sxt/field25/type/element.h"
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
@@ -50,4 +50,4 @@ void cneg(cg1t::element_p2& r, unsigned int b) noexcept {
   f12o::neg(t, r.Y);
   f12o::cmov(r.Y, t, b);
 }
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/neg.h
+++ b/sxt/curve_bng1/operation/neg.h
@@ -27,7 +27,7 @@ namespace sxt::cn1o {
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept;
+void neg(cn1t::element_p2& r, const cn1t::element_p2& p) noexcept;
 
 //--------------------------------------------------------------------------------------------------
 // cneg
@@ -36,5 +36,5 @@ void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept;
  * r = -r if b = 1 else r
  */
 CUDA_CALLABLE
-void cneg(cg1t::element_p2& r, unsigned int b) noexcept;
+void cneg(cn1t::element_p2& r, unsigned int b) noexcept;
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/neg.h
+++ b/sxt/curve_bng1/operation/neg.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::cg1t {
+struct element_p2;
+}
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// neg
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// cneg
+//--------------------------------------------------------------------------------------------------
+/*
+ r = -r if b = 1 else r
+ */
+CUDA_CALLABLE
+void cneg(cg1t::element_p2& r, unsigned int b) noexcept;
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/neg.h
+++ b/sxt/curve_bng1/operation/neg.h
@@ -18,11 +18,11 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 struct element_p2;
 }
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
@@ -32,9 +32,9 @@ void neg(cg1t::element_p2& r, const cg1t::element_p2& p) noexcept;
 //--------------------------------------------------------------------------------------------------
 // cneg
 //--------------------------------------------------------------------------------------------------
-/*
- r = -r if b = 1 else r
+/**
+ * r = -r if b = 1 else r
  */
 CUDA_CALLABLE
 void cneg(cg1t::element_p2& r, unsigned int b) noexcept;
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/neg.t.cc
+++ b/sxt/curve_bng1/operation/neg.t.cc
@@ -26,26 +26,26 @@ using namespace sxt::cn1o;
 
 TEST_CASE("negation on projective elements") {
   SECTION("produces the identity when summing the generator with its negation") {
-    cg1t::element_p2 gen_neg;
-    neg(gen_neg, cg1cn::generator_p2_v);
+    cn1t::element_p2 gen_neg;
+    neg(gen_neg, cn1cn::generator_p2_v);
 
-    cg1t::element_p2 expect_identity;
-    add(expect_identity, cg1cn::generator_p2_v, gen_neg);
+    cn1t::element_p2 expect_identity;
+    add(expect_identity, cn1cn::generator_p2_v, gen_neg);
 
-    REQUIRE(expect_identity == cg1t::element_p2::identity());
+    REQUIRE(expect_identity == cn1t::element_p2::identity());
   }
 
   SECTION("can be done inplace") {
-    cg1t::element_p2 ng;
-    neg(ng, cg1cn::generator_p2_v);
-    cg1t::element_p2 g{cg1cn::generator_p2_v};
+    cn1t::element_p2 ng;
+    neg(ng, cn1cn::generator_p2_v);
+    cn1t::element_p2 g{cn1cn::generator_p2_v};
     cneg(g, 1);
 
     REQUIRE(g == ng);
 
-    g = cg1cn::generator_p2_v;
+    g = cn1cn::generator_p2_v;
     cneg(g, 0);
 
-    REQUIRE(g == cg1cn::generator_p2_v);
+    REQUIRE(g == cn1cn::generator_p2_v);
   }
 }

--- a/sxt/curve_bng1/operation/neg.t.cc
+++ b/sxt/curve_bng1/operation/neg.t.cc
@@ -1,0 +1,51 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/operation/neg.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/constant/generator.h"
+#include "sxt/curve_g1/operation/add.h"
+#include "sxt/curve_g1/type/element_p2.h"
+
+using namespace sxt;
+using namespace sxt::cg1o;
+
+TEST_CASE("negation on projective elements") {
+  SECTION("produces the identity when summing the generator with its negation") {
+    cg1t::element_p2 gen_neg;
+    neg(gen_neg, cg1cn::generator_p2_v);
+
+    cg1t::element_p2 expect_identity;
+    add(expect_identity, cg1cn::generator_p2_v, gen_neg);
+
+    REQUIRE(expect_identity == cg1t::element_p2::identity());
+  }
+
+  SECTION("can be done inplace") {
+    cg1t::element_p2 ng;
+    neg(ng, cg1cn::generator_p2_v);
+    cg1t::element_p2 g{cg1cn::generator_p2_v};
+    cneg(g, 1);
+
+    REQUIRE(g == ng);
+
+    g = cg1cn::generator_p2_v;
+    cneg(g, 0);
+
+    REQUIRE(g == cg1cn::generator_p2_v);
+  }
+}

--- a/sxt/curve_bng1/operation/neg.t.cc
+++ b/sxt/curve_bng1/operation/neg.t.cc
@@ -14,15 +14,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/operation/neg.h"
+#include "sxt/curve_bng1/operation/neg.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/curve_g1/constant/generator.h"
-#include "sxt/curve_g1/operation/add.h"
-#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/curve_bng1/constant/generator.h"
+#include "sxt/curve_bng1/operation/add.h"
+#include "sxt/curve_bng1/type/element_p2.h"
 
 using namespace sxt;
-using namespace sxt::cg1o;
+using namespace sxt::cn1o;
 
 TEST_CASE("negation on projective elements") {
   SECTION("produces the identity when summing the generator with its negation") {

--- a/sxt/curve_bng1/operation/scalar_multiply.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.cc
@@ -64,18 +64,18 @@ static bool get_first_one_bit(int& first_one_byte, int& first_one_bit,
 // scalar_multiply_impl
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-static void scalar_multiply_impl(cg1t::element_p2& h, const cg1t::element_p2& p,
+static void scalar_multiply_impl(cn1t::element_p2& h, const cn1t::element_p2& p,
                                  const uint8_t q[32], const int first_one_byte,
                                  const int first_one_bit) noexcept {
-  cg1t::element_p2 acc{cg1t::element_p2::identity()};
+  cn1t::element_p2 acc{cn1t::element_p2::identity()};
   int starting_bit{first_one_bit};
 
   for (int byte_index = first_one_byte; byte_index >= 0; --byte_index) {
     auto byte = q[byte_index];
     for (int bit_index = starting_bit; bit_index >= 0; --bit_index) {
-      cg1o::double_element(acc, acc);
+      double_element(acc, acc);
       if ((byte >> bit_index) & 1) {
-        cg1o::add(acc, acc, p);
+        add(acc, acc, p);
       }
     }
     starting_bit = 7; // reset starting bit for the remainder of bytes
@@ -88,7 +88,7 @@ static void scalar_multiply_impl(cg1t::element_p2& h, const cg1t::element_p2& p,
 // scalar_multiply255
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
+void scalar_multiply255(cn1t::element_p2& h, const cn1t::element_p2& p,
                         const uint8_t q[32]) noexcept {
   int first_one_byte{0};
   int first_one_bit{0};
@@ -96,7 +96,7 @@ void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
   if (get_first_one_bit(first_one_byte, first_one_bit, q)) {
     scalar_multiply_impl(h, p, q, first_one_byte, first_one_bit);
   } else {
-    h = cg1t::element_p2::identity();
+    h = cn1t::element_p2::identity();
   }
 }
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/scalar_multiply.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.cc
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/*
+/**
  * Adopted from zkcrypto/bls12_381
  *
  * Copyright (c) 2021
@@ -23,13 +23,13 @@
  *
  * See third_party/license/zkcrypto.LICENSE
  */
-#include "sxt/curve_g1/operation/scalar_multiply.h"
+#include "sxt/curve_bng1/operation/scalar_multiply.h"
 
-#include "sxt/curve_g1/operation/add.h"
-#include "sxt/curve_g1/operation/double.h"
-#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/curve_bng1/operation/add.h"
+#include "sxt/curve_bng1/operation/double.h"
+#include "sxt/curve_bng1/type/element_p2.h"
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // is_first_bit
 //--------------------------------------------------------------------------------------------------
@@ -99,4 +99,4 @@ void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
     h = cg1t::element_p2::identity();
   }
 }
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/scalar_multiply.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.cc
@@ -1,0 +1,102 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
+#include "sxt/curve_g1/operation/scalar_multiply.h"
+
+#include "sxt/curve_g1/operation/add.h"
+#include "sxt/curve_g1/operation/double.h"
+#include "sxt/curve_g1/type/element_p2.h"
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// is_first_bit
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+static bool inline is_first_bit(const int first_byte, const int first_bit) noexcept {
+  return first_byte == 31 && first_bit == 7;
+}
+
+//--------------------------------------------------------------------------------------------------
+// get_first_one_bit
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+static bool get_first_one_bit(int& first_one_byte, int& first_one_bit,
+                              const uint8_t q[32]) noexcept {
+  for (int byte_index = 31; byte_index >= 0; --byte_index) {
+    auto byte = q[byte_index];
+    for (int bit_index = 7; bit_index >= 0; --bit_index) {
+      if (((byte >> bit_index) & 1) && !is_first_bit(byte_index, bit_index)) {
+        first_one_byte = byte_index;
+        first_one_bit = bit_index;
+        return true;
+      }
+    }
+  }
+
+  first_one_byte = -1;
+  first_one_bit = -1;
+  return false;
+}
+
+//--------------------------------------------------------------------------------------------------
+// scalar_multiply_impl
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+static void scalar_multiply_impl(cg1t::element_p2& h, const cg1t::element_p2& p,
+                                 const uint8_t q[32], const int first_one_byte,
+                                 const int first_one_bit) noexcept {
+  cg1t::element_p2 acc{cg1t::element_p2::identity()};
+  int starting_bit{first_one_bit};
+
+  for (int byte_index = first_one_byte; byte_index >= 0; --byte_index) {
+    auto byte = q[byte_index];
+    for (int bit_index = starting_bit; bit_index >= 0; --bit_index) {
+      cg1o::double_element(acc, acc);
+      if ((byte >> bit_index) & 1) {
+        cg1o::add(acc, acc, p);
+      }
+    }
+    starting_bit = 7; // reset starting bit for the remainder of bytes
+  }
+
+  h = acc;
+}
+
+//--------------------------------------------------------------------------------------------------
+// scalar_multiply255
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
+                        const uint8_t q[32]) noexcept {
+  int first_one_byte{0};
+  int first_one_bit{0};
+
+  if (get_first_one_bit(first_one_byte, first_one_bit, q)) {
+    scalar_multiply_impl(h, p, q, first_one_byte, first_one_bit);
+  } else {
+    h = cg1t::element_p2::identity();
+  }
+}
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/scalar_multiply.h
+++ b/sxt/curve_bng1/operation/scalar_multiply.h
@@ -35,6 +35,6 @@ namespace sxt::cn1o {
  * been reduced.
  */
 CUDA_CALLABLE
-void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
+void scalar_multiply255(cn1t::element_p2& h, const cn1t::element_p2& p,
                         const uint8_t q[32]) noexcept;
 } // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/scalar_multiply.h
+++ b/sxt/curve_bng1/operation/scalar_multiply.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::cg1t {
+struct element_p2;
+}
+
+namespace sxt::cg1o {
+//--------------------------------------------------------------------------------------------------
+// scalar_multiply255
+//--------------------------------------------------------------------------------------------------
+/*
+ This is a simple double-and-add implementation of point multiplication, moving from most
+ significant to least significant bit of the scalar. We skip the leading bit because it's
+ always unset for Fq elements. Assumes the scalar q is little endian and the exponent has already
+ been reduced.
+*/
+CUDA_CALLABLE
+void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
+                        const uint8_t q[32]) noexcept;
+} // namespace sxt::cg1o

--- a/sxt/curve_bng1/operation/scalar_multiply.h
+++ b/sxt/curve_bng1/operation/scalar_multiply.h
@@ -20,21 +20,21 @@
 
 #include "sxt/base/macro/cuda_callable.h"
 
-namespace sxt::cg1t {
+namespace sxt::cn1t {
 struct element_p2;
 }
 
-namespace sxt::cg1o {
+namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
 // scalar_multiply255
 //--------------------------------------------------------------------------------------------------
-/*
- This is a simple double-and-add implementation of point multiplication, moving from most
- significant to least significant bit of the scalar. We skip the leading bit because it's
- always unset for Fq elements. Assumes the scalar q is little endian and the exponent has already
- been reduced.
-*/
+/**
+ * This is a simple double-and-add implementation of point multiplication, moving from most
+ * significant to least significant bit of the scalar. We skip the leading bit because it's
+ * always unset for Fq elements. Assumes the scalar q is little endian and the exponent has already
+ * been reduced.
+ */
 CUDA_CALLABLE
 void scalar_multiply255(cg1t::element_p2& h, const cg1t::element_p2& p,
                         const uint8_t q[32]) noexcept;
-} // namespace sxt::cg1o
+} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/scalar_multiply.t.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.t.cc
@@ -18,6 +18,8 @@
 
 #include "sxt/base/test/unit_test.h"
 #include "sxt/curve_bng1/constant/generator.h"
+#include "sxt/curve_bng1/operation/add.h"
+#include "sxt/curve_bng1/operation/double.h"
 #include "sxt/curve_bng1/type/element_p2.h"
 
 using namespace sxt;
@@ -28,52 +30,69 @@ TEST_CASE("scalar multiplication returns") {
     constexpr std::array<uint8_t, 32> a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                         0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    cg1t::element_p2 ret;
+    cn1t::element_p2 ret;
 
-    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+    scalar_multiply255(ret, cn1cn::generator_p2_v, a.data());
 
-    REQUIRE(cg1t::element_p2::identity() == ret);
-  }
-
-  SECTION("the identity if only the first bit is 1") {
-    constexpr std::array<uint8_t, 32> a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
-                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80};
-    cg1t::element_p2 ret;
-
-    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
-
-    REQUIRE(cg1t::element_p2::identity() == ret);
+    REQUIRE(cn1t::element_p2::identity() == ret);
   }
 
   SECTION("the same value if the scalar is one") {
     constexpr std::array<uint8_t, 32> a{0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                         0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
                                         0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
-    cg1t::element_p2 ret;
+    cn1t::element_p2 ret;
 
-    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+    scalar_multiply255(ret, cn1cn::generator_p2_v, a.data());
 
-    REQUIRE(cg1cn::generator_p2_v == ret);
+    REQUIRE(cn1cn::generator_p2_v == ret);
   }
 
-  SECTION("the expected pre-computed value") {
-    constexpr std::array<uint8_t, 32> a{0x1b, 0xa7, 0x6d, 0xa5, 0x98, 0x82, 0x56, 0x2b,
-                                        0xd2, 0x19, 0xf5, 0xe,  0xc8, 0xfa, 0x5,  0x85,
-                                        0x91, 0xe7, 0x1d, 0x5e, 0xd2, 0x60, 0x22, 0x10,
-                                        0x6a, 0xdc, 0x18, 0xfd, 0xfc, 0xf8, 0x9a, 0xc};
+  SECTION("2G if the scalar is two") {
+    constexpr std::array<uint8_t, 32> a{0x02, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
 
-    constexpr cg1t::element_p2 expected{{0xa80565e509d658c5, 0xff0b490d2a6da917, 0xf178d3cd7d4ff503,
-                                         0xbb1dcbc2d53ddf89, 0x6d4bca121da390f7, 0xa40068d3eaaef89},
-                                        {0x6fae81a2c5d9320f, 0x127185de1966cef9, 0xfa1a4697641b53ef,
-                                         0x59db1d37761ab56d, 0xebc9e60da366ab0f, 0x9574ab82b0a5f75},
-                                        {0xb25fa910e5757174, 0xf51ff09386bdbb6a, 0x5a603696e84b08ff,
-                                         0x6bcedba19d0c2e30, 0xc1fe7e38dfd460cf,
-                                         0xb6f9f61a7f4a36e}};
-    cg1t::element_p2 ret;
+    cn1t::element_p2 ret_scalar;
+    scalar_multiply255(ret_scalar, cn1cn::generator_p2_v, a.data());
 
-    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+    cn1t::element_p2 g_2_add;
+    add(g_2_add, cn1cn::generator_p2_v, cn1cn::generator_p2_v);
 
-    REQUIRE(expected == ret);
+    cn1t::element_p2 g_2_double;
+    double_element(g_2_double, cn1cn::generator_p2_v);
+
+    REQUIRE(ret_scalar == g_2_add);
+    REQUIRE(ret_scalar == g_2_double);
+    REQUIRE(ret_scalar != cn1t::element_p2::identity());
+  }
+
+  SECTION("4G if the scalar is four") {
+    constexpr std::array<uint8_t, 32> a{0x04, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+
+    cn1t::element_p2 ret_scalar;
+    scalar_multiply255(ret_scalar, cn1cn::generator_p2_v, a.data());
+
+    cn1t::element_p2 g_2;
+    cn1t::element_p2 g_4;
+    add(g_2, cn1cn::generator_p2_v, cn1cn::generator_p2_v);
+    double_element(g_4, g_2);
+
+    REQUIRE(ret_scalar == g_4);
+    REQUIRE(ret_scalar != cn1t::element_p2::identity());
+  }
+
+  SECTION("the scalar modulus to return zero") {
+    constexpr std::array<uint8_t, 32> a{0x01, 0x00, 0x00, 0xf0, 0x93, 0xf5, 0xe1, 0x43,
+                                        0x91, 0x70, 0xb9, 0x79, 0x48, 0xe8, 0x33, 0x28,
+                                        0x5d, 0x58, 0x81, 0x81, 0xb6, 0x45, 0x50, 0xb8,
+                                        0x29, 0xa0, 0x31, 0xe1, 0x72, 0x4e, 0x64, 0x30};
+    cn1t::element_p2 ret;
+
+    scalar_multiply255(ret, cn1cn::generator_p2_v, a.data());
+
+    REQUIRE(cn1t::element_p2::identity() == ret);
   }
 }

--- a/sxt/curve_bng1/operation/scalar_multiply.t.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.t.cc
@@ -14,14 +14,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "sxt/curve_g1/operation/scalar_multiply.h"
+#include "sxt/curve_bng1/operation/scalar_multiply.h"
 
 #include "sxt/base/test/unit_test.h"
-#include "sxt/curve_g1/constant/generator.h"
-#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/curve_bng1/constant/generator.h"
+#include "sxt/curve_bng1/type/element_p2.h"
 
 using namespace sxt;
-using namespace sxt::cg1o;
+using namespace sxt::cn1o;
 
 TEST_CASE("scalar multiplication returns") {
   SECTION("the identity if the scalar is zero") {

--- a/sxt/curve_bng1/operation/scalar_multiply.t.cc
+++ b/sxt/curve_bng1/operation/scalar_multiply.t.cc
@@ -1,0 +1,79 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/operation/scalar_multiply.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/constant/generator.h"
+#include "sxt/curve_g1/type/element_p2.h"
+
+using namespace sxt;
+using namespace sxt::cg1o;
+
+TEST_CASE("scalar multiplication returns") {
+  SECTION("the identity if the scalar is zero") {
+    constexpr std::array<uint8_t, 32> a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    cg1t::element_p2 ret;
+
+    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+
+    REQUIRE(cg1t::element_p2::identity() == ret);
+  }
+
+  SECTION("the identity if only the first bit is 1") {
+    constexpr std::array<uint8_t, 32> a{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x80};
+    cg1t::element_p2 ret;
+
+    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+
+    REQUIRE(cg1t::element_p2::identity() == ret);
+  }
+
+  SECTION("the same value if the scalar is one") {
+    constexpr std::array<uint8_t, 32> a{0x01, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
+                                        0x0,  0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0};
+    cg1t::element_p2 ret;
+
+    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+
+    REQUIRE(cg1cn::generator_p2_v == ret);
+  }
+
+  SECTION("the expected pre-computed value") {
+    constexpr std::array<uint8_t, 32> a{0x1b, 0xa7, 0x6d, 0xa5, 0x98, 0x82, 0x56, 0x2b,
+                                        0xd2, 0x19, 0xf5, 0xe,  0xc8, 0xfa, 0x5,  0x85,
+                                        0x91, 0xe7, 0x1d, 0x5e, 0xd2, 0x60, 0x22, 0x10,
+                                        0x6a, 0xdc, 0x18, 0xfd, 0xfc, 0xf8, 0x9a, 0xc};
+
+    constexpr cg1t::element_p2 expected{{0xa80565e509d658c5, 0xff0b490d2a6da917, 0xf178d3cd7d4ff503,
+                                         0xbb1dcbc2d53ddf89, 0x6d4bca121da390f7, 0xa40068d3eaaef89},
+                                        {0x6fae81a2c5d9320f, 0x127185de1966cef9, 0xfa1a4697641b53ef,
+                                         0x59db1d37761ab56d, 0xebc9e60da366ab0f, 0x9574ab82b0a5f75},
+                                        {0xb25fa910e5757174, 0xf51ff09386bdbb6a, 0x5a603696e84b08ff,
+                                         0x6bcedba19d0c2e30, 0xc1fe7e38dfd460cf,
+                                         0xb6f9f61a7f4a36e}};
+    cg1t::element_p2 ret;
+
+    scalar_multiply255(ret, cg1cn::generator_p2_v, a.data());
+
+    REQUIRE(expected == ret);
+  }
+}


### PR DESCRIPTION
# Rationale for this change
In order to support MSM with `G1` elements on the `bn254` curve we need to implement the curve package. This work will introduce the `add`, `neg`, and `scalar_multiply` to the `bn254` operation package. The components are copied from the `curve_g1/operation` package, which supports the `bls12-381` curve. The components are updated to support the `bn254` `G1` curve.

Non-trivial changes are isolated to [this commit](https://github.com/spaceandtimelabs/blitzar/commit/5701fdcae321b2ec8d561bcb419d0f5fd046eda4).

# What changes are included in this PR?
- `add`, `neg`, and `scalar_multiply` components and tests are copied from `curve_g1/operation` and updated to support `bn254` `G1` curve elements.

# Are these changes tested?
Yes