### PR TITLE
feat: add interface accessor for partition table sums (PROOF-831)

### DIFF
--- a/sxt/base/test/BUILD
+++ b/sxt/base/test/BUILD
@@ -12,6 +12,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "temp_file",
+    impl_deps = [
+    ],
+    with_test = False,
+)
+
+sxt_cc_component(
     name = "unit_test",
     with_test = False,
     deps = [

--- a/sxt/base/test/temp_file.cc
+++ b/sxt/base/test/temp_file.cc
@@ -1,0 +1,28 @@
+#include "sxt/base/test/temp_file.h"
+
+#include <cerrno>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+#include <print>
+
+namespace sxt::bastst {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+temp_file::temp_file(std::ios_base::openmode openmode) noexcept
+    : name_{std::tmpnam(nullptr)}, out_{name_, openmode} {
+}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+temp_file::~temp_file() noexcept {
+  out_.close();
+  auto rcode = std::remove(name_.c_str());
+  if (rcode != 0) {
+    std::println(stderr, "failed to close file {}: {}", name_, std::strerror(errno));
+    std::abort();
+  }
+}
+} // namespace sxt::bastst

--- a/sxt/base/test/temp_file.cc
+++ b/sxt/base/test/temp_file.cc
@@ -1,9 +1,25 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/test/temp_file.h"
 
 #include <cerrno>
-#include <cstring>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <print>
 
 namespace sxt::bastst {
@@ -11,8 +27,7 @@ namespace sxt::bastst {
 // constructor
 //--------------------------------------------------------------------------------------------------
 temp_file::temp_file(std::ios_base::openmode openmode) noexcept
-    : name_{std::tmpnam(nullptr)}, out_{name_, openmode} {
-}
+    : name_{std::tmpnam(nullptr)}, out_{name_, openmode} {}
 
 //--------------------------------------------------------------------------------------------------
 // destructor

--- a/sxt/base/test/temp_file.h
+++ b/sxt/base/test/temp_file.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <fstream>
+#include <string>
+
+namespace sxt::bastst {
+//--------------------------------------------------------------------------------------------------
+// temp_file 
+//--------------------------------------------------------------------------------------------------
+/**
+ * Set up a temporary file that is deleted in the destructor.
+ *
+ * This is meant to make easier to write tests involving files.
+ */
+class temp_file {
+ public:
+   explicit temp_file(std::ios_base::openmode = std::ios_base::out) noexcept;
+
+   ~temp_file() noexcept;
+
+   const std::string& name() const noexcept { return name_; }
+
+   std::ofstream& stream() noexcept { return out_; }
+ private:
+   std::string name_;
+   std::ofstream out_;
+};
+} // namespace sxt::bastst

--- a/sxt/base/test/temp_file.h
+++ b/sxt/base/test/temp_file.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <fstream>
@@ -5,7 +21,7 @@
 
 namespace sxt::bastst {
 //--------------------------------------------------------------------------------------------------
-// temp_file 
+// temp_file
 //--------------------------------------------------------------------------------------------------
 /**
  * Set up a temporary file that is deleted in the destructor.
@@ -13,16 +29,17 @@ namespace sxt::bastst {
  * This is meant to make easier to write tests involving files.
  */
 class temp_file {
- public:
-   explicit temp_file(std::ios_base::openmode = std::ios_base::out) noexcept;
+public:
+  explicit temp_file(std::ios_base::openmode = std::ios_base::out) noexcept;
 
-   ~temp_file() noexcept;
+  ~temp_file() noexcept;
 
-   const std::string& name() const noexcept { return name_; }
+  const std::string& name() const noexcept { return name_; }
 
-   std::ofstream& stream() noexcept { return out_; }
- private:
-   std::string name_;
-   std::ofstream out_;
+  std::ofstream& stream() noexcept { return out_; }
+
+private:
+  std::string name_;
+  std::ofstream out_;
 };
 } // namespace sxt::bastst

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -22,3 +22,34 @@ sxt_cc_component(
         "//sxt/base/macro:cuda_callable",
     ],
 )
+
+sxt_cc_component(
+    name = "partition_table_accessor",
+    with_test = False,
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/type:raw_stream",
+    ],
+)
+
+sxt_cc_component(
+    name = "in_memory_partition_table_accessor",
+    deps = [
+      ":partition_table_accessor",
+      "//sxt/base/device:memory_utility",
+      "//sxt/base/container:span_utility",
+      "//sxt/base/error:assert",
+      "//sxt/base/error:panic",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:pinned_resource",
+    ],
+    test_deps = [
+      "//sxt/base/curve:example_element",
+      "//sxt/base/device:synchronization",
+      "//sxt/base/device:stream",
+      "//sxt/base/test:temp_file",
+      "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:device_resource",
+    ],
+)

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -35,21 +35,21 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "in_memory_partition_table_accessor",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:temp_file",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:device_resource",
+    ],
     deps = [
-      ":partition_table_accessor",
-      "//sxt/base/device:memory_utility",
-      "//sxt/base/container:span_utility",
-      "//sxt/base/error:assert",
-      "//sxt/base/error:panic",
+        ":partition_table_accessor",
+        "//sxt/base/container:span_utility",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/error:assert",
+        "//sxt/base/error:panic",
         "//sxt/memory/management:managed_array",
         "//sxt/memory/resource:pinned_resource",
-    ],
-    test_deps = [
-      "//sxt/base/curve:example_element",
-      "//sxt/base/device:synchronization",
-      "//sxt/base/device:stream",
-      "//sxt/base/test:temp_file",
-      "//sxt/base/test:unit_test",
-        "//sxt/memory/resource:device_resource",
     ],
 )

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.cc
@@ -1,0 +1,1 @@
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <cerrno>
@@ -19,34 +35,34 @@ namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T>
 class in_memory_partition_table_accessor final : public partition_table_accessor<T> {
- public:
-   explicit in_memory_partition_table_accessor(std::string_view filename) noexcept
-       : table_{memr::get_pinned_resource()} {
-     std::ifstream in{filename, std::ios::binary};
-     if (!in.good()) {
-       baser::panic("failed to open {}: {}", filename, std::strerror(errno));
-     }
-     auto pos = in.tellg();
-     in.seekg(0, std::ios::end);
-     auto size = in.tellg() - pos;
-     in.seekg(pos);
-     SXT_RELEASE_ASSERT(size % sizeof(T) == 0);
-     table_.resize(size / sizeof(T));
-     in.read(reinterpret_cast<char*>(table_.data()), size);
-   }
+public:
+  explicit in_memory_partition_table_accessor(std::string_view filename) noexcept
+      : table_{memr::get_pinned_resource()} {
+    std::ifstream in{filename, std::ios::binary};
+    if (!in.good()) {
+      baser::panic("failed to open {}: {}", filename, std::strerror(errno));
+    }
+    auto pos = in.tellg();
+    in.seekg(0, std::ios::end);
+    auto size = in.tellg() - pos;
+    in.seekg(pos);
+    SXT_RELEASE_ASSERT(size % sizeof(T) == 0);
+    table_.resize(size / sizeof(T));
+    in.read(reinterpret_cast<char*>(table_.data()), size);
+  }
 
-   void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
-                                              unsigned first) const noexcept override {
-     SXT_DEBUG_ASSERT(
-         // clang-format off
+  void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
+                                             unsigned first) const noexcept override {
+    SXT_DEBUG_ASSERT(
+        // clang-format off
          table_.size() >= dest.size() + first &&
          basdv::is_active_device_pointer(dest.data())
-         // clang-format on
-     );
-     basdv::async_copy_host_to_device(dest, basct::subspan(table_, first, dest.size()), stream);
-   }
+        // clang-format on
+    );
+    basdv::async_copy_host_to_device(dest, basct::subspan(table_, first, dest.size()), stream);
+  }
 
