### PR TITLE
perf: implement inline assembly in base field arithmetic utility mac function (PROOF-825)

### DIFF
--- a/sxt/base/field/BUILD
+++ b/sxt/base/field/BUILD
@@ -6,7 +6,10 @@ load(
 sxt_cc_component(
     name = "arithmetic_utility",
     test_deps = [
+        "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",


### PR DESCRIPTION
# Rationale for this change
In an effort to improve the performance of MSM with the `bls12-381` and `bn254` curve elements, field operation optimizations have been identified in the base field packages. This work is part of the performance improvements. The base field arithmetic utility component's `mac` function should introduce inline assembly for CUDA architectures. Results from primitive benchmarks, which is an average of three different GPU benchmarks (Single T4 VM, Multi T4 VM, and GeForce RXT 3080) GPU indicate that the inline assembly improves curve ops in the following ways:

Curve ops  
- `bls12-381` curve addition
  - 1.20x speed up compared to previous work in PROOF-823
  - 1.85x speed up with PROOF-822, 823, and this PR
- `bn254` curve addition
  - 1.06x speed up compared to previous work in PROOF-823
  - 1.65x speed up with PROOF-822, 823, and this PR

Field ops  
- `bls12-381` field addition
  - 1.03x slow down compared to previous work in PROOF-823
  - no change with PROOF-822, 823, and this PR
- `bn254` field addition
  - 1.01x slow down compared to previous work in PROOF-823
  - 1.10x speed up with PROOF-822, 823, and this PR
- `bls12-381` field multiplication
  - 1.48.x speed up compared to previous work in PROOF-823
  - 2.80x speed up with PROOF-822, 823, and this PR
- `bn254` field multiplication
  - 1.27x speed up compared to previous work in PROOF-823
  - 4.38x speed up with PROOF-822, 823, and this PR

# What changes are included in this PR?
- Inline assembly is added to base field arithmetic utility component's `mac` function.
- Tests are added to base field arithmetic utility component.

# Are these changes tested?
Yes