### PR TITLE
feat: inline neg in the field12 and field25 base packages (PROOF-824)

### DIFF
--- a/sxt/field12/operation/BUILD
+++ b/sxt/field12/operation/BUILD
@@ -74,19 +74,16 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "neg",
-    impl_deps = [
-        "//sxt/base/field:arithmetic_utility",
-        "//sxt/field12/base:constants",
-        "//sxt/field12/type:element",
-    ],
-    is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field12/base:constants",
         "//sxt/field12/type:element",
     ],
     deps = [
+        "//sxt/base/field:arithmetic_utility",
         "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/base:constants",
+        "//sxt/field12/type:element",
     ],
 )
 

--- a/sxt/field12/operation/neg.cc
+++ b/sxt/field12/operation/neg.cc
@@ -14,43 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Adopted from zkcrypto/bls12_381
- *
- * Copyright (c) 2021
- * Sean Bowe <ewillbefull@gmail.com>
- * Jack Grigg <thestr4d@gmail.com>
- *
- * See third_party/license/zkcrypto.LICENSE
- */
 #include "sxt/field12/operation/neg.h"
-
-#include "sxt/base/field/arithmetic_utility.h"
-#include "sxt/field12/base/constants.h"
-#include "sxt/field12/type/element.h"
-
-namespace sxt::f12o {
-//--------------------------------------------------------------------------------------------------
-// neg
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void neg(f12t::element& h, const f12t::element& f) noexcept {
-  uint64_t d[6] = {};
-  uint64_t borrow{0};
-
-  basfld::sbb(d[0], borrow, f12b::p_v[0], f[0]);
-  basfld::sbb(d[1], borrow, f12b::p_v[1], f[1]);
-  basfld::sbb(d[2], borrow, f12b::p_v[2], f[2]);
-  basfld::sbb(d[3], borrow, f12b::p_v[3], f[3]);
-  basfld::sbb(d[4], borrow, f12b::p_v[4], f[4]);
-  basfld::sbb(d[5], borrow, f12b::p_v[5], f[5]);
-
-  // Let's use a mask if `self` was zero, which would mean
-  // the result of the subtraction is p.
-  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3] | f[4] | f[5]) == 0)} - uint64_t{1};
-
-  for (int i = 0; i < 6; ++i) {
-    h[i] = d[i] & mask;
-  }
-}
-} // namespace sxt::f12o

--- a/sxt/field12/operation/neg.h
+++ b/sxt/field12/operation/neg.h
@@ -14,18 +14,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
 #pragma once
 
+#include "sxt/base/field/arithmetic_utility.h"
 #include "sxt/base/macro/cuda_callable.h"
-
-namespace sxt::f12t {
-class element;
-}
+#include "sxt/field12/base/constants.h"
+#include "sxt/field12/type/element.h"
 
 namespace sxt::f12o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(f12t::element& h, const f12t::element& f) noexcept;
+inline void neg(f12t::element& h, const f12t::element& f) noexcept {
+  uint64_t d[6] = {};
+  uint64_t borrow{0};
+
+  basfld::sbb(d[0], borrow, f12b::p_v[0], f[0]);
+  basfld::sbb(d[1], borrow, f12b::p_v[1], f[1]);
+  basfld::sbb(d[2], borrow, f12b::p_v[2], f[2]);
+  basfld::sbb(d[3], borrow, f12b::p_v[3], f[3]);
+  basfld::sbb(d[4], borrow, f12b::p_v[4], f[4]);
+  basfld::sbb(d[5], borrow, f12b::p_v[5], f[5]);
+
+  // Let's use a mask if `self` was zero, which would mean
+  // the result of the subtraction is p.
+  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3] | f[4] | f[5]) == 0)} - uint64_t{1};
+
+  for (int i = 0; i < 6; ++i) {
+    h[i] = d[i] & mask;
+  }
+}
 } // namespace sxt::f12o


### PR DESCRIPTION
# Rationale for this change
In an effort to improve the performance of MSM with the `bls12-381` and `bn254` curve elements, field operation optimizations have been identified in the base field packages. This work is part of the performance improvements. The base field `neg` operation component is inlined. Results from primitive benchmarks, which is an average of three different GPU benchmarks (Single T4 VM, Multi T4 VM, and GeForce RXT 3080) GPU indicate that inlining the base field `neg` operation provides:

From previous performance PR (PROOF-823)
Curve ops
- 1.09x speed up of `bls12-381` curve addition from PROOF-823
- 1.04x speed up of `bn254` curve addition from PROOF-823

Field ops
- 1.08x speed up of `bls12-381` field addition from PROOF-823
- 1.02x speed up of `bn254` field addition from PROOF-823
- 1.01x slow down of `bls12-381` field multiplication from PROOF-823
- 1.01x slow down of `bn254` field multiplication from PROOF-823

From original performance
Curve ops
- 1.54x speed up of `bls12-381` curve addition from original
- 1.54x speed up of `bn254` curve addition from original

Field ops
- 1.03x slow down of `bls12-381` field addition from original
- 1.09x speed up of `bn254` field addition from original
- 1.89x speed up of `bls12-381` field multiplication from original
- 3.43x speed up of `bn254` field multiplication from original

In an effort to isolate inline refactoring and introducing inline assembly to Blitzar, the work in this PR has been broken into two pieces. This PR represents the first piece, inlining existing code. Speed ups of 1.09x and 1.04x do not represent much gain in performance. The full benefits will be realized when inline assembly is introduced. Inline assembly and inlining `neg` produced the best performance benchmark.

# What changes are included in this PR?
- The `f12o::neg` component is inlined.
- The `f25o::neg` component is inlined.

# Are these changes tested?
Yes