### PR TITLE
feat: compute multiproduct table for bucket method (PROOF-642)

### DIFF
--- a/sxt/multiexp/bucket_method2/BUILD
+++ b/sxt/multiexp/bucket_method2/BUILD
@@ -1,0 +1,55 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "multiproduct_table",
+    impl_deps = [
+        ":multiproduct_table_kernel",
+        "//sxt/algorithm/iteration:for_each",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/base/error:assert",
+        "//sxt/base/log:log",
+        "//sxt/base/num:divide_up",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/device:synchronization",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:device_resource",
+        "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/base:scalar_array",
+    ],
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/async:future",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/execution/async:future_fwd",
+        "//sxt/memory/management:managed_array_fwd",
+    ],
+)
+
+sxt_cc_component(
+    name = "multiproduct_table_kernel",
+    impl_deps = [
+    ],
+    test_deps = [
+        "//sxt/base/device:synchronization",
+        "//sxt/base/num:constexpr_switch",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/algorithm/block:runlength_count",
+        "//sxt/base/device:stream",
+        "@local_cuda//:cub",
+    ],
+)

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -1,0 +1,85 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method2/multiproduct_table.h"
+
+#include "cub/cub.cuh"
+#include "sxt/algorithm/iteration/for_each.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/log/log.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/device/synchronization.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+#include "sxt/multiexp/base/scalar_array.h"
+#include "sxt/multiexp/bucket_method2/multiproduct_table_kernel.h"
+
+namespace sxt::mtxbk2 {
+//--------------------------------------------------------------------------------------------------
+// make_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+xena::future<> make_multiproduct_table(basct::span<uint16_t> bucket_prefix_counts,
+                                       basct::span<uint16_t> indexes,
+                                       basct::cspan<const uint8_t*> scalars,
+                                       unsigned element_num_bytes, unsigned bit_width,
+                                       unsigned n) noexcept {
+  auto num_outputs = scalars.size();
+  auto num_buckets_per_digit = (1u << bit_width) - 1u;
+  auto num_digits = basn::divide_up(element_num_bytes * 8u, bit_width);
+  auto num_buckets_per_output = num_buckets_per_digit * num_digits;
+  auto num_buckets_total = num_buckets_per_output * num_outputs;
+  SXT_DEBUG_ASSERT(bucket_prefix_counts.size() == num_buckets_total &&
+                   indexes.size() == num_outputs * num_digits * n &&
+                   basdv::is_active_device_pointer(bucket_prefix_counts.data()) &&
+                   basdv::is_active_device_pointer(indexes.data()));
+
+  // transpose scalars
+  basl::info("copying scalars to device");
+  memmg::managed_array<uint8_t> bytes{num_outputs * n * element_num_bytes,
+                                      memr::get_device_resource()};
+  co_await mtxb::transpose_scalars_to_device(bytes, scalars, element_num_bytes, n);
+
+  // compute buckets
+  basl::info("computing multiproduct decomposition");
+  SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
+  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "only support n <= 1024 for now");
+  basdv::stream stream;
+  fit_multiproduct_table_kernel(
+      [&]<unsigned NumThreads, unsigned ItemsPerThread>(
+          std::integral_constant<unsigned, NumThreads>,
+          std::integral_constant<unsigned, ItemsPerThread>) noexcept {
+        multiproduct_table_kernel<NumThreads, ItemsPerThread, 8>
+            <<<dim3(num_digits, num_outputs, 1), NumThreads, 0, stream>>>(
+                bucket_prefix_counts.data(), indexes.data(), bytes.data(), n);
+      },
+      n);
+
+  // prefix sum
+  auto f = [bucket_prefix_counts = bucket_prefix_counts.data(),
+            num_buckets_per_digit = num_buckets_per_digit] __host__
+           __device__(unsigned /*num_digits_total*/, unsigned index) noexcept {
+             auto counts = bucket_prefix_counts + index * num_buckets_per_digit;
+             for (unsigned i = 1; i < num_buckets_per_digit; ++i) {
+               counts[i] += counts[i - 1u];
+             }
+           };
+  algi::launch_for_each_kernel(stream, f, num_digits * num_outputs);
+  co_await xendv::await_stream(stream);
+}
+} // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -58,7 +58,7 @@ xena::future<> make_multiproduct_table(basct::span<uint16_t> bucket_prefix_count
   // compute buckets
   basl::info("computing multiproduct decomposition");
   SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
