### PR TITLE
feat: compute table of partition sums (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -4,21 +4,21 @@ load(
 )
 
 sxt_cc_component(
-  name = "partition_table",
-  deps = [
-    "//sxt/base/bit:iteration",
-    "//sxt/base/bit:permutation",
-    "//sxt/base/container:span",
-    "//sxt/base/error:assert",
-    "//sxt/algorithm/iteration:for_each",
-    "//sxt/base/curve:element",
-    "//sxt/base/macro:cuda_callable",
-  ],
-  test_deps = [
-    "//sxt/base/curve:example_element",
-    "//sxt/base/device:synchronization",
-    "//sxt/base/device:stream",
-    "//sxt/base/test:unit_test",
-    "//sxt/memory/resource:managed_device_resource",
-  ],
+    name = "partition_table",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/algorithm/iteration:for_each",
+        "//sxt/base/bit:iteration",
+        "//sxt/base/bit:permutation",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/error:assert",
+        "//sxt/base/macro:cuda_callable",
+    ],
 )

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -1,0 +1,24 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+  name = "partition_table",
+  deps = [
+    "//sxt/base/bit:iteration",
+    "//sxt/base/bit:permutation",
+    "//sxt/base/container:span",
+    "//sxt/base/error:assert",
+    "//sxt/algorithm/iteration:for_each",
+    "//sxt/base/curve:element",
+    "//sxt/base/macro:cuda_callable",
+  ],
+  test_deps = [
+    "//sxt/base/curve:example_element",
+    "//sxt/base/device:synchronization",
+    "//sxt/base/device:stream",
+    "//sxt/base/test:unit_test",
+    "//sxt/memory/resource:managed_device_resource",
+  ],
+)

--- a/sxt/multiexp/pippenger2/partition_table.cc
+++ b/sxt/multiexp/pippenger2/partition_table.cc
@@ -1,0 +1,1 @@
+#include "sxt/multiexp/pippenger2/partition_table.h"

