### PR TITLE
bench: add bls12-381 primitive benchmarks (PROOF-804)

### DIFF
--- a/benchmark/primitives/BUILD
+++ b/benchmark/primitives/BUILD
@@ -1,0 +1,64 @@
+load("//bazel:sxt_benchmark.bzl", "sxt_cc_benchmark")
+load("//bazel:sxt_build_system.bzl", "sxt_cc_library")
+
+sxt_cc_benchmark(
+    name = "benchmark",
+    srcs = [
+        "benchmark.m.cc",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":curve_ops_bls12_381",
+        ":field_ops_bls12_381",
+    ],
+)
+
+sxt_cc_library(
+    name = "curve_ops_bls12_381",
+    srcs = [
+        "curve_ops_bls12_381.cu",
+    ],
+    hdrs = [
+        "curve_ops_bls12_381.h",
+    ],
+    deps = [
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/curve_g1/operation:add",
+        "//sxt/curve_g1/random:element_p2",
+        "//sxt/curve_g1/type:element_p2",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_library(
+    name = "field_ops_bls12_381",
+    srcs = [
+        "field_ops_bls12_381.cu",
+    ],
+    hdrs = [
+        "field_ops_bls12_381.h",
+    ],
+    deps = [
+        ":stats",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/field12/operation:add",
+        "//sxt/field12/operation:mul",
+        "//sxt/field12/random:element",
+        "//sxt/field12/type:element",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_library(
+    name = "stats",
+    srcs = [
+        "stats.cc",
+    ],
+    hdrs = [
+        "stats.h",
+    ],
+)

--- a/benchmark/primitives/README.md
+++ b/benchmark/primitives/README.md
@@ -1,0 +1,21 @@
+# Benchmarking for primitives on the GPU
+Currently only supports benchmarks for addition with `bls12-381` curve elements. Creates two vectors of size `<n_elements>` and does vector addition with them `<repetitions>` number of times. Timing results are output in milliseconds.
+
+This benchmark is similar to the Icicle's [example/multiply](https://github.com/ingonyama-zk/icicle/tree/40309329fbf6c5fc7e77d629c72b4a3d28036444/examples/c%2B%2B/multiply), but updated to measure curve addition, field addition, and field multiplication.
+
+## Usages
+`bazel run -c opt //benchmark/primitives:benchmark <curve> <op> <n_elements> <repetitions> <optional - n_threads> <optional - n_executions>`
+
+- `curve`: specifies the curve. Currently only supports `bls12_381`
+- `op`: specifies what operations to target, either `curve` or `field`
+- `n_elements`: specifies the number of elements in the vector
+- `repetitions`: specifies the number of operations executed for each element of the vector
+- `n_threads`: specifies the max number of threads per block
+- `n_executions`: specifies the number of executions used when measuring benchmark statistics
+
+## Example
+Run curve operations using `bls12-381` elements.  
+`bazel run -c opt //benchmark/primitives:benchmark bls12_381 curve 10000 1000 256 10`
+
+Run field operations (addition and multiplication) using `bls12-381` elements.  
+`bazel run -c opt //benchmark/primitives:benchmark bls12_381 field 1000000 1000 256 10`

--- a/benchmark/primitives/benchmark.m.cc
+++ b/benchmark/primitives/benchmark.m.cc
@@ -1,0 +1,62 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <print>
+
+#include "benchmark/primitives/curve_ops_bls12_381.h"
+#include "benchmark/primitives/field_ops_bls12_381.h"
+
+using namespace sxt;
+
+int main(int argc, char* argv[]) {
+  if (argc < 5) {
+    std::print("Usage: benchmark <curve> <op> <n_elements> <repetitions> <optional - n_threads> "
+               "<optional - n_executions>\n");
+    return -1;
+  }
+
+  const std::string curve = argv[1];
+  const std::string op = argv[2];
+  auto n_elements = std::atoi(argv[3]);
+  auto repetitions = std::atoi(argv[4]);
+  auto n_threads = (argc > 5) ? std::atoi(argv[5]) : 256;
+  auto n_executions = (argc > 6) ? std::atoi(argv[6]) : 10;
+
+  std::println("===== benchmark results =====");
+  std::println("backend : GPU");
+  std::println("curve : {}", curve);
+  std::println("operation : {}", op);
+  std::println("Number of elements : {}", n_elements);
+  std::println("Repetitions : {}", repetitions);
+  std::println("Max threads per block : {}", n_threads);
+  std::println("Number of executions : {}", n_executions);
+  std::println("*****************************");
+
+  if (curve == "bls12_381") {
+    if (op == "curve") {
+      curve_ops_bls12_381(n_elements, repetitions, n_threads, n_executions);
+    } else if (op == "field") {
+      field_ops_bls12_381("add", n_elements, repetitions, n_threads, n_executions);
+      field_ops_bls12_381("mul", n_elements, repetitions, n_threads, n_executions);
+    }
+  }
+
+  std::println("******************************");
+  std::println("===== benchmark complete =====");
+  std::println("******************************");
+
+  return 0;
+}

--- a/benchmark/primitives/curve_ops_bls12_381.cu
+++ b/benchmark/primitives/curve_ops_bls12_381.cu
@@ -1,0 +1,134 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "curve_ops_bls12_381.h"
+
+#include <chrono>
+#include <print>
+
+#include "stats.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/curve_g1/operation/add.h"
+#include "sxt/curve_g1/random/element_p2.h"
+#include "sxt/curve_g1/type/element_p2.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// vector_add_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void vector_add_impl(cg1t::element_p2* __restrict__ vec_ret,
+                                const cg1t::element_p2* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    cg1t::element_p2 x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      cg1o::add(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_add
+//--------------------------------------------------------------------------------------------------
+void vector_add(cg1t::element_p2* vec_result, const cg1t::element_p2* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_add_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void init_random_array_impl(cg1t::element_p2* __restrict__ rand, unsigned n_elements) {
+    int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < n_elements)
+    {
+        basn::fast_random_number_generator rng{static_cast<uint64_t>(tid + 1),
+                                               static_cast<uint64_t>(n_elements + 1)};
+        cg1rn::generate_random_element(rand[tid], rng);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array
+//--------------------------------------------------------------------------------------------------
+void init_random_array(cg1t::element_p2* rand, unsigned n_elements, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    init_random_array_impl<<<num_blocks, threads_per_block>>>(rand, n_elements);
+}
+
+//--------------------------------------------------------------------------------------------------
+// curve_ops_bls12_381
+//--------------------------------------------------------------------------------------------------
+void curve_ops_bls12_381(unsigned n_elements, unsigned repetitions, unsigned n_threads, unsigned n_executions) noexcept {
+  std::println("curve_ops_bls12_381 add");
+
+  // Allocate memory for the input and output vectors
+  memmg::managed_array<cg1t::element_p2> a(n_elements, memr::get_device_resource());
+  memmg::managed_array<cg1t::element_p2> ret(n_elements, memr::get_device_resource());
+
+  // Populate the input vectors with random curve elements
+  init_random_array(a.data(), n_elements, n_threads);
+
+  // Warm-up loop
+  vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  cudaDeviceSynchronize();
+
+  // Report any errors from the warmup loop
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    std::println("CUDA error: {}", cudaGetErrorString(err));
+  }
+
+  // Benchmarking loop
+  std::vector<double> elapsed_times;
+  for (unsigned i = 0; i < n_executions; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+    vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    cudaDeviceSynchronize();
+    auto end_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    elapsed_times.push_back(duration.count());
+
+    // Report any errors from the benchmark loop
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+      std::println("CUDA error: {}", cudaGetErrorString(err));
+    }
+  }
+
+  // Report data
+  std::println("Final benchmarks over {} executions", n_executions);
+  std::println("...Median : {} ms", sxt::median(elapsed_times));
+  std::println("...Min    : {} ms", sxt::min(elapsed_times));
+  std::println("...Max    : {} ms", sxt::max(elapsed_times));
+  std::println("...Mean   : {} ms", sxt::mean(elapsed_times));
+  std::println("...STD    : {} ms", sxt::std_dev(elapsed_times));
+  std::println("...Performance : {} Giga Curve Additions Per Second", sxt::gmps(elapsed_times, repetitions, n_elements));
+  std::println("");
+}
+}

--- a/benchmark/primitives/curve_ops_bls12_381.h
+++ b/benchmark/primitives/curve_ops_bls12_381.h
@@ -1,0 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// curve_ops_bls12_381
+//--------------------------------------------------------------------------------------------------
+void curve_ops_bls12_381(unsigned n_elements, unsigned repetitions, unsigned n_threads = 256,
+                         unsigned n_executions = 10) noexcept;
+} // namespace sxt

--- a/benchmark/primitives/field_ops_bls12_381.cu
+++ b/benchmark/primitives/field_ops_bls12_381.cu
@@ -1,0 +1,173 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "field_ops_bls12_381.h"
+
+#include <chrono>
+#include <format>
+#include <print>
+
+#include "stats.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/field12/operation/add.h"
+#include "sxt/field12/operation/mul.h"
+#include "sxt/field12/random/element.h"
+#include "sxt/field12/type/element.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// vector_add_impl 
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+__global__ void vector_add_impl(T* __restrict__ vec_ret,
+                                const T* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    T x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      f12o::add(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_mul_impl 
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+__global__ void vector_mul_impl(T* __restrict__ vec_ret,
+                                const T* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    T x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      f12o::mul(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_add 
+//--------------------------------------------------------------------------------------------------
+void vector_add(f12t::element* vec_result, const f12t::element* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_add_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_mul
+//--------------------------------------------------------------------------------------------------
+void vector_mul(f12t::element* vec_result, const f12t::element* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_mul_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void init_random_array_impl(f12t::element* __restrict__ rand, unsigned n_elements) {
+    int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < n_elements)
+    {
+        basn::fast_random_number_generator rng{static_cast<uint64_t>(tid + 1),
+                                               static_cast<uint64_t>(n_elements + 1)};
+        f12rn::generate_random_element(rand[tid], rng);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array
+//--------------------------------------------------------------------------------------------------
+void init_random_array(f12t::element* rand, unsigned n_elements, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    init_random_array_impl<<<num_blocks, threads_per_block>>>(rand, n_elements);
+}
+
+//--------------------------------------------------------------------------------------------------
+// field_ops_bls12_381
+//--------------------------------------------------------------------------------------------------
+void field_ops_bls12_381(std::string op, unsigned n_elements, unsigned repetitions, unsigned n_threads, unsigned n_executions) noexcept {
+  std::println("field_ops_bls12_381 for {}", op);
+
+  // Allocate memory for the input and output vectors
+  memmg::managed_array<f12t::element> a(n_elements, memr::get_device_resource());
+  memmg::managed_array<f12t::element> ret(n_elements, memr::get_device_resource());
+
+  // Populate the input vectors with random curve elements
+  init_random_array(a.data(), n_elements, n_threads);
+
+  // Warm-up loop
+  if (op == "add") {
+    vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  } else {
+    vector_mul(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  }
+  cudaDeviceSynchronize();
+
+  // Report any errors from the warm up loop
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    std::println("CUDA error: {}", cudaGetErrorString(err));
+  }
+
+  // Benchmarking loop
+  std::vector<double> elapsed_times;
+  for (unsigned i = 0; i < n_executions; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+    if (op == "add") {
+      vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    } else {
+      vector_mul(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    }
+    cudaDeviceSynchronize();
+    auto end_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    elapsed_times.push_back(duration.count());
+
+    // Report any errors from the benchmark loop
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+      std::println("CUDA error: {}", cudaGetErrorString(err));
+    }
+  }
+
+  // Report data
+  std::println("Final benchmarks over {} executions", n_executions);
+  std::println("...Median : {} ms", sxt::median(elapsed_times));
+  std::println("...Min    : {} ms", sxt::min(elapsed_times));
+  std::println("...Max    : {} ms", sxt::max(elapsed_times));
+  std::println("...Mean   : {} ms", sxt::mean(elapsed_times));
+  std::println("...STD    : {} ms", sxt::std_dev(elapsed_times));
+  std::println("...Performance : {} Giga Field {} Per Second", sxt::gmps(elapsed_times, repetitions, n_elements), op);
+  std::println("");
+}
+}

--- a/benchmark/primitives/field_ops_bls12_381.h
+++ b/benchmark/primitives/field_ops_bls12_381.h
@@ -1,0 +1,27 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// field_ops_bls12_381
+//--------------------------------------------------------------------------------------------------
+void field_ops_bls12_381(std::string op, unsigned n_elements, unsigned repetitions,
+                         unsigned n_threads = 256, unsigned n_executions = 10) noexcept;
+} // namespace sxt

--- a/benchmark/primitives/stats.cc
+++ b/benchmark/primitives/stats.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "stats.h"

--- a/benchmark/primitives/stats.h
+++ b/benchmark/primitives/stats.h
@@ -1,0 +1,82 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// min
+//--------------------------------------------------------------------------------------------------
+template <class T> static T min(const std::vector<T>& data) {
+  return *std::min_element(data.begin(), data.end());
+}
+
+//--------------------------------------------------------------------------------------------------
+// max
+//--------------------------------------------------------------------------------------------------
+template <class T> static T max(const std::vector<T>& data) {
+  return *std::max_element(data.begin(), data.end());
+}
+
+//--------------------------------------------------------------------------------------------------
+// mean
+//--------------------------------------------------------------------------------------------------
+template <class T> static T mean(const std::vector<T>& data) {
+  return std::accumulate(data.begin(), data.end(), 0.0) / data.size();
+}
+
+//--------------------------------------------------------------------------------------------------
+// std_dev
+//--------------------------------------------------------------------------------------------------
+template <class T> static T std_dev(const std::vector<T>& data) {
+  const T mean = sxt::mean(data);
+  const T variance = std::accumulate(data.begin(), data.end(), 0.0,
+                                     [mean](T accumulator, T val) {
+                                       return accumulator + (val - mean) * (val - mean);
+                                     }) /
+                     data.size();
+  return std::sqrt(variance);
+}
+
+//--------------------------------------------------------------------------------------------------
+// median
+//--------------------------------------------------------------------------------------------------
+template <class T> static T median(const std::vector<T>& data) {
+  std::vector<T> sorted_data = data;
+  std::sort(sorted_data.begin(), sorted_data.end());
+  if (sorted_data.size() % 2 == 0) {
+    return (sorted_data[sorted_data.size() / 2 - 1] + sorted_data[sorted_data.size() / 2]) / 2;
+  } else {
+    return sorted_data[sorted_data.size() / 2];
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// gmps
+//--------------------------------------------------------------------------------------------------
+/**
+ * Giga operations per second. The data vector must be in milliseconds.
+ */
+template <class T>
+static T gmps(const std::vector<T>& data, unsigned repetitions, unsigned n_elements) {
+  const T median = sxt::median(data);
+  return 1.0e-9 * repetitions * n_elements / (1.0e-3 * median);
+}
+} // namespace sxt

--- a/benchmark/primitives/stats.h
+++ b/benchmark/primitives/stats.h
@@ -51,7 +51,7 @@ template <class T> static T std_dev(const std::vector<T>& data) {
                                      [mean](T accumulator, T val) {
                                        return accumulator + (val - mean) * (val - mean);
                                      }) /
-                     data.size();
+                     (data.size() - 1);
   return std::sqrt(variance);
 }
 
@@ -60,11 +60,15 @@ template <class T> static T std_dev(const std::vector<T>& data) {
 //--------------------------------------------------------------------------------------------------
 template <class T> static T median(const std::vector<T>& data) {
   std::vector<T> sorted_data = data;
-  std::sort(sorted_data.begin(), sorted_data.end());
+
+  auto n = sorted_data.size() / 2;
+  std::nth_element(sorted_data.begin(), sorted_data.begin() + n, sorted_data.end());
+
   if (sorted_data.size() % 2 == 0) {
-    return (sorted_data[sorted_data.size() / 2 - 1] + sorted_data[sorted_data.size() / 2]) / 2;
+    T max_of_lower_half = *std::max_element(sorted_data.begin(), sorted_data.begin() + n);
+    return (max_of_lower_half + sorted_data[n]) / 2;
   } else {
-    return sorted_data[sorted_data.size() / 2];
+    return sorted_data[n];
   }
 }
 


### PR DESCRIPTION
# Rationale for this change
Measuring primitive performance inside of Blitzar will help us identify where to focus improvement efforts. This work adds primitive benchmarks for `bls12-381` curve addition, field addition, and field multiplication inside of Blitzar.

A follow up PR will add primitive benchmarks for the `bn254` curve.

# What changes are included in this PR?
- A new benchmark package is added, `primitives`.
- Files to support measuring curve addition, field addition, and field multiplication for `bls12-381` elements are added.

# Are these changes tested?
Yes