-  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "only support n <= 1024 for now");
+  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "limit length for now");
   basdv::stream stream;
   fit_multiproduct_table_kernel(
       [&]<unsigned NumThreads, unsigned ItemsPerThread>(

--- a/sxt/multiexp/bucket_method2/multiproduct_table.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstdint>
+
+#include "sxt/base/container/span.h"
+#include "sxt/execution/async/future_fwd.h"
+#include "sxt/memory/management/managed_array_fwd.h"
+
+namespace sxt::mtxbk2 {
+//--------------------------------------------------------------------------------------------------
+// make_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+/**
+ * Create a table with the multiproducts needed for each bucket of a multiexponentiation.
+ *
+ * bucket_prefix_counts contains the inclusive prefix sum of the number of bucket entries
+ * and indexes contains the generator indexes for a buckets multiproduct laid out sequentially.
+ */
+xena::future<> make_multiproduct_table(basct::span<uint16_t> bucket_prefix_counts,
+                                       basct::span<uint16_t> indexes,
+                                       basct::cspan<const uint8_t*> scalars,
+                                       unsigned element_num_bytes, unsigned bit_width,
+                                       unsigned n) noexcept;
+} // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
@@ -92,4 +92,24 @@ TEST_CASE("we can construct the multi-product table for the bucket method") {
     REQUIRE(bucket_prefix_counts == expected_counts);
     REQUIRE(indexes == expected_indexes);
   }
+
+  SECTION("we handle two scalars of one") {
+    n = 2;
+    std::vector<uint8_t> scalars1(32 * n);
+    scalars1[0] = 1;
+    scalars1[element_num_bytes] = 1;
+    scalars = {scalars1.data()};
+    indexes.resize(num_digits * n);
+    auto fut = make_multiproduct_table(bucket_prefix_counts, indexes, scalars, element_num_bytes,
+                                       bit_width, n);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    std::fill_n(expected_counts.begin(), num_buckets_per_digit, 2u);
+    expected_indexes.resize(indexes.size());
+    expected_indexes[0] = 0;
+    expected_indexes[1] = 1;
+    basdv::synchronize_device();
+    REQUIRE(bucket_prefix_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
 }

--- a/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
@@ -112,4 +112,25 @@ TEST_CASE("we can construct the multi-product table for the bucket method") {
     REQUIRE(bucket_prefix_counts == expected_counts);
     REQUIRE(indexes == expected_indexes);
   }
+
+  SECTION("we handle two scalars of one and two") {
+    n = 2;
+    std::vector<uint8_t> scalars1(32 * n);
+    scalars1[0] = 1;
+    scalars1[element_num_bytes] = 2;
+    scalars = {scalars1.data()};
+    indexes.resize(num_digits * n);
+    auto fut = make_multiproduct_table(bucket_prefix_counts, indexes, scalars, element_num_bytes,
+                                       bit_width, n);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    expected_counts[0] = 1;
+    std::fill_n(expected_counts.begin() + 1, num_buckets_per_digit - 1, 2u);
+    expected_indexes.resize(indexes.size());
+    expected_indexes[0] = 0;
+    expected_indexes[1] = 1;
+    basdv::synchronize_device();
+    REQUIRE(bucket_prefix_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
 }

--- a/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.t.cc
@@ -1,0 +1,95 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method2/multiproduct_table.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxbk2;
+
+TEST_CASE("we can construct the multi-product table for the bucket method") {
+  std::pmr::vector<uint16_t> bucket_prefix_counts{memr::get_managed_device_resource()};
+  std::pmr::vector<uint16_t> indexes{memr::get_managed_device_resource()};
+  std::vector<const uint8_t*> scalars;
+  const unsigned element_num_bytes = 32;
+  const unsigned bit_width = 8;
+  const unsigned num_buckets_per_digit = 255;
+  const unsigned num_digits = 32;
+  bucket_prefix_counts.resize(num_buckets_per_digit * num_digits);
+  unsigned n = 0;
+
+  std::pmr::vector<uint16_t> expected_counts(bucket_prefix_counts.size());
+  std::pmr::vector<uint16_t> expected_indexes;
+
+  SECTION("we handle the case of a single scalar of zeros") {
+    n = 1;
+    std::vector<uint8_t> scalars1(32 * n);
+    scalars = {scalars1.data()};
+    indexes.resize(num_digits * n);
+    auto fut = make_multiproduct_table(bucket_prefix_counts, indexes, scalars, element_num_bytes,
+                                       bit_width, n);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    expected_indexes.resize(indexes.size());
+    basdv::synchronize_device();
+    REQUIRE(bucket_prefix_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+
+  SECTION("we handle the case of a single scalar of one") {
+    n = 1;
+    std::vector<uint8_t> scalars1(32 * n);
+    scalars1[0] = 1;
+    scalars = {scalars1.data()};
+    indexes.resize(num_digits * n);
+    auto fut = make_multiproduct_table(bucket_prefix_counts, indexes, scalars, element_num_bytes,
+                                       bit_width, n);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    std::fill_n(expected_counts.begin(), num_buckets_per_digit, 1u);
+    expected_indexes.resize(indexes.size());
+    basdv::synchronize_device();
+    REQUIRE(bucket_prefix_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+
+  SECTION("we handle two scalars of zero and one") {
+    n = 2;
+    std::vector<uint8_t> scalars1(32 * n);
+    scalars1[0] = 0;
+    scalars1[element_num_bytes] = 1;
+    scalars = {scalars1.data()};
+    indexes.resize(num_digits * n);
+    auto fut = make_multiproduct_table(bucket_prefix_counts, indexes, scalars, element_num_bytes,
+                                       bit_width, n);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    std::fill_n(expected_counts.begin(), num_buckets_per_digit, 1u);
+    expected_indexes.resize(indexes.size());
+    expected_indexes[0] = 1;
+    basdv::synchronize_device();
+    REQUIRE(bucket_prefix_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+}

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method2/multiproduct_table_kernel.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -1,0 +1,111 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <utility>
+
+#include "cub/cub.cuh"
+#include "sxt/algorithm/block/runlength_count.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/num/constexpr_switch.h"
+#include "sxt/base/num/divide_up.h"
+
+namespace sxt::mtxbk2 {
+//--------------------------------------------------------------------------------------------------
+// max_multiexponentiation_length_v
+//--------------------------------------------------------------------------------------------------
+static constexpr unsigned max_multiexponentiation_length_v = 128 * 32;
+
+//--------------------------------------------------------------------------------------------------
+// multiproduct_table_kernel
+//--------------------------------------------------------------------------------------------------
+template <uint16_t NumThreads, uint16_t ItemsPerThread, unsigned BitWidth>
+__global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
+                                          uint16_t* __restrict__ indexes,
+                                          const uint8_t* __restrict__ bytes, unsigned n) {
+  uint16_t thread_index = threadIdx.x;
+  auto digit_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+  auto num_digits = gridDim.x;
+  auto num_buckets_per_digit = (1u << BitWidth) - 1u;
+
+  // algorithms and shared memory
+  using RadixSort = cub::BlockRadixSort<uint8_t, NumThreads, ItemsPerThread, uint16_t>;
+  using RunlengthCount = algbk::runlength_count<uint8_t, uint16_t, NumThreads, (1u << BitWidth)>;
+  __shared__ union {
+    RadixSort::TempStorage sort;
+    RunlengthCount::temp_storage count;
+  } temp_storage;
+
+  // adjust pointers
+  bucket_counts += digit_index * num_buckets_per_digit;
+  bucket_counts += output_index * num_digits * num_buckets_per_digit;
+  indexes += digit_index * n;
+  indexes += output_index * num_digits * n;
+  bytes += digit_index * n;
+  bytes += output_index * num_digits * n;
+
+  // load bytes
+  uint8_t keys[ItemsPerThread];
+  uint16_t values[ItemsPerThread];
+  for (uint16_t i = 0; i < ItemsPerThread; ++i) {
+    auto index = thread_index + i * NumThreads;
+    if (index < n) {
+      keys[i] = bytes[index];
+      values[i] = index;
+    } else {
+      keys[i] = 0;
+      values[i] = 0;
+    }
+  }
+
+  // sort
+  RadixSort(temp_storage.sort).Sort(keys, values);
+
+  // count
+  auto counts = RunlengthCount(temp_storage.count).count(keys);
+  __syncthreads();
+
+  // write counts
+  for (unsigned i = thread_index; i < num_buckets_per_digit; i += NumThreads) {
+    bucket_counts[i] = counts[i + 1];
+  }
+
+  // write indexes
+  auto zero_count = counts[0];
+  for (unsigned i = 0; i < ItemsPerThread; ++i) {
+    auto index = i + thread_index * ItemsPerThread;
+    if (index >= zero_count) {
+      indexes[index - zero_count] = values[i];
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// fit_multiproduct_table_kernel
+//--------------------------------------------------------------------------------------------------
+template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
+  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
+  if (n < 128) {
+    return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, 1>{});
+  }
+  basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
+      basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
+        return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});
+      });
+}
+} // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -100,9 +100,6 @@ __global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
 //--------------------------------------------------------------------------------------------------
 template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
   SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
-  if (n < 128) {
-    return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, 1>{});
-  }
   basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
       basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
         return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.t.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.t.cc
@@ -1,0 +1,100 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/bucket_method2/multiproduct_table_kernel.h"
+
+#include <vector>
+
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxbk2;
+
+TEST_CASE("we can compute a bucket decomposition") {
+  std::pmr::vector<uint16_t> bucket_counts{memr::get_managed_device_resource()};
+  std::pmr::vector<uint16_t> indexes{memr::get_managed_device_resource()};
+  std::pmr::vector<uint8_t> bytes{memr::get_managed_device_resource()};
+
+  std::pmr::vector<uint16_t> expected_counts;
+  std::pmr::vector<uint16_t> expected_indexes;
+
+  SECTION("we handle the case of a single element of 0") {
+    bucket_counts.resize(1);
+    indexes.resize(1);
+    bytes = {0u};
+    multiproduct_table_kernel<32, 1, 1>
+        <<<1, 32>>>(bucket_counts.data(), indexes.data(), bytes.data(), bytes.size());
+    expected_counts.resize(1);
+    expected_indexes.resize(1);
+    basdv::synchronize_device();
+    REQUIRE(bucket_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+
+  SECTION("we handle the case of a single element of 1") {
+    bucket_counts.resize(1);
+    indexes.resize(1);
+    bytes = {1u};
+    multiproduct_table_kernel<32, 1, 1>
+        <<<1, 32>>>(bucket_counts.data(), indexes.data(), bytes.data(), bytes.size());
+    expected_counts = {1u};
+    expected_indexes.resize(1);
+    basdv::synchronize_device();
+    REQUIRE(bucket_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+
+  SECTION("we handle the case of two elements of zero") {
+    bucket_counts.resize(1);
+    indexes.resize(2);
+    bytes = {0u, 0u};
+    multiproduct_table_kernel<32, 1, 1>
+        <<<1, 32>>>(bucket_counts.data(), indexes.data(), bytes.data(), bytes.size());
+    expected_counts = {0u};
+    expected_indexes.resize(2);
+    basdv::synchronize_device();
+    REQUIRE(bucket_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+
+  SECTION("we handle the case of two elements of zero and one") {
+    bucket_counts.resize(1);
+    indexes.resize(2);
+    bytes = {0u, 1u};
+    multiproduct_table_kernel<32, 1, 1>
+        <<<1, 32>>>(bucket_counts.data(), indexes.data(), bytes.data(), bytes.size());
+    expected_counts = {1u};
+    expected_indexes = {1u, 0u};
+    basdv::synchronize_device();
+    REQUIRE(bucket_counts == expected_counts);
+    REQUIRE(indexes == expected_indexes);
+  }
+}
+
+TEST_CASE("we can fit parameters for a multiproduct kernel") {
+  for (unsigned n = 1; n <= max_multiexponentiation_length_v; ++n) {
+    fit_multiproduct_table_kernel(
+        [&]<unsigned NumThreads, unsigned ItemsPerThread>(
+            std::integral_constant<unsigned, NumThreads>,
+            std::integral_constant<unsigned, ItemsPerThread>) noexcept {
+          REQUIRE(NumThreads * ItemsPerThread >= n);
+          REQUIRE(NumThreads * (ItemsPerThread - 1) < n);
+        },
+        n);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Compute the multi-product table for a version of the bucket method that better handles many outputs.

# What changes are included in this PR?

* Added a component to compute the multiproduct table for the bucket method.

# Are these changes tested?

Yes.
