### PR TITLE
fix: fix bug in inner product proof (PROOF-788)

### DIFF
--- a/sxt/proof/inner_product/gpu_driver.cc
+++ b/sxt/proof/inner_product/gpu_driver.cc
@@ -169,11 +169,6 @@ xena::future<void> gpu_driver::fold(workspace& ws, const s25t::element& x) const
   // a_vector
   work.a_vector = work.a_vector.subspan(0, mid);
   auto a_fut = async_fold_scalars(work.a_vector, a_vector, x, x_inv);
-  if (mid == 1) {
-    // no need to compute the other folded values if we reduce to a single element
-    co_await std::move(a_fut);
-    co_return;
-  }
 
   // b_vector
   work.b_vector = work.b_vector.subspan(0, mid);


### PR DESCRIPTION
# Rationale for this change

There is a bug in the inner product proof where a coroutine is being destroyed while memory it owns is still referenced.

# What changes are included in this PR?

Change inner product gpu driver to not destroy coroutine early.

# Are these changes tested?

Ran tests locally, but will also try to test on a multi-gpu machine where the issue is reproduced more consistently.
