### PR TITLE
bench: add bn254 primitive benchmarks (PROOF-804)

### DIFF
--- a/benchmark/primitives/BUILD
+++ b/benchmark/primitives/BUILD
@@ -9,7 +9,9 @@ sxt_cc_benchmark(
     visibility = ["//visibility:public"],
     deps = [
         ":curve_ops_bls12_381",
+        ":curve_ops_bn254",
         ":field_ops_bls12_381",
+        ":field_ops_bn254",
     ],
 )
 
@@ -33,6 +35,25 @@ sxt_cc_library(
 )
 
 sxt_cc_library(
+    name = "curve_ops_bn254",
+    srcs = [
+        "curve_ops_bn254.cu",
+    ],
+    hdrs = [
+        "curve_ops_bn254.h",
+    ],
+    deps = [
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/curve_bng1/operation:add",
+        "//sxt/curve_bng1/random:element_p2",
+        "//sxt/curve_bng1/type:element_p2",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_library(
     name = "field_ops_bls12_381",
     srcs = [
         "field_ops_bls12_381.cu",
@@ -48,6 +69,27 @@ sxt_cc_library(
         "//sxt/field12/operation:mul",
         "//sxt/field12/random:element",
         "//sxt/field12/type:element",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_library(
+    name = "field_ops_bn254",
+    srcs = [
+        "field_ops_bn254.cu",
+    ],
+    hdrs = [
+        "field_ops_bn254.h",
+    ],
+    deps = [
+        ":stats",
+        "//sxt/base/num:divide_up",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/field25/operation:add",
+        "//sxt/field25/operation:mul",
+        "//sxt/field25/random:element",
+        "//sxt/field25/type:element",
         "//sxt/memory/management:managed_array",
         "//sxt/memory/resource:device_resource",
     ],

--- a/benchmark/primitives/README.md
+++ b/benchmark/primitives/README.md
@@ -17,5 +17,11 @@ This benchmark is similar to the Icicle's [example/multiply](https://github.com/
 Run curve operations using `bls12-381` elements.  
 `bazel run -c opt //benchmark/primitives:benchmark bls12_381 curve 10000 1000 256 10`
 
+Run curve operations using `bn254` elements.  
+`bazel run -c opt //benchmark/primitives:benchmark bn254 curve 10000 1000 256 10`
+
 Run field operations (addition and multiplication) using `bls12-381` elements.  
 `bazel run -c opt //benchmark/primitives:benchmark bls12_381 field 1000000 1000 256 10`
+
+Run field operations (addition and multiplication) using `bn254` elements.  
+`bazel run -c opt //benchmark/primitives:benchmark bn254 field 1000000 1000 256 10`

--- a/benchmark/primitives/benchmark.m.cc
+++ b/benchmark/primitives/benchmark.m.cc
@@ -17,7 +17,9 @@
 #include <print>
 
 #include "benchmark/primitives/curve_ops_bls12_381.h"
+#include "benchmark/primitives/curve_ops_bn254.h"
 #include "benchmark/primitives/field_ops_bls12_381.h"
+#include "benchmark/primitives/field_ops_bn254.h"
 
 using namespace sxt;
 
@@ -52,6 +54,15 @@ int main(int argc, char* argv[]) {
       field_ops_bls12_381("add", n_elements, repetitions, n_threads, n_executions);
       field_ops_bls12_381("mul", n_elements, repetitions, n_threads, n_executions);
     }
+  } else if (curve == "bn254") {
+    if (op == "curve") {
+      curve_ops_bn254(n_elements, repetitions, n_threads, n_executions);
+    } else if (op == "field") {
+      field_ops_bn254("add", n_elements, repetitions, n_threads, n_executions);
+      field_ops_bn254("mul", n_elements, repetitions, n_threads, n_executions);
+    }
+  } else {
+    std::println("curve not supported");
   }
 
   std::println("******************************");

--- a/benchmark/primitives/curve_ops_bn254.cu
+++ b/benchmark/primitives/curve_ops_bn254.cu
@@ -1,0 +1,134 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "curve_ops_bn254.h"
+
+#include <chrono>
+#include <print>
+
+#include "stats.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/curve_bng1/operation/add.h"
+#include "sxt/curve_bng1/random/element_p2.h"
+#include "sxt/curve_bng1/type/element_p2.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// vector_add_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void vector_add_impl(cn1t::element_p2* __restrict__ vec_ret,
+                                const cn1t::element_p2* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    cn1t::element_p2 x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      cn1o::add(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_add
+//--------------------------------------------------------------------------------------------------
+void vector_add(cn1t::element_p2* vec_result, const cn1t::element_p2* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_add_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void init_random_array_impl(cn1t::element_p2* __restrict__ rand, unsigned n_elements) {
+    int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < n_elements)
+    {
+        basn::fast_random_number_generator rng{static_cast<uint64_t>(tid + 1),
+                                               static_cast<uint64_t>(n_elements + 1)};
+        cn1rn::generate_random_element(rand[tid], rng);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array
+//--------------------------------------------------------------------------------------------------
+void init_random_array(cn1t::element_p2* rand, unsigned n_elements, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    init_random_array_impl<<<num_blocks, threads_per_block>>>(rand, n_elements);
+}
+
+//--------------------------------------------------------------------------------------------------
+// curve_ops_bn254
+//--------------------------------------------------------------------------------------------------
+void curve_ops_bn254(unsigned n_elements, unsigned repetitions, unsigned n_threads, unsigned n_executions) noexcept {
+  std::println("curve_ops_bn254 add");
+
+  // Allocate memory for the input and output vectors
+  memmg::managed_array<cn1t::element_p2> a(n_elements, memr::get_device_resource());
+  memmg::managed_array<cn1t::element_p2> ret(n_elements, memr::get_device_resource());
+
+  // Populate the input vectors with random curve elements
+  init_random_array(a.data(), n_elements, n_threads);
+
+  // Warm-up loop
+  vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  cudaDeviceSynchronize();
+
+  // Report any errors from the warmup loop
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    std::println("CUDA error: {}", cudaGetErrorString(err));
+  }
+
+  // Benchmarking loop
+  std::vector<double> elapsed_times;
+  for (unsigned i = 0; i < n_executions; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+    vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    cudaDeviceSynchronize();
+    auto end_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    elapsed_times.push_back(duration.count());
+
+    // Report any errors from the benchmark loop
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+      std::println("CUDA error: {}", cudaGetErrorString(err));
+    }
+  }
+
+  // Report data
+  std::println("Final benchmarks over {} executions", n_executions);
+  std::println("...Median : {} ms", sxt::median(elapsed_times));
+  std::println("...Min    : {} ms", sxt::min(elapsed_times));
+  std::println("...Max    : {} ms", sxt::max(elapsed_times));
+  std::println("...Mean   : {} ms", sxt::mean(elapsed_times));
+  std::println("...STD    : {} ms", sxt::std_dev(elapsed_times));
+  std::println("...Performance : {} Giga Curve Additions Per Second", sxt::gmps(elapsed_times, repetitions, n_elements));
+  std::println("");
+}
+}

--- a/benchmark/primitives/curve_ops_bn254.h
+++ b/benchmark/primitives/curve_ops_bn254.h
@@ -1,0 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// curve_ops_bn254
+//--------------------------------------------------------------------------------------------------
+void curve_ops_bn254(unsigned n_elements, unsigned repetitions, unsigned n_threads = 256,
+                     unsigned n_executions = 10) noexcept;
+} // namespace sxt

--- a/benchmark/primitives/field_ops_bn254.cu
+++ b/benchmark/primitives/field_ops_bn254.cu
@@ -1,0 +1,173 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "field_ops_bn254.h"
+
+#include <chrono>
+#include <format>
+#include <print>
+
+#include "stats.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/field25/operation/add.h"
+#include "sxt/field25/operation/mul.h"
+#include "sxt/field25/random/element.h"
+#include "sxt/field25/type/element.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// vector_add_impl 
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+__global__ void vector_add_impl(T* __restrict__ vec_ret,
+                                const T* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    T x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      f25o::add(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_mul_impl 
+//--------------------------------------------------------------------------------------------------
+template <typename T>
+__global__ void vector_mul_impl(T* __restrict__ vec_ret,
+                                const T* __restrict__ vec_a,
+                                unsigned n_elements,
+                                unsigned repetitions) {
+  auto tid = blockDim.x * blockIdx.x + threadIdx.x;
+  if (tid < n_elements) {
+    T x = vec_a[tid];
+    auto res = x;
+    for (unsigned i = 0; i < repetitions; ++i) {
+      f25o::mul(res, res, x);
+    }
+    vec_ret[tid] = res;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_add 
+//--------------------------------------------------------------------------------------------------
+void vector_add(f25t::element* vec_result, const f25t::element* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_add_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+//--------------------------------------------------------------------------------------------------
+// vector_mul
+//--------------------------------------------------------------------------------------------------
+void vector_mul(f25t::element* vec_result, const f25t::element* vec_a, unsigned n_elements, unsigned repetitions, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    vector_mul_impl<<<num_blocks, threads_per_block>>>(vec_result, vec_a, n_elements, repetitions);
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array_impl 
+//--------------------------------------------------------------------------------------------------
+__global__ void init_random_array_impl(f25t::element* __restrict__ rand, unsigned n_elements) {
+    int tid = blockDim.x * blockIdx.x + threadIdx.x;
+    if (tid < n_elements)
+    {
+        basn::fast_random_number_generator rng{static_cast<uint64_t>(tid + 1),
+                                               static_cast<uint64_t>(n_elements + 1)};
+        f25rn::generate_random_element(rand[tid], rng);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// init_random_array
+//--------------------------------------------------------------------------------------------------
+void init_random_array(f25t::element* rand, unsigned n_elements, unsigned n_threads) {
+    const unsigned threads_per_block = n_threads;
+    const unsigned num_blocks = basn::divide_up(n_elements, threads_per_block);
+
+    init_random_array_impl<<<num_blocks, threads_per_block>>>(rand, n_elements);
+}
+
+//--------------------------------------------------------------------------------------------------
+// field_ops_bn254
+//--------------------------------------------------------------------------------------------------
+void field_ops_bn254(std::string op, unsigned n_elements, unsigned repetitions, unsigned n_threads, unsigned n_executions) noexcept {
+  std::println("field_ops_bn254 for {}", op);
+
+  // Allocate memory for the input and output vectors
+  memmg::managed_array<f25t::element> a(n_elements, memr::get_device_resource());
+  memmg::managed_array<f25t::element> ret(n_elements, memr::get_device_resource());
+
+  // Populate the input vectors with random curve elements
+  init_random_array(a.data(), n_elements, n_threads);
+
+  // Warm-up loop
+  if (op == "add") {
+    vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  } else {
+    vector_mul(ret.data(), a.data(), n_elements, repetitions, n_threads);
+  }
+  cudaDeviceSynchronize();
+
+  // Report any errors from the warm up loop
+  cudaError_t err = cudaGetLastError();
+  if (err != cudaSuccess) {
+    std::println("CUDA error: {}", cudaGetErrorString(err));
+  }
+
+  // Benchmarking loop
+  std::vector<double> elapsed_times;
+  for (unsigned i = 0; i < n_executions; ++i) {
+    auto start_time = std::chrono::steady_clock::now();
+    if (op == "add") {
+      vector_add(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    } else {
+      vector_mul(ret.data(), a.data(), n_elements, repetitions, n_threads);
+    }
+    cudaDeviceSynchronize();
+    auto end_time = std::chrono::steady_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(end_time - start_time);
+    elapsed_times.push_back(duration.count());
+
+    // Report any errors from the benchmark loop
+    err = cudaGetLastError();
+    if (err != cudaSuccess) {
+      std::println("CUDA error: {}", cudaGetErrorString(err));
+    }
+  }
+
+  // Report data
+  std::println("Final benchmarks over {} executions", n_executions);
+  std::println("...Median : {} ms", sxt::median(elapsed_times));
+  std::println("...Min    : {} ms", sxt::min(elapsed_times));
+  std::println("...Max    : {} ms", sxt::max(elapsed_times));
+  std::println("...Mean   : {} ms", sxt::mean(elapsed_times));
+  std::println("...STD    : {} ms", sxt::std_dev(elapsed_times));
+  std::println("...Performance : {} Giga Field {} Per Second", sxt::gmps(elapsed_times, repetitions, n_elements), op);
+  std::println("");
+}
+}

--- a/benchmark/primitives/field_ops_bn254.h
+++ b/benchmark/primitives/field_ops_bn254.h
@@ -1,0 +1,27 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2023-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+namespace sxt {
+//--------------------------------------------------------------------------------------------------
+// field_ops_bn254
+//--------------------------------------------------------------------------------------------------
+void field_ops_bn254(std::string op, unsigned n_elements, unsigned repetitions,
+                     unsigned n_threads = 256, unsigned n_executions = 10) noexcept;
+} // namespace sxt


### PR DESCRIPTION
# Rationale for this change
Measuring primitive performance inside of Blitzar will help us identify where to focus improvement efforts. This work adds primitive benchmarks for `bn254` curve addition, field addition, and field multiplication inside of Blitzar.

# What changes are included in this PR?
- Files to support measuring curve addition, field addition, and field multiplication for `bn254` elements are added.

# Are these changes tested?
Yes