### PR TITLE
feat: add runlength count algorithm (PROOF-642)

### DIFF
--- a/sxt/algorithm/block/BUILD
+++ b/sxt/algorithm/block/BUILD
@@ -1,0 +1,17 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "runlength_count",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/base/device:synchronization",
+        "//sxt/base/macro:cuda_callable",
+        "@local_cuda//:cub",
+    ],
+)

--- a/sxt/algorithm/block/runlength_count.cc
+++ b/sxt/algorithm/block/runlength_count.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/algorithm/block/runlength_count.h"

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -1,0 +1,80 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "cub/cub.cuh"
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::algbk {
+//--------------------------------------------------------------------------------------------------
+// runlength_count
+//--------------------------------------------------------------------------------------------------
+/**
+ * This is adapted from block_histogram_sort in CUB. See
+ *   https://github.com/NVIDIA/cccl/blob/a51b1f8c75f8e577eeccc74b45f1ff16a2727265/cub/cub/block/specializations/block_histogram_sort.cuh
+ */
+template <class T, class CounterT, unsigned NumThreads, unsigned NumBins> class runlength_count {
+  using Discontinuity = cub::BlockDiscontinuity<T, NumThreads>;
+
+public:
+  struct temp_storage {
+    typename Discontinuity::TempStorage discontinuity;
+    CounterT run_begin[NumBins];
+    CounterT run_end[NumBins];
+  };
+
+  CUDA_CALLABLE explicit runlength_count(temp_storage& storage) noexcept
+      : storage_{storage}, discontinuity_{storage.discontinuity} {}
+
+  /**
+   * If items holds sorted items across threads in a block, count and return a
+   * pointer to a table of the items run lengths.
+   */
+  template <unsigned ItemsPerThread>
+  CUDA_CALLABLE CounterT* count(T (&items)[ItemsPerThread]) noexcept {
+    auto thread_id = threadIdx.x;
+    for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
+      storage_.run_begin[i] = NumThreads * ItemsPerThread;
+      storage_.run_end[i] = NumThreads * ItemsPerThread;
+    }
+    int flags[ItemsPerThread];
+    auto flag_op = [&storage = storage_](T a, T b, int b_index) noexcept {
+      if (a != b) {
+        storage.run_begin[b] = static_cast<CounterT>(b_index);
+        storage.run_end[a] = static_cast<CounterT>(b_index);
+        return true;
+      } else {
+        return false;
+      }
+    };
+    __syncthreads();
+    discontinuity_.FlagHeads(flags, items, flag_op);
+    if (thread_id == 0) {
+      storage_.run_begin[items[0]] = 0;
+    }
+    __syncthreads();
+    for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
+      storage_.run_end[i] -= storage_.run_begin[i];
+    }
+    return storage_.run_end;
+  }
+
+private:
+  temp_storage& storage_;
+  Discontinuity discontinuity_;
+};
+} // namespace sxt::algbk

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -42,7 +42,7 @@ public:
 
   /**
    * If items holds sorted items across threads in a block, count and return a
-   * pointer to a table of the items run lengths.
+   * pointer to a table of the items' run lengths.
    */
   template <unsigned ItemsPerThread>
   CUDA_CALLABLE CounterT* count(T (&items)[ItemsPerThread]) noexcept {

--- a/sxt/algorithm/block/runlength_count.t.cc
+++ b/sxt/algorithm/block/runlength_count.t.cc
@@ -1,0 +1,79 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/algorithm/block/runlength_count.h"
+
+#include <cstdint>
+#include <vector>
+
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::algbk;
+
+template <size_t NumThreads> static __global__ void k1(int* counts) {
+  uint8_t items[1];
+  items[0] = 1;
+  using RunlengthCount = runlength_count<uint8_t, int, NumThreads, 256>;
+  __shared__ typename RunlengthCount::temp_storage temp_storage;
+  auto cnts = RunlengthCount{temp_storage}.count(items);
+  __syncthreads();
+  for (unsigned i = threadIdx.x; i < 256; i += blockDim.x) {
+    counts[i] = cnts[i];
+  }
+}
+
+template <size_t NumThreads> static __global__ void k2(int* counts) {
+  uint8_t items[1];
+  items[0] = threadIdx.x;
+  using RunlengthCount = runlength_count<uint8_t, int, NumThreads, 256>;
+  __shared__ typename RunlengthCount::temp_storage temp_storage;
+  auto cnts = RunlengthCount{temp_storage}.count(items);
+  __syncthreads();
+  for (unsigned i = threadIdx.x; i < 256; i += blockDim.x) {
+    counts[i] = cnts[i];
+  }
+}
+
+TEST_CASE("we can count the run lengths of sorted values") {
+  std::pmr::vector<int> counts{256, memr::get_managed_device_resource()};
+
+  std::pmr::vector<int> expected(counts.size());
+
+  SECTION("we handle a single thread") {
+    k1<1><<<1, 1>>>(counts.data());
+    basdv::synchronize_device();
+    expected[1] = 1;
+    REQUIRE(counts == expected);
+  }
+
+  SECTION("we handle two threads") {
+    k1<2><<<1, 2>>>(counts.data());
+    basdv::synchronize_device();
+    expected[1] = 2;
+    REQUIRE(counts == expected);
+  }
+
+  SECTION("we handle two threads with different values") {
+    k2<2><<<1, 2>>>(counts.data());
+    basdv::synchronize_device();
+    expected[0] = 1;
+    expected[1] = 1;
+    REQUIRE(counts == expected);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add an algorithm that counts the run lengths of sorted items across a block of threads.

This will be used to compute the multi-product table of a multiexponentiation.

The coded is written in the style of Nvidia's CUB library.

# What changes are included in this PR?

* Add package group for algorithms that operate on thread blocks
* Add a component for the runlength algorithm.

# Are these changes tested?

Yes.