- private:
-   memmg::managed_array<T> table_;
+private:
+  memmg::managed_array<T> table_;
 };
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cerrno>
+#include <cstring>
+#include <fstream>
+#include <string_view>
+
+#include "sxt/base/container/span_utility.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/error/panic.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/pippenger2/partition_table_accessor.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// in_memory_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+class in_memory_partition_table_accessor final : public partition_table_accessor<T> {
+ public:
+   explicit in_memory_partition_table_accessor(std::string_view filename) noexcept
+       : table_{memr::get_pinned_resource()} {
+     std::ifstream in{filename, std::ios::binary};
+     if (!in.good()) {
+       baser::panic("failed to open {}: {}", filename, std::strerror(errno));
+     }
+     auto pos = in.tellg();
+     in.seekg(0, std::ios::end);
+     auto size = in.tellg() - pos;
+     in.seekg(pos);
+     SXT_RELEASE_ASSERT(size % sizeof(T) == 0);
+     table_.resize(size / sizeof(T));
+     in.read(reinterpret_cast<char*>(table_.data()), size);
+   }
+
+   void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
+                                              unsigned first) const noexcept override {
+     SXT_DEBUG_ASSERT(
+         // clang-format off
+         table_.size() >= dest.size() + first &&
+         basdv::is_active_device_pointer(dest.data())
+         // clang-format on
+     );
+     basdv::async_copy_host_to_device(dest, basct::subspan(table_, first, dest.size()), stream);
+   }
+
+ private:
+   memmg::managed_array<T> table_;
+};
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -1,0 +1,48 @@
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
+
+#include <vector>
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/temp_file.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can provide access to precomputed partition sums stored on disk") {
+  bastst::temp_file temp_file{std::ios::binary};
+
+  using E = bascrv::element97;
+  basdv::stream stream;
+
+  SECTION("we can access a single element") {
+    E e{11};
+    temp_file.stream().write(reinterpret_cast<const char*>(&e), sizeof(e));
+    temp_file.stream().close();
+    in_memory_partition_table_accessor<E> accessor{temp_file.name()};
+    memmg::managed_array<E> v_dev{1, memr::get_device_resource()};
+    accessor.async_copy_precomputed_sums_to_device(v_dev, stream, 0);
+    std::vector<E> v(1);
+    basdv::async_copy_device_to_host(v, v_dev, stream);
+    basdv::synchronize_stream(stream);
+    std::vector<E> expected = {e};
+    REQUIRE(v == expected);
+  }
+
+  SECTION("we can access a elements with offset") {
+    std::vector<E> data{11, 12};
+    temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
+    temp_file.stream().close();
+    in_memory_partition_table_accessor<E> accessor{temp_file.name()};
+    memmg::managed_array<E> v_dev{1, memr::get_device_resource()};
+    accessor.async_copy_precomputed_sums_to_device(v_dev, stream, 1);
+    std::vector<E> v(1);
+    basdv::async_copy_device_to_host(v, v_dev, stream);
+    basdv::synchronize_stream(stream);
+    std::vector<E> expected = {data[1]};
+    REQUIRE(v == expected);
+  }
+}

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 
 #include <vector>
@@ -9,6 +25,7 @@
 #include "sxt/base/test/unit_test.h"
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/memory/resource/device_resource.h"
+
 using namespace sxt;
 using namespace sxt::mtxpp2;
 

--- a/sxt/multiexp/pippenger2/partition_table_accessor.cc
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/multiexp/pippenger2/partition_table_accessor.h"

--- a/sxt/multiexp/pippenger2/partition_table_accessor.cc
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.cc
@@ -1,0 +1,1 @@
+#include "sxt/multiexp/pippenger2/partition_table_accessor.h"

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/type/raw_stream.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T> class partition_table_accessor {
+public:
+  virtual ~partition_table_accessor() noexcept = default;
+
+  virtual void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
+                                                     unsigned first) const noexcept = 0;
+};
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/base/container/span.h"


### PR DESCRIPTION
# Rationale for this change

Add an interface and accessor for the precomputed sums used in the partition step of Pippenger's algorithm.

Note: This might get extended in the future to have accessors that go from a file to GPU memory so that it's not necessary to hold all of the precomputed sums in host memory.

# What changes are included in this PR?

 * Add an interface an in-memory implementation of a partition table accessor.
 * Add utilities for testing with files

# Are these changes tested?

Yes
