### PR TITLE
feat: add function to copy and transpose scalars into device memory (PROOF-642)

### DIFF
--- a/sxt/multiexp/base/BUILD
+++ b/sxt/multiexp/base/BUILD
@@ -42,3 +42,34 @@ sxt_cc_component(
         ":exponent_sequence",
     ],
 )
+
+sxt_cc_component(
+    name = "scalar_array",
+    impl_deps = [
+        "@local_cuda//:cub",
+        "//sxt/base/container:span_utility",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/base/error:assert",
+        "//sxt/base/num:ceil_log2",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:divide_up",
+        "//sxt/execution/async:future",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/device:synchronization",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+    ],
+    test_deps = [
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/execution/async:future",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/execution/async:future_fwd",
+    ],
+)

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -1,0 +1,129 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/scalar_array.h"
+
+#include <vector>
+
+#include "cub/cub.cuh"
+#include "sxt/base/container/span_utility.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/num/ceil_log2.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/device/synchronization.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// scalar_blob
+//--------------------------------------------------------------------------------------------------
+namespace {
+template <unsigned NumBytes> struct scalar_blob {
+  uint8_t data[NumBytes];
+};
+} // namespace
+
+//--------------------------------------------------------------------------------------------------
+// transpose_kernel
+//--------------------------------------------------------------------------------------------------
+template <unsigned NumBytes>
+static __global__ void transpose_kernel(uint8_t* __restrict__ dst,
+                                        const scalar_blob<NumBytes>* __restrict__ src,
+                                        unsigned n) noexcept {
+  using Scalar = scalar_blob<NumBytes>;
+
+  auto byte_index = threadIdx.x;
+  auto tile_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+  auto num_tiles = gridDim.x;
+  auto n_per_tile = basn::divide_up(basn::divide_up(n, NumBytes), num_tiles) * NumBytes;
+
+  auto first = tile_index * n_per_tile;
+  auto m = min(n_per_tile, n - first);
+
+  // adjust pointers
+  src += first;
+  src += output_index * n;
+  dst += byte_index * n + first;
+  dst += output_index * NumBytes * n;
+
+  // set up algorithm
+  using BlockExchange = cub::BlockExchange<uint8_t, NumBytes, NumBytes>;
+  __shared__ typename BlockExchange::TempStorage temp_storage;
+
+  // transpose
+  Scalar s;
+  unsigned out_first = 0;
+  for (unsigned i = byte_index; i < n_per_tile; i += NumBytes) {
+    if (i < m) {
+      s = src[i];
+    }
+    BlockExchange(temp_storage).StripedToBlocked(s.data);
+    __syncthreads();
+    for (unsigned j = 0; j < NumBytes; ++j) {
+      auto out_index = out_first + j;
+      if (out_index < m) {
+        dst[out_index] = s.data[j];
+      }
+    }
+    out_first += NumBytes;
+    __syncthreads();
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// transpose_scalars_to_device
+//--------------------------------------------------------------------------------------------------
+xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
+                                           basct::cspan<const uint8_t*> scalars,
+                                           unsigned element_num_bytes, unsigned n) noexcept {
+  auto num_outputs = static_cast<unsigned>(scalars.size());
+  if (n == 0 || num_outputs == 0) {
+    co_return;
+  }
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      array.size() == num_outputs * element_num_bytes * n &&
+      basdv::is_active_device_pointer(array.data()) &&
+      basdv::is_host_pointer(scalars[0])
+      // clang-format on
+  );
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  memmg::managed_array<uint8_t> array_p{array.size(), &resource};
+  auto num_bytes_per_output = element_num_bytes * n;
+  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+    basdv::async_copy_host_to_device(
+        basct::subspan(array_p, output_index * num_bytes_per_output, num_bytes_per_output),
+        basct::cspan<uint8_t>{scalars[output_index], num_bytes_per_output}, stream);
+  }
+  auto num_tiles = std::min(basn::divide_up(n, num_outputs * element_num_bytes), 64u);
+  auto num_bytes_log2 = basn::ceil_log2(element_num_bytes);
+  basn::constexpr_switch<6>(
+      num_bytes_log2,
+      [&]<unsigned LogNumBytes>(std::integral_constant<unsigned, LogNumBytes>) noexcept {
+        constexpr auto NumBytes = 1u << LogNumBytes;
+        SXT_DEBUG_ASSERT(NumBytes == element_num_bytes);
+        transpose_kernel<NumBytes><<<dim3(num_tiles, num_outputs, 1), NumBytes, 0, stream>>>(
+            array.data(), reinterpret_cast<scalar_blob<NumBytes>*>(array_p.data()), n);
+      });
+  co_await xendv::await_stream(std::move(stream));
+}
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/scalar_array.h
+++ b/sxt/multiexp/base/scalar_array.h
@@ -1,0 +1,38 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// transpose_scalars_to_device
+//--------------------------------------------------------------------------------------------------
+/**
+ * Copy scalars in host memory to the device and transpose their bytes. For example,
+ * if there are two scalars, s1 and s2, of 4 bytes on the host layed out as follows
+ *    s1[0], s1[1], s1[2], s1[3], s2[0], s2[1], s2[2], s2[3]
+ *  then this function will copy the scalars to device memory and lay them out like this
+ *    s1[0], s2[0], s1[1], s2[1], s1[2], s2[2], s1[3], s2[3]
+ */
+xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
+                                           basct::cspan<const uint8_t*> scalars,
+                                           unsigned element_num_bytes, unsigned n) noexcept;
+} // namespace sxt::mtxb

