### PR TITLE
docs: format the Rust docs (PROOF-786)

### DIFF
--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -42,7 +42,7 @@ struct sxt_bls12_381_g1_compressed {
 };
 
 /** encodes an element of the finite field for `curve25519`
- * 
+ *
  * modulo `(2^252 + 27742317777372353535851937790883648493)`
  */
 struct sxt_curve25519_scalar {
@@ -96,7 +96,7 @@ struct sxt_sequence_descriptor {
 
 /**
  * Initializes the library.
- * 
+ *
  * This should only be called once.
  *
  * # Arguments:

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -316,7 +316,7 @@ int sxt_ristretto255_get_generators(struct sxt_ristretto255* generators, uint64_
  *
  * The `n`-th Ristretto point is defined as:
  *
- * ```rust
+ * ```text
  * if n == 0:
  *    one_commit[0] = ristretto_identity;
  * else:
@@ -325,7 +325,7 @@ int sxt_ristretto255_get_generators(struct sxt_ristretto255* generators, uint64_
  *
  * where
  *
- * ```rust
+ * ```text
  * struct sxt_ristretto255 ristretto_identity = {
  *    {0, 0, 0, 0, 0},
  *    {1, 0, 0, 0, 0},

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -25,98 +25,104 @@ extern "C" {
 #define SXT_CPU_BACKEND 1
 #define SXT_GPU_BACKEND 2
 
-/** config struct to hold the chosen backend **/
+/** config struct to hold the chosen backend */
 struct sxt_config {
   int backend;
   uint64_t num_precomputed_generators;
 };
 
+/** encodes an element of the `ristretto255` group */
 struct sxt_ristretto255_compressed {
-  // encodes an element of the ristretto255 group
   uint8_t ristretto_bytes[32];
 };
 
+/** encodes an element of the `bls12-381` `G1` group in compressed form */
 struct sxt_bls12_381_g1_compressed {
-  // encodes an element of the bls12-381 G1 group
   uint8_t g1_bytes[48];
 };
 
+/** encodes an element of the finite field for `curve25519`
+ * 
+ * modulo `(2^252 + 27742317777372353535851937790883648493)`
+ */
 struct sxt_curve25519_scalar {
-  // encodes an element of the finite field modulo (2^252 + 27742317777372353535851937790883648493)
   uint8_t bytes[32];
 };
 
+/** encodes a strobe-based transcript */
 struct sxt_transcript {
-  // encodes a strobe-based transcript
   uint8_t bytes[203];
 };
 
+/** encodes an element of the `curve25519` group */
 struct sxt_ristretto255 {
-  // encodes an element of the curve255 group
   uint64_t X[5];
   uint64_t Y[5];
   uint64_t Z[5];
   uint64_t T[5];
 };
 
+/** encodes an affine element of the `bls12-381` `G1` group */
 struct sxt_bls12_381_g1 {
-  // encodes an affine element of the bls12-381 G1 group
   uint64_t X[6];
   uint64_t Y[6];
 };
 
+/** encodes an affine element of the `bn254` `G1` group */
 struct sxt_bn254_g1 {
-  // encodes an affine element of the bn254 G1 group
   uint64_t X[4];
   uint64_t Y[4];
   uint8_t infinity;
 };
 
-/** describes a sequence of values **/
+/** describes a sequence of values */
 struct sxt_sequence_descriptor {
-  // the number of bytes used to represent an element in the sequence
-  // element_nbytes must be a power of 2 and must satisfy 1 <= element_nbytes <= 32
+  // The number of bytes used to represent an element in the sequence.
+  // `element_nbytes` must be a power of `2` and must satisfy `1 <= element_nbytes <= 32`.
   uint8_t element_nbytes;
 
-  // the number of elements in the sequence
+  // The number of elements in the sequence.
   uint64_t n;
 
-  // pointer to the data for the sequence of elements where there are n elements
-  // in the sequence and each element encodes a number of element_nbytes bytes
-  // represented in the little endian format
+  // Pointer to the data for the sequence of elements where there are `n` elements
+  // in the sequence and each element encodes a number of `element_nbytes` bytes
+  // represented in the little endian format.
   const uint8_t* data;
 
-  // whether the elements are signed
-  // Note: if signed, then element_nbytes must be <= 16
+  // Whether the elements are signed.
+  // Note: if signed, then `element_nbytes` must be `<= 16`.
   int is_signed;
 };
 
 /**
- * Initialize the library. This should only be called once.
+ * Initializes the library.
+ * 
+ * This should only be called once.
  *
- * Arguments:
+ * # Arguments:
  *
  * - config (in): specifies which backend should be used in the computations. Those
- *   available are: SXT_GPU_BACKEND, and SXT_CPU_BACKEND
+ *   available are: `SXT_GPU_BACKEND`, and `SXT_CPU_BACKEND`.
  *
  * # Return:
  *
- * - 0 on success; otherwise a nonzero error code
+ * - `0` on success; otherwise a nonzero error code
  */
 int sxt_init(const struct sxt_config* config);
 
 /**
- * Compute the Pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values that internally generates `curve25519`
+ * group elements.
  *
- * Denote an element of a sequence by a_ij where i represents the sequence index
- * and j represents the element index. Let * represent the operator for the
- * ristretto255 group. Then res\[i] encodes the ristretto255 group value
+ * Denote an element of a sequence by `a_ij` where `i` represents the sequence index
+ * and `j` represents the element index. Let `*` represent the operator for the
+ * ristretto255 group. Then `res[i]` encodes the ristretto255 group value
  *
  * ```text
  *     Prod_{j=1 to n_i} g_{offset_generators + j} ^ a_ij
  * ```
  *
- * where n_i represents the number of elements in sequence i and g_{offset_generators + j}
+ * where `n_i` represents the number of elements in sequence `i` and `g_{offset_generators + j}`
  * is a group element determined by a prespecified function
  *
  * ```text
@@ -125,25 +131,25 @@ int sxt_init(const struct sxt_config* config);
  *
  * # Arguments:
  *
- * - commitments   (out): an array of length num_sequences where the computed commitments
+ * - `commitments` (out): an array of length num_sequences where the computed commitments
  *                     of each sequence must be written into
  *
- * - num_sequences (in): specifies the number of sequences
- * - descriptors   (in): an array of length num_sequences that specifies each sequence
- * - offset_generators (in): specifies the offset used to fetch the generators
+ * - `num_sequences` (in): specifies the number of sequences
+ * - `descriptors` (in): an array of length `num_sequences` that specifies each sequence
+ * - `offset_generators` (in): specifies the offset used to fetch the generators
  *
  * # Abnormal program termination in case of:
  *
  * - backend not initialized or incorrectly initialized
- * - descriptors == nullptr
- * - commitments == nullptr
- * - descriptor\[i].element_nbytes == 0
- * - descriptor\[i].element_nbytes > 32
- * - descriptor\[i].n > 0 && descriptor\[i].data == nullptr
+ * - `descriptors == nullptr`
+ * - `commitments == nullptr`
+ * - `descriptor[i].element_nbytes == 0`
+ * - `descriptor[i].element_nbytes > 32`
+ * - `descriptor[i].n > 0 && descriptor[i].data == nullptr`
  *
  * # Considerations:
  *
- * - num_sequences equal to 0 will skip the computation
+ * - `num_sequences == 0` will skip the computation
  */
 void sxt_curve25519_compute_pedersen_commitments(struct sxt_ristretto255_compressed* commitments,
                                                  uint32_t num_sequences,
@@ -151,120 +157,120 @@ void sxt_curve25519_compute_pedersen_commitments(struct sxt_ristretto255_compres
                                                  uint64_t offset_generators);
 
 /**
- * Compute the Pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values using `curve25519` group elements.
  *
- * Denote an element of a sequence by a_ij where i represents the sequence index
- * and j represents the element index. Let * represent the operator for the
- * ristretto255 group. Then res\[i] encodes the ristretto255 group value
+ * Denote an element of a sequence by `a_ij` where `i` represents the sequence index
+ * and `j` represents the element index. Let `*` represent the operator for the
+ * ristretto255 group. Then `res[i]` encodes the ristretto255 group value.
  *
  * ```text
  *     Prod_{j=1 to n_i} g_j ^ a_ij
  * ```
  *
- * where n_i represents the number of elements in sequence i and g_j is a group
- * element determined by the `generators[j]` user value given as input
+ * where `n_i` represents the number of elements in sequence `i` and `g_j` is a group
+ * element determined by the `generators[j]` user value given as input.
  *
  * # Arguments:
  *
- * - commitments   (out): an array of length num_sequences where the computed commitments
+ * - `commitments` (out): an array of length num_sequences where the computed commitments
  *                     of each sequence must be written into
  *
- * - num_sequences (in): specifies the number of sequences
- * - descriptors   (in): an array of length num_sequences that specifies each sequence
- * - generators    (in): an array of length `max_num_rows` = `the maximum between all n_i`
+ * - `num_sequences` (in): specifies the number of sequences
+ * - `descriptors` (in): an array of length `num_sequences` that specifies each sequence
+ * - `generators` (in): an array of length `max_num_rows` equals the maximum between all `n_i`
  *
  * # Abnormal program termination in case of:
  *
  * - backend not initialized or incorrectly initialized
- * - descriptors == nullptr
- * - commitments == nullptr
- * - descriptor\[i].element_nbytes == 0
- * - descriptor\[i].element_nbytes > 32
- * - descriptor\[i].n > 0 && descriptor\[i].data == nullptr
+ * - `descriptors == nullptr`
+ * - `commitments == nullptr`
+ * - `descriptor[i].element_nbytes == 0`
+ * - `descriptor[i].element_nbytes > 32`
+ * - `descriptor[i].n > 0 && descriptor[i].data == nullptr`
  *
  * # Considerations:
  *
- * - num_sequences equal to 0 will skip the computation
+ * - `num_sequences == 0` will skip the computation
  */
 void sxt_curve25519_compute_pedersen_commitments_with_generators(
     struct sxt_ristretto255_compressed* commitments, uint32_t num_sequences,
     const struct sxt_sequence_descriptor* descriptors, const struct sxt_ristretto255* generators);
 
 /**
- * Compute the Pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values using `bls12-381` `G1` group elements.
  *
- * Denote an element of a sequence by a_ij where i represents the sequence index
- * and j represents the element index. Let * represent the operator for the
- * bls12-381 G1 group. Then res\[i] encodes the bls12-381 G1 group value
+ * Denote an element of a sequence by `a_ij` where `i` represents the sequence index
+ * and `j` represents the element index. Let `*` represent the operator for the
+ * `bls12-381` `G1` group. Then `res[i]` encodes the `bls12-381` `G1` group value
  *
  * ```text
  *     Prod_{j=1 to n_i} g_j ^ a_ij
  * ```
  *
- * where n_i represents the number of elements in sequence i and g_j is a group
+ * where `n_i` represents the number of elements in sequence `i` and `g_j` is a group
  * element determined by the `generators[j]` user value given as input
  *
  * # Arguments:
  *
- * - commitments   (out): an array of length num_sequences where the computed commitments
+ * - `commitments` (out): an array of length num_sequences where the computed commitments
  *                     of each sequence must be written into
  *
- * - num_sequences (in): specifies the number of sequences
- * - descriptors   (in): an array of length num_sequences that specifies each sequence
- * - generators    (in): an array of length `max_num_rows` = `the maximum between all n_i`
+ * - `num_sequences` (in): specifies the number of sequences
+ * - `descriptors` (in): an array of length `num_sequences` that specifies each sequence
+ * - `generators` (in): an array of length `max_num_rows` equals the maximum between all `n_i`
  *
  * # Abnormal program termination in case of:
  *
  * - backend not initialized or incorrectly initialized
- * - descriptors == nullptr
- * - commitments == nullptr
- * - descriptor\[i].element_nbytes == 0
- * - descriptor\[i].element_nbytes > 32
- * - descriptor\[i].n > 0 && descriptor\[i].data == nullptr
+ * - `descriptors == nullptr`
+ * - `commitments == nullptr`
+ * - `descriptor[i].element_nbytes == 0`
+ * - `descriptor[i].element_nbytes > 32`
+ * - `descriptor[i].n > 0 && descriptor[i].data == nullptr`
  *
  * # Considerations:
  *
- * - num_sequences equal to 0 will skip the computation
+ * - `num_sequences == 0` will skip the computation
  */
 void sxt_bls12_381_g1_compute_pedersen_commitments_with_generators(
     struct sxt_bls12_381_g1_compressed* commitments, uint32_t num_sequences,
     const struct sxt_sequence_descriptor* descriptors, const struct sxt_bls12_381_g1* generators);
 
 /**
- * Compute the Pedersen commitments for sequences of values
+ * Compute the Pedersen commitments for sequences of values using `bn254` `G1` group elements.
  *
- * Denote an element of a sequence by a_ij where i represents the sequence index
- * and j represents the element index. Let * represent the operator for the
- * bn254 G1 group. Then res\[i] encodes the bn254 G1 group value
+ * Denote an element of a sequence by `a_ij` where `i` represents the sequence index
+ * and `j` represents the element index. Let `*` represent the operator for the
+ * `bn254` `G1` group. Then `res[i]` encodes the `bn254` `G1` group value
  *
  * ```text
  *     Prod_{j=1 to n_i} g_j ^ a_ij
  * ```
  *
- * where n_i represents the number of elements in sequence i and g_j is a group
+ * where `n_i` represents the number of elements in sequence `i` and `g_j` is a group
  * element determined by the `generators[j]` user value given as input
  *
  * # Arguments:
  *
- * - commitments   (out): an array of length num_sequences where the computed commitments
+ * - `commitments` (out): an array of length num_sequences where the computed commitments
  *                     of each sequence must be written into
  *
- * - num_sequences (in): specifies the number of sequences
- * - descriptors   (in): an array of length num_sequences that specifies each sequence
- * - generators    (in): an array of length `max_num_rows` = `the maximum between all n_i`
+ * - `num_sequences` (in): specifies the number of sequences
+ * - `descriptors` (in): an array of length `num_sequences` that specifies each sequence
+ * - `generators` (in): an array of length `max_num_rows` equals the maximum between all `n_i`
  *
  * # Abnormal program termination in case of:
  *
  * - backend not initialized or incorrectly initialized
- * - descriptors == nullptr
- * - commitments == nullptr
- * - descriptor\[i].element_nbytes == 0
- * - descriptor\[i].element_nbytes > 32
- * - descriptor\[i].n > 0 && descriptor\[i].data == nullptr
+ * - `descriptors == nullptr`
+ * - `commitments == nullptr`
+ * - `descriptor[i].element_nbytes == 0`
+ * - `descriptor[i].element_nbytes > 32`
+ * - `descriptor[i].n > 0 && descriptor[i].data == nullptr`
  *
  * # Considerations:
  *
- * - num_sequences equal to 0 will skip the computation
+ * - `num_sequences == 0` will skip the computation
  */
 void sxt_bn254_g1_uncompressed_compute_pedersen_commitments_with_generators(
     struct sxt_bn254_g1* commitments, uint32_t num_sequences,
@@ -272,76 +278,79 @@ void sxt_bn254_g1_uncompressed_compute_pedersen_commitments_with_generators(
 
 /**
  * Gets the pre-specified random generated elements used for the Pedersen commitments in the
- * `sxt_curve25519_compute_pedersen_commitments` function
+ * `sxt_curve25519_compute_pedersen_commitments` function.
  *
+ * ```text
  * sxt_ristretto255_get_generators(generators, num_generators, offset_generators) →
- *     generators\[0] = generate_random_ristretto(0 + offset_generators)
- *     generators\[1] = generate_random_ristretto(1 + offset_generators)
- *     generators\[2] = generate_random_ristretto(2 + offset_generators)
- *       .
- *       .
- *       .
- *     generators\[num_generators - 1] = generate_random_ristretto(num_generators - 1 +
+ *     generators[0] = generate_random_ristretto(0 + offset_generators)
+ *     generators[1] = generate_random_ristretto(1 + offset_generators)
+ *     generators[2] = generate_random_ristretto(2 + offset_generators)
+ *       ...
+ *     generators[num_generators - 1] = generate_random_ristretto(num_generators - 1 +
  * offset_generators)
- *
+ * ```
  * # Arguments:
  *
- * - generators         (out): sxt_element_p3 pointer where the results must be written into
- *
- * - num_generators     (in): the total number of random generated elements to be computed
- * - offset_generators  (in): the offset that shifts the first element computed from `0` to
+ * - `generators` (out): `sxt_ristretto255` pointer where the results must be written into
+ * - `offset_generators` (in): the offset that shifts the first element computed from `0` to
  * `offset_generators`
+ * - `num_generators` (in): the total number of random generated elements to be computed
  *
  * # Return:
  *
- * - 0 on success; otherwise a nonzero error code
+ * - `0` on success; otherwise a nonzero error code
  *
  * # Invalid input parameters, which generate error code:
  *
- * - num_generators > 0 && generators == nullptr
+ * - `num_generators > 0 && generators == nullptr`
  *
  * # Considerations:
  *
- * - num_generators equal to 0 will skip the computation
+ * - `num_generators == 0` will skip the computation
  */
 int sxt_ristretto255_get_generators(struct sxt_ristretto255* generators, uint64_t offset_generators,
                                     uint64_t num_generators);
 
 /**
- * Gets the n-th ristretto point defined as:
+ * Gets the `n`-th Ristretto point.
  *
- * If n == 0:
- *    one_commit\[0] = ristretto_identity;
+ * The `n`-th Ristretto point is defined as:
  *
- * Else:
- *    one_commit\[0] = g\[0] + g\[1] + ... + g\[n - 1];
+ * ```rust
+ * if n == 0:
+ *    one_commit[0] = ristretto_identity;
+ * else:
+ *    one_commit[0] = g[0] + g[1] + ... + g[n - 1];
+ * ```
  *
  * where
  *
+ * ```rust
  * struct sxt_ristretto255 ristretto_identity = {
  *    {0, 0, 0, 0, 0},
  *    {1, 0, 0, 0, 0},
  *    {1, 0, 0, 0, 0},
  *    {0, 0, 0, 0, 0},
  * };
+ * ```
  *
- * and `g[i]` is the i-th generator provided by `sxt_ristretto255_get_generators` function at offset
- * 0.
+ * and `g[i]` is the `i`-th generator provided by `sxt_ristretto255_get_generators` function at
+ * offset `0`.
  *
  * # Return:
  *
- * - 0 on success; otherwise a nonzero error code
+ * - `0` on success; otherwise a nonzero error code
  *
  * # Invalid input parameters, which generate error code:
  *
- * - one_commit == nullptr
+ * - `one_commit == nullptr`
  */
 int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t n);
 
 /**
- * Creates an inner product proof
+ * Creates an inner product proof.
  *
- * The proof is created with respect to the base G, provided by
+ * The proof is created with respect to the base `G`, provided by
  * `sxt_ristretto255_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
  *
  * The `verifier` transcript is passed in as a parameter so that the
@@ -353,12 +362,12 @@ int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t 
  *
  * # Algorithm description
  *
- * Initially, we compute G and Q = G\[np], where np = 1ull << ceil(log2(n))
- * and G is zero-indexed.
+ * Initially, we compute `G` and `Q = G[np]`, where `np = 1ull << ceil(log2(n))`
+ * and `G` is zero-indexed.
  *
- * The protocol consists of k = ceil(lg_2(n)) rounds, indexed by j = k - 1 , ... , 0.
+ * The protocol consists of `k = ceil(lg_2(n))` rounds, indexed by `j = k - 1 , ... , 0`.
  *
- * In the j-th round, the prover computes:
+ * In the `j`-th round, the prover computes:
  *
  * ```text
  * a_lo = {a[0], a[1], ..., a[n / 2 - 1]}
@@ -372,13 +381,13 @@ int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t 
  * r_vector[j] = <a_hi, G_lo> + <a_hi, b_lo> * Q
  * ```
  *
- * Note that if the `a` or `b` length is not a power of 2,
- * then `a` or `b` is padded with zeros until it has a power of 2.
- * G always has a power of 2 given how it is constructed.
+ * Note that if the `a` or `b` length is not a power of `2`,
+ * then `a` or `b` is padded with zeros until it has a power of `2`.
+ * `G` always has a power of `2` given how it is constructed.
  *
- * Then the prover sends l_vector\[j] and r_vector\[j] to the verifier,
+ * Then the prover sends `l_vector[j]` and `r_vector[j]` to the verifier,
  * and the verifier responds with a
- * challenge value u\[j] <- Z_p (finite field of order p),
+ * challenge value `u[j] <- Z_p` (finite field of order p),
  * which is non-interactively simulated by
  * the input strobe-based transcript:
  *
@@ -389,7 +398,7 @@ int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t 
  * u[j] = transcript.challenge_value("x");
  * ```
  *
- * Then the prover uses u\[j] to compute
+ * Then the prover uses `u[j]` to compute
  *
  * ```text
  * a = a_lo * u[j] + (u[j]^-1) * a_hi;
@@ -404,26 +413,26 @@ int sxt_curve25519_get_one_commit(struct sxt_ristretto255* one_commit, uint64_t 
  * n = n / 2;
  * ```
  *
- * and use these vectors (all of length 2^j) for the next round.
+ * and use these vectors (all of length `2^j`) for the next round.
  *
- * After the last (j = 0) round, the prover sends ap_value = a\[0] to the verifier.
+ * After the last `(j = 0)` round, the prover sends `ap_value = a[0]` to the verifier.
  *
  * # Arguments:
  *
- * - l_vector (out): transcript point array with length `ceil(log2(n))`
- * - r_vector (out): transcript point array with length `ceil(log2(n))`
- * - ap_value (out): a single scalar
- * - transcript (in/out): a single strobe-based transcript
- * - n (in): non-zero length for the input arrays
- * - generators_offset (in): offset used to fetch the bases
- * - a_vector (in): array with length n
- * - b_vector (in): array with length n
+ * - `l_vector` (out): transcript point array with length `ceil(log2(n))`
+ * - `r_vector` (out): transcript point array with length `ceil(log2(n))`
+ * - `ap_value` (out): a single scalar
+ * - `transcript` (in/out): a single strobe-based transcript
+ * - `n` (in): non-zero length for the input arrays
+ * - `generators_offset` (in): offset used to fetch the bases
+ * - `a_vector` (in): array with length `n`
+ * - `b_vector` (in): array with length `n`
  *
  * # Abnormal program termination in case of:
  *
- * - transcript, ap_value, b_vector, or a_vector is nullptr
- * - n is zero
- * - n is non-zero, but l_vector or r_vector is nullptr
+ * - `transcript`, `ap_value`, `b_vector`, or `a_vector` is `nullptr`
+ * - `n` is zero
+ * - `n` is non-zero, but `l_vector` or `r_vector` is `nullptr`
  */
 void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_vector,
                                         struct sxt_ristretto255_compressed* r_vector,
@@ -434,7 +443,7 @@ void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_ve
                                         const struct sxt_curve25519_scalar* b_vector);
 
 /**
- * Verifies an inner product proof
+ * Verifies an inner product proof.
  *
  * The proof is verified with respect to the base G, provided by
  * `sxt_ristretto255_get_generators(G, generators_offset, 1ull << ceil(log2(n)))`.
@@ -444,30 +453,31 @@ void sxt_curve25519_prove_inner_product(struct sxt_ristretto255_compressed* l_ve
  *
  * # Arguments:
  *
- * - transcript (in/out): a single strobe-based transcript
- * - n (in): non-zero length for the input arrays
- * - generators_offset (in): offset used to fetch the bases
- * - b_vector (in): array with length n, the same one used by `sxt_curve25519_prove_inner_product`
- * - product (in): a single scalar, represented by <a, b>,
+ * - `transcript` (in/out): a single strobe-based transcript
+ * - `n` (in): non-zero length for the input arrays
+ * - `generators_offset` (in): offset used to fetch the bases
+ * - `b_vector` (in): array with length `n`, the same one used by
+ * `sxt_curve25519_prove_inner_product`
+ * - `product` (in): a single scalar, represented by `<a, b>`,
  *                 the inner product of the two vectors `a` and `b` used by
  * `sxt_curve25519_prove_inner_product`
- * - a_commit (in): a single ristretto point, represented by <a, G> (the inner product of the two
- * vectors)
- * - l_vector (in): transcript point array with length `ceil(log2(n))`, generated by
+ * - `a_commit` (in): a single ristretto point, represented by `<a, G>` (the inner product of the
+ * two vectors)
+ * - `l_vector` (in): transcript point array with length `ceil(log2(n))`, generated by
  * `sxt_curve25519_prove_inner_product`
- * - r_vector (in): transcript point array with length `ceil(log2(n))`, generated by
+ * - `r_vector` (in): transcript point array with length `ceil(log2(n))`, generated by
  * `sxt_curve25519_prove_inner_product`
- * - ap_value (in): a single scalar, generated by `sxt_curve25519_prove_inner_product`
+ * - `ap_value` (in): a single scalar, generated by `sxt_curve25519_prove_inner_product`
  *
  * # Return:
  *
- * - 1 in case the proof can be verified; otherwise, return 0
+ * - `1` in case the proof can be verified; otherwise, return `0`
  *
  * # Abnormal program termination in case of:
  *
- * - transcript, ap_value, product, a_commit, or b_vector is nullptr
- * - n is zero
- * - n is non-zero, but l_vector or r_vector is nullptr
+ * - `transcript`, `ap_value`, `product`, `a_commit`, or `b_vector` is `nullptr`
+ * - `n` is zero
+ * - `n` is non-zero, but `l_vector` or `r_vector` is `nullptr`
  */
 int sxt_curve25519_verify_inner_product(struct sxt_transcript* transcript, uint64_t n,
                                         uint64_t generators_offset,


### PR DESCRIPTION
# Rationale for this change
In an effort to improve documentation, formatting has been updated in the `blitzar_api.h` file. No text has been rewritten, only formatting to improve readability on crates.io.

# What changes are included in this PR?
- Formatting has been updated throughout `blitzar_api.h`.

# Are these changes tested?
Yes, locally using `cargo doc`.