--- a/sxt/multiexp/pippenger2/partition_table.cc
+++ b/sxt/multiexp/pippenger2/partition_table.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/multiexp/pippenger2/partition_table.h"

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cassert>
+#include <limits>
+#include <print>
+
+#include "sxt/base/bit/permutation.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/macro/cuda_callable.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// compute_partition_table_slice
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+CUDA_CALLABLE void compute_partition_table_slice(T* __restrict__ sums,
+                                            const T* __restrict__ generators) noexcept {
+  sums[0] = T::identity();
+
+  // single entry sums
+  for (unsigned i=0; i<16; ++i) {
+    sums[1 << i] = generators[i];
+  }
+
+  // multi-entry sums
+  for (unsigned k = 2; k <= 16; ++k) {
+    unsigned partition = std::numeric_limits<uint16_t>::max() >> (16u - k);
+    auto partition_last = partition << (16u - k);
+    while (true) {
+      auto rest = partition & (partition - 1u);
+      auto t = partition ^ rest;
+      auto sum = sums[rest];
+      auto e = sums[t];
+      add_inplace(sum, e);
+      sums[partition] = sum;
+      if (partition == partition_last) {
+        break;
+      }
+      partition = basbt::next_permutation(partition);
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// compute_partition_table 
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) noexcept {
+  auto num_entries = 1u << 16u;
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+     sums.size() == num_entries * generators.size() / 16u &&
+     generators.size() % 16 == 0
+      // clang-format on
+  );
+  auto n = generators.size() / 16u;
+  for (unsigned i=0; i<n; ++i) {
+    auto sums_slice = sums.subspan(i * num_entries, num_entries);
+    auto generators_slice = generators.subspan(i * 16u, 16u);
+    compute_partition_table_slice<T>(sums_slice.data(), generators_slice.data());
+  }
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <cassert>
@@ -16,11 +32,11 @@ namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T>
 CUDA_CALLABLE void compute_partition_table_slice(T* __restrict__ sums,
-                                            const T* __restrict__ generators) noexcept {
+                                                 const T* __restrict__ generators) noexcept {
   sums[0] = T::identity();
 
   // single entry sums
-  for (unsigned i=0; i<16; ++i) {
+  for (unsigned i = 0; i < 16; ++i) {
     sums[1 << i] = generators[i];
   }
 
@@ -28,7 +44,11 @@ CUDA_CALLABLE void compute_partition_table_slice(T* __restrict__ sums,
   for (unsigned k = 2; k <= 16; ++k) {
     unsigned partition = std::numeric_limits<uint16_t>::max() >> (16u - k);
     auto partition_last = partition << (16u - k);
+
+    // iterate over all possible permutations with k bits set to 1
+    // until we reach partition_last
     while (true) {
+      // compute the k bit sum from a (k-1) bit sum and a 1 bit sum
       auto rest = partition & (partition - 1u);
       auto t = partition ^ rest;
       auto sum = sums[rest];
@@ -44,8 +64,12 @@ CUDA_CALLABLE void compute_partition_table_slice(T* __restrict__ sums,
 }
 
 //--------------------------------------------------------------------------------------------------
-// compute_partition_table 
+// compute_partition_table
 //--------------------------------------------------------------------------------------------------
+/**
+ * Compute table of sums used for Pippenger's partition step with a width of 16. Each slice of the
+ * table contains all possible sums of a group of 16 generators.
+ */
 template <bascrv::element T>
 void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) noexcept {
   auto num_entries = 1u << 16u;
@@ -56,7 +80,7 @@ void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) no
       // clang-format on
   );
   auto n = generators.size() / 16u;
-  for (unsigned i=0; i<n; ++i) {
+  for (unsigned i = 0; i < n; ++i) {
     auto sums_slice = sums.subspan(i * num_entries, num_entries);
     auto generators_slice = generators.subspan(i * 16u, 16u);
     compute_partition_table_slice<T>(sums_slice.data(), generators_slice.data());

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -16,9 +16,7 @@
  */
 #pragma once
 
-#include <cassert>
 #include <limits>
-#include <print>
 
 #include "sxt/base/bit/permutation.h"
 #include "sxt/base/container/span.h"

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -1,0 +1,40 @@
+#include "sxt/multiexp/pippenger2/partition_table.h"
+
+#include <iostream>
+#include <vector>
+
+#include "sxt/base/bit/iteration.h"
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can compute a slice of the partition table") {
+  using E = bascrv::element97;
+  std::vector<E> sums(1u << 16);
+  std::vector<E> generators = {1u, 2u,  3u,  4u,  5u,  6u,  7u,  8u,
+                               9u, 10u, 11u, 12u, 13u, 14u, 15u, 16u};
+  compute_partition_table_slice(sums.data(), generators.data());
+  for (unsigned i = 0; i < sums.size(); ++i) {
+    auto expected = E::identity();
+    basbt::for_each_bit(reinterpret_cast<uint8_t*>(&i), sizeof(i), [&](unsigned index) noexcept {
+      auto g = generators[index];
+      add_inplace(expected, g);
+    });
+    REQUIRE(sums[i] == expected);
+  }
+}
+
+TEST_CASE("we can compute the full partition table") {
+  using E = bascrv::element97;
+  auto n = 2u;
+  auto num_entries = 1u << 16u;
+  std::vector<E> sums(num_entries * n);
+  std::vector<E> generators(16u * n);
+  for (unsigned i=0; i<generators.size(); ++i) {
+    generators[i] = i + 1u;
+  }
+  compute_partition_table<E>(sums, generators);
+  REQUIRE(sums[1] == generators[0]);
+  REQUIRE(sums[num_entries + 1] == generators[16]);
+}

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -16,7 +16,6 @@
  */
 #include "sxt/multiexp/pippenger2/partition_table.h"
 
-#include <iostream>
 #include <vector>
 
 #include "sxt/base/bit/iteration.h"

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/multiexp/pippenger2/partition_table.h"
 
 #include <iostream>
@@ -6,6 +22,7 @@
 #include "sxt/base/bit/iteration.h"
 #include "sxt/base/curve/example_element.h"
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 using namespace sxt::mtxpp2;
 
@@ -31,7 +48,7 @@ TEST_CASE("we can compute the full partition table") {
   auto num_entries = 1u << 16u;
   std::vector<E> sums(num_entries * n);
   std::vector<E> generators(16u * n);
-  for (unsigned i=0; i<generators.size(); ++i) {
+  for (unsigned i = 0; i < generators.size(); ++i) {
     generators[i] = i + 1u;
   }
   compute_partition_table<E>(sums, generators);


### PR DESCRIPTION
# Rationale for this change

Compute the table of precomputed sums used in the Pippenger partition step

# What changes are included in this PR?

Add a component for computing the partition table.

# Are these changes tested?

Yes.
