### PR TITLE
feat: add component for computing product of partitions (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -4,6 +4,36 @@ load(
 )
 
 sxt_cc_component(
+    name = "partition_product",
+    test_deps = [
+        ":in_memory_partition_table_accessor",
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/algorithm/iteration:for_each",
+        "//sxt/base/bit:iteration",
+        "//sxt/base/bit:permutation",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/base/error:assert",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/base/num:divide_up",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/device:synchronization",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_component(
     name = "partition_table",
     test_deps = [
         "//sxt/base/curve:example_element",

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -50,7 +50,8 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   }
 
   SECTION("we can access a elements with offset") {
-    std::vector<E> data{11, 12};
+    std::vector<E> data((1u << 16u) * 2);
+    data[1u << 16u] = 12u;
     temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
@@ -59,7 +60,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
     std::vector<E> v(1);
     basdv::async_copy_device_to_host(v, v_dev, stream);
     basdv::synchronize_stream(stream);
-    std::vector<E> expected = {data[1]};
+    std::vector<E> expected = {12u};
     REQUIRE(v == expected);
   }
 }

--- a/sxt/multiexp/pippenger2/partition_product.cc
+++ b/sxt/multiexp/pippenger2/partition_product.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/partition_product.h"

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -1,0 +1,142 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+
+#include "sxt/algorithm/iteration/for_each.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/device/synchronization.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+#include "sxt/multiexp/pippenger2/partition_table_accessor.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// compute_partition_index
+//--------------------------------------------------------------------------------------------------
+/**
+ * Compute the index in the partition table of the product for a group of 16 scalars.
+ */
+CUDA_CALLABLE inline uint16_t compute_partition_index(const uint8_t* __restrict__ scalars,
+                                                      unsigned step, unsigned n,
+                                                      unsigned bit_index) noexcept {
+  uint16_t res = 0;
+  unsigned num_elements = std::min(16u, n);
+  auto mask = 1u << bit_index;
+  for (unsigned i = 0; i < num_elements; ++i) {
+    auto byte = scalars[i * step];
+    auto bit_value = static_cast<uint16_t>((byte & mask) != 0);
+    res |= static_cast<uint16_t>(bit_value << i);
+  }
+  return res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// partition_product_kernel
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+CUDA_CALLABLE void
+partition_product_kernel(T* __restrict__ products, const T* __restrict__ partition_table,
+                         const uint8_t* __restrict__ scalars, unsigned byte_index,
+                         unsigned bit_offset, unsigned num_products, unsigned n) noexcept {
+  constexpr unsigned num_partition_entries = 1u << 16u;
+
+  auto step = num_products / 8u;
+
+  scalars += byte_index;
+  products += byte_index * 8u + bit_offset;
+
+  // lookup the first entry
+  auto partition_index = compute_partition_index(scalars, step, n, bit_offset);
+  auto res = partition_table[partition_index];
+
+  // sum remaining entries
+  while (n >= 16u) {
+    n -= 16u;
+    partition_table += num_partition_entries;
+    scalars += 16u * step;
+
+    partition_index = compute_partition_index(scalars, step, n, bit_offset);
+    auto e = partition_table[partition_index];
+    add_inplace(res, e);
+  }
+
+  // write result
+  *products = res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// partition_product
+//--------------------------------------------------------------------------------------------------
+/**
+ * Compute the multiproduct for the bits of an array of scalars using an accessor to
+ * precomputed sums for each group of generators.
+ */
+template <bascrv::element T>
+xena::future<> partition_product(basct::span<T> products,
+                                 const partition_table_accessor<T>& accessor,
+                                 basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
+  auto num_products = products.size();
+  auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
+  auto num_partitions = basn::divide_up(n, 16u);
+  auto num_table_entries = 1u << 16u;
+  SXT_DEBUG_ASSERT(offset % 16u == 0);
+
+  // scalars_dev
+  memmg::managed_array<uint8_t> scalars_dev{scalars.size(), memr::get_device_resource()};
+  auto scalars_fut = [&]() noexcept -> xena::future<> {
+    basdv::stream stream;
+    basdv::async_copy_host_to_device(scalars_dev, scalars, stream);
+    co_await xendv::await_stream(stream);
+  }();
+
+  // partition_table
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  memmg::managed_array<T> partition_table{num_partitions * num_table_entries, &resource};
+  accessor.async_copy_precomputed_sums_to_device(partition_table, stream, offset / 16u);
+  co_await std::move(scalars_fut);
+
+  // product
+  auto f = [
+               // clang-format off
+    products = products.data(),
+    scalars = scalars_dev.data(),
+    partition_table = partition_table.data(),
+    n = n
+               // clang-format on
+  ] __device__
+           __host__(unsigned num_products, unsigned product_index) noexcept {
+             auto byte_index = product_index / 8u;
+             auto bit_offset = product_index % 8u;
+             partition_product_kernel<T>(products, partition_table, scalars, byte_index, bit_offset,
+                                         num_products, n);
+           };
+  algi::launch_for_each_kernel(stream, f, num_products);
+  co_await xendv::await_stream(stream);
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -1,0 +1,131 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/partition_product.h"
+
+#include <random>
+#include <vector>
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can compute the index used to lookup the precomputed sum for a partition") {
+  uint8_t scalars[32] = {};
+
+  SECTION("we handle the zero case") {
+    auto index = compute_partition_index(scalars, 1, 16, 0);
+    REQUIRE(index == 0);
+  }
+
+  SECTION("we handle non-zero cases") {
+    scalars[0] = 1;
+    scalars[2] = 1;
+    auto index = compute_partition_index(scalars, 1, 16, 0);
+    REQUIRE(index == 5);
+  }
+
+  SECTION("we handle a bit index of 2") {
+    scalars[0] = 2;
+    auto index = compute_partition_index(scalars, 1, 16, 1);
+    REQUIRE(index == 1);
+  }
+
+  SECTION("we handle n < 16") {
+    scalars[0] = 1u;
+    scalars[2] = 1u;
+    auto index = compute_partition_index(scalars, 1, 2, 0);
+    REQUIRE(index == 1);
+  }
+
+  SECTION("we handle a step size of 2") {
+    scalars[16] = 1;
+    auto index = compute_partition_index(scalars, 2, 16, 0);
+    REQUIRE(index == 1u << 8u);
+  }
+}
+
+TEST_CASE("we can compute the product of partitions") {
+  constexpr auto num_entries = 1u << 16u;
+  using E = bascrv::element97;
+  memmg::managed_array<E> products{8, memr::get_managed_device_resource()};
+  std::vector<uint8_t> scalars(1);
+  memmg::managed_array<E> expected(8);
+  for (auto& e : expected) {
+    e = 0u;
+  }
+
+  memmg::managed_array<E> partition_table((1u << 16) * 10);
+  std::mt19937 rng{0};
+  for (unsigned i = 0; i < partition_table.size(); ++i) {
+    if (i % (1u << 16u) == 0) {
+      partition_table[i] = 0u;
+    } else {
+      partition_table[i] = std::uniform_int_distribution<unsigned>{0, 96}(rng);
+    }
+  }
+  in_memory_partition_table_accessor accessor{memmg::managed_array<E>{partition_table}};
+
+  SECTION("we handle a product with a single scalar") {
+    scalars[0] = 1;
+    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected[0] = partition_table[1];
+    REQUIRE(products == expected);
+  }
+
+  SECTION("we handle a product with an offset") {
+    scalars[0] = 1;
+    auto fut = partition_product<E>(products, accessor, scalars, 16);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected[0] = partition_table[num_entries + 1];
+    REQUIRE(products == expected);
+  }
+
+  SECTION("we handle a product with two scalars") {
+    scalars = {1u, 3u};
+    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected[0] = partition_table[3];
+    expected[1] = partition_table[2];
+    REQUIRE(products == expected);
+  }
+
+  SECTION("we handle a product with more than 16 scalars") {
+    scalars.resize(32);
+    scalars[0] = 1u;
+    scalars[16] = 1u;
+    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected[0] = partition_table[1].value + partition_table[num_entries + 1].value;
+    REQUIRE(products == expected);
+  }
+}


### PR DESCRIPTION
# Rationale for this change


Compute the multi product product of scalars using an accessor to precomputed products for groups of 16 generators.

# What changes are included in this PR?

* Add component to compute the multi-product for the bits of a scalar array.
* Fix interpretation of the offset argument in in_memory_partition_table_accessor

# Are these changes tested?

Yes
