### PR TITLE
feat: add random element generators to bls12-381 and bn254 curves (PROOF-511)

### DIFF
--- a/sxt/curve_bng1/random/BUILD
+++ b/sxt/curve_bng1/random/BUILD
@@ -1,0 +1,19 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "element_p2",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_bng1/property:curve",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/curve_bng1/constant:generator",
+        "//sxt/curve_bng1/operation:scalar_multiply",
+        "//sxt/curve_bng1/type:element_p2",
+    ],
+)

--- a/sxt/curve_bng1/random/element_p2.cc
+++ b/sxt/curve_bng1/random/element_p2.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_bng1/random/element_p2.h"

--- a/sxt/curve_bng1/random/element_p2.h
+++ b/sxt/curve_bng1/random/element_p2.h
@@ -31,6 +31,8 @@ namespace sxt::cn1rn {
 /**
  * Generates a random scalar point and multiplies by
  * the generator to generate a random point on the curve.
+ * Note: the random scalar does not respect the modulus of the curve's scalar field.
+ * This is okay for benchmarks, but not for secure random element generation.
  */
 CUDA_CALLABLE
 inline void generate_random_element(cn1t::element_p2& a,

--- a/sxt/curve_bng1/random/element_p2.h
+++ b/sxt/curve_bng1/random/element_p2.h
@@ -1,0 +1,48 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstring>
+
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/curve_bng1/constant/generator.h"
+#include "sxt/curve_bng1/operation/scalar_multiply.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+
+namespace sxt::cn1rn {
+//--------------------------------------------------------------------------------------------------
+// generate_random_element
+//--------------------------------------------------------------------------------------------------
+/**
+ * Generates a random scalar point and multiplies by
+ * the generator to generate a random point on the curve.
+ */
+CUDA_CALLABLE
+inline void generate_random_element(cn1t::element_p2& a,
+                                    basn::fast_random_number_generator& rng) noexcept {
+  // Generate random scalar
+  uint8_t data[32] = {};
+  for (int i = 0; i < 32; i += 8) {
+    auto x = rng();
+    std::memcpy(static_cast<void*>(data + i), static_cast<void*>(&x), sizeof(x));
+  }
+
+  // Generate random point by multiplying the generator by the scalar
+  cn1o::scalar_multiply255(a, cn1cn::generator_p2_v, data);
+}
+} // namespace sxt::cn1rn

--- a/sxt/curve_bng1/random/element_p2.t.cc
+++ b/sxt/curve_bng1/random/element_p2.t.cc
@@ -1,0 +1,38 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_bng1/random/element_p2.h"
+
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_bng1/property/curve.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+
+using namespace sxt;
+using namespace sxt::cn1rn;
+
+TEST_CASE("random element generation") {
+  basn::fast_random_number_generator rng{1, 2};
+
+  SECTION("will return different values on the curve if called multiple times") {
+    cn1t::element_p2 e1, e2;
+    generate_random_element(e1, rng);
+    generate_random_element(e2, rng);
+    REQUIRE(e1 != e2);
+    REQUIRE(cn1p::is_on_curve(e1));
+    REQUIRE(cn1p::is_on_curve(e2));
+  }
+}

--- a/sxt/curve_g1/random/BUILD
+++ b/sxt/curve_g1/random/BUILD
@@ -1,0 +1,19 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "element_p2",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/curve_g1/property:curve",
+    ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/curve_g1/constant:generator",
+        "//sxt/curve_g1/operation:scalar_multiply",
+        "//sxt/curve_g1/type:element_p2",
+    ],
+)

--- a/sxt/curve_g1/random/element_p2.cc
+++ b/sxt/curve_g1/random/element_p2.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/random/element_p2.h"

--- a/sxt/curve_g1/random/element_p2.h
+++ b/sxt/curve_g1/random/element_p2.h
@@ -31,6 +31,8 @@ namespace sxt::cg1rn {
 /**
  * Generates a random scalar point and multiplies by
  * the generator to generate a random point on the curve.
+ * Note: the random scalar does not respect the modulus of the curve's scalar field.
+ * This is okay for benchmarks, but not for secure random element generation.*
  */
 CUDA_CALLABLE
 inline void generate_random_element(cg1t::element_p2& a,

--- a/sxt/curve_g1/random/element_p2.h
+++ b/sxt/curve_g1/random/element_p2.h
@@ -1,0 +1,48 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cstring>
+
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/curve_g1/constant/generator.h"
+#include "sxt/curve_g1/operation/scalar_multiply.h"
+#include "sxt/curve_g1/type/element_p2.h"
+
+namespace sxt::cg1rn {
+//--------------------------------------------------------------------------------------------------
+// generate_random_element
+//--------------------------------------------------------------------------------------------------
+/**
+ * Generates a random scalar point and multiplies by
+ * the generator to generate a random point on the curve.
+ */
+CUDA_CALLABLE
+inline void generate_random_element(cg1t::element_p2& a,
+                                    basn::fast_random_number_generator& rng) noexcept {
+  // Generate random scalar
+  uint8_t data[32] = {};
+  for (int i = 0; i < 32; i += 8) {
+    auto x = rng();
+    std::memcpy(static_cast<void*>(data + i), static_cast<void*>(&x), sizeof(x));
+  }
+
+  // Generate random point by multiplying the generator by the scalar
+  cg1o::scalar_multiply255(a, cg1cn::generator_p2_v, data);
+}
+} // namespace sxt::cg1rn

--- a/sxt/curve_g1/random/element_p2.t.cc
+++ b/sxt/curve_g1/random/element_p2.t.cc
@@ -1,0 +1,38 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/curve_g1/random/element_p2.h"
+
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve_g1/property/curve.h"
+#include "sxt/curve_g1/type/element_p2.h"
+
+using namespace sxt;
+using namespace sxt::cg1rn;
+
+TEST_CASE("random element generation") {
+  basn::fast_random_number_generator rng{1, 2};
+
+  SECTION("will return different values on the curve if called multiple times") {
+    cg1t::element_p2 e1, e2;
+    generate_random_element(e1, rng);
+    generate_random_element(e2, rng);
+    REQUIRE(e1 != e2);
+    REQUIRE(cg1p::is_on_curve(e1));
+    REQUIRE(cg1p::is_on_curve(e2));
+  }
+}


### PR DESCRIPTION
# Rationale for this change
Random element generators are needed to run benchmarks on curve addition primitives. This work adds random element generators to the `bn254` and `bls12-381` curves.

The random element is generated by generating a random scalar and multiplying the number by the curve's generator. Note, the random scalar does not respect the modulus of the curve's scalar field. This is okay for benchmarks, but not for secure random element generation. The scalar field packages have not been implemented yet.

# What changes are included in this PR?
- A `random` component is added to both the `curve_g1` and `curve_bng1` packages.

# Are these changes tested?
Yes.