--- a/sxt/multiexp/base/scalar_array.t.cc
+++ b/sxt/multiexp/base/scalar_array.t.cc
@@ -1,0 +1,122 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/base/scalar_array.h"
+
+#include <numeric>
+#include <vector>
+
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxb;
+
+TEST_CASE("we can copy transpose scalar arrays to device memory") {
+  memmg::managed_array<uint8_t> array{memr::get_managed_device_resource()};
+
+  SECTION("we handle the empty case") {
+    std::vector<uint8_t> scalars1(0);
+    array.resize(0);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 1, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+  }
+
+  SECTION("we can transpose a single scalar of 1 byte") {
+    std::vector<uint8_t> scalars1(1);
+    scalars1[0] = 123u;
+    array.resize(1);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 1, 1);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 123u);
+  }
+
+  SECTION("we can transpose a single scalar of 2 bytes") {
+    std::vector<uint8_t> scalars1(2);
+    scalars1[0] = 1u;
+    scalars1[1] = 2u;
+    array.resize(2);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 2, 1);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 1u);
+    REQUIRE(array[1] == 2u);
+  }
+
+  SECTION("we can transpose a single scalar of 32 bytes") {
+    std::vector<uint8_t> scalars1(32);
+    std::iota(scalars1.begin(), scalars1.end(), 0);
+    array.resize(32);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 32, 1);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 0u);
+    REQUIRE(array[31u] == 31u);
+  }
+
+  SECTION("we can transpose two scalars of 1 byte") {
+    std::vector<uint8_t> scalars1(2);
+    std::iota(scalars1.begin(), scalars1.end(), 0);
+    array.resize(2);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 1, 2);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 0u);
+    REQUIRE(array[1] == 1u);
+  }
+
+  SECTION("we can transpose two scalars of 2 byte") {
+    std::vector<uint8_t> scalars1(4);
+    std::iota(scalars1.begin(), scalars1.end(), 0);
+    array.resize(4);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 2, 2);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 0u);
+    REQUIRE(array[1] == 2u);
+    REQUIRE(array[2] == 1u);
+    REQUIRE(array[3] == 3u);
+  }
+
+  SECTION("we can transpose two scalars of 32 bytes") {
+    std::vector<uint8_t> scalars1(64);
+    std::iota(scalars1.begin(), scalars1.end(), 0);
+    array.resize(64);
+    std::vector<const uint8_t*> scalars = {scalars1.data()};
+    auto fut = transpose_scalars_to_device(array, scalars, 32, 2);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(array[0] == 0u);
+    REQUIRE(array[1] == 32u);
+    REQUIRE(array[2] == 1u);
+    REQUIRE(array[3] == 33u);
+    REQUIRE(array[62] == 31u);
+    REQUIRE(array[63] == 63u);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a function that will copy and transpose scalar exponents into device memory.

This will be used as part of the bucket method.

# What changes are included in this PR?

* Add a new component that creates an array of transposed scalars

# Are these changes tested?

Yes.
