### PR TITLE
feat: add a function to iterate over bit permutations (PROOF-831)

### DIFF
--- a/sxt/base/bit/BUILD
+++ b/sxt/base/bit/BUILD
@@ -31,11 +31,11 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "permutation",
-    deps = [
-      ":count",
-    ],
     test_deps = [
         "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":count",
     ],
 )
 

--- a/sxt/base/bit/BUILD
+++ b/sxt/base/bit/BUILD
@@ -30,6 +30,16 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "permutation",
+    deps = [
+      ":count",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "span_op",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/base/bit/count.h
+++ b/sxt/base/bit/count.h
@@ -18,14 +18,23 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <concepts>
 
 namespace sxt::basbt {
 //--------------------------------------------------------------------------------------------------
 // count_trailing_zeros
 //--------------------------------------------------------------------------------------------------
+inline int count_trailing_zeros(unsigned x) noexcept { return __builtin_ctz(x); }
+
 inline int count_trailing_zeros(unsigned long x) noexcept { return __builtin_ctzl(x); }
 
 inline int count_trailing_zeros(unsigned long long x) noexcept { return __builtin_ctzll(x); }
+
+template<std::unsigned_integral T>
+  requires (sizeof(T) < sizeof(unsigned))
+inline int count_trailing_zeros(T x) noexcept {
+  return count_trailing_zeros(static_cast<unsigned>(x));
+}
 
 //--------------------------------------------------------------------------------------------------
 // count_leading_zeros

--- a/sxt/base/bit/count.h
+++ b/sxt/base/bit/count.h
@@ -17,8 +17,8 @@
 #pragma once
 
 #include <algorithm>
-#include <cstdint>
 #include <concepts>
+#include <cstdint>
 
 namespace sxt::basbt {
 //--------------------------------------------------------------------------------------------------
@@ -30,8 +30,8 @@ inline int count_trailing_zeros(unsigned long x) noexcept { return __builtin_ctz
 
 inline int count_trailing_zeros(unsigned long long x) noexcept { return __builtin_ctzll(x); }
 
-template<std::unsigned_integral T>
-  requires (sizeof(T) < sizeof(unsigned))
+template <std::unsigned_integral T>
+  requires(sizeof(T) < sizeof(unsigned))
 inline int count_trailing_zeros(T x) noexcept {
   return count_trailing_zeros(static_cast<unsigned>(x));
 }

--- a/sxt/base/bit/permutation.cc
+++ b/sxt/base/bit/permutation.cc
@@ -1,0 +1,1 @@
+#include "sxt/base/bit/permutation.h"

--- a/sxt/base/bit/permutation.cc
+++ b/sxt/base/bit/permutation.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/bit/permutation.h"

--- a/sxt/base/bit/permutation.h
+++ b/sxt/base/bit/permutation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <concepts>
+
+#include "sxt/base/bit/count.h"
+
+namespace sxt::basbt {
+//--------------------------------------------------------------------------------------------------
+// next_permutation 
+//--------------------------------------------------------------------------------------------------
+// adopted from https://stackoverflow.com/a/8281965
+template <std::unsigned_integral T>
+T next_permutation(T x) noexcept {
+  static constexpr T one{1};
+  T t = x | (x - one);
+  return (t + one) | (((~t & -~t) - one) >> (basbt::count_trailing_zeros(x) + 1));
+}
+} // namespace sxt::basbt

--- a/sxt/base/bit/permutation.h
+++ b/sxt/base/bit/permutation.h
@@ -24,7 +24,11 @@ namespace sxt::basbt {
 //--------------------------------------------------------------------------------------------------
 // next_permutation
 //--------------------------------------------------------------------------------------------------
-// adopted from https://stackoverflow.com/a/8281965
+/**
+ * Iterate over all permutations of a number with a given number of bits set to 1.
+ *
+ * Adopted from https://stackoverflow.com/a/8281965
+ */
 template <std::unsigned_integral T> T next_permutation(T x) noexcept {
   static constexpr T one{1};
   T t = x | (x - one);

--- a/sxt/base/bit/permutation.h
+++ b/sxt/base/bit/permutation.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <concepts>
@@ -6,11 +22,10 @@
 
 namespace sxt::basbt {
 //--------------------------------------------------------------------------------------------------
-// next_permutation 
+// next_permutation
 //--------------------------------------------------------------------------------------------------
 // adopted from https://stackoverflow.com/a/8281965
-template <std::unsigned_integral T>
-T next_permutation(T x) noexcept {
+template <std::unsigned_integral T> T next_permutation(T x) noexcept {
   static constexpr T one{1};
   T t = x | (x - one);
   return (t + one) | (((~t & -~t) - one) >> (basbt::count_trailing_zeros(x) + 1));

--- a/sxt/base/bit/permutation.t.cc
+++ b/sxt/base/bit/permutation.t.cc
@@ -7,5 +7,14 @@ using namespace sxt;
 using namespace sxt::basbt;
 
 TEST_CASE("we can compute the next bit permutation") {
-  REQUIRE(next_permutation(0b00010011u) == 0b00010101u);
+  SECTION("we can permute over a single bit") {
+    REQUIRE(next_permutation(0b1u) == 0b10u);
+    REQUIRE(next_permutation(0b10u) == 0b100u);
+  }
+
+  SECTION("we can permute over two bits") {
+    REQUIRE(next_permutation(0b11u) == 0b101u);
+    REQUIRE(next_permutation(0b101u) == 0b110u);
+    REQUIRE(next_permutation(0b110u) == 0b1001u);
+  }
 }

--- a/sxt/base/bit/permutation.t.cc
+++ b/sxt/base/bit/permutation.t.cc
@@ -1,0 +1,11 @@
+#include "sxt/base/bit/permutation.h"
+
+#include <iostream>
+
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::basbt;
+
+TEST_CASE("we can compute the next bit permutation") {
+  REQUIRE(next_permutation(0b00010011u) == 0b00010101u);
+}

--- a/sxt/base/bit/permutation.t.cc
+++ b/sxt/base/bit/permutation.t.cc
@@ -1,8 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/bit/permutation.h"
 
 #include <iostream>
 
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 using namespace sxt::basbt;
 


### PR DESCRIPTION
# Rationale for this change

When making a table of precomputed values for the partition step of Pippenger's algorithm, it's useful to be able to iterate over all permutations with a given number of bits set to 1. This PR adds a low level function to provide this capability.

# What changes are included in this PR?

* A function for iterating over bit permutations
* Modify count_trailing_zeros to work for smaller integral types.

# Are these changes tested?

Yes.