### PR TITLE
feat: add utility to create an in memory partition table accessor (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -83,3 +83,23 @@ sxt_cc_component(
         "//sxt/memory/resource:pinned_resource",
     ],
 )
+
+sxt_cc_component(
+    name = "in_memory_partition_table_accessor_utility",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:device_resource",
+    ],
+    deps = [
+        ":in_memory_partition_table_accessor",
+        ":partition_table",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/num:divide_up",
+        "//sxt/memory/resource:pinned_resource",
+    ],
+)

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -1,0 +1,51 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/num/divide_up.h"
+#include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
+#include "sxt/multiexp/pippenger2/partition_table.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// make_in_memory_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+std::unique_ptr<partition_table_accessor<T>>
+make_in_memory_partition_table_accessor(basct::cspan<T> generators) noexcept {
+  auto n = generators.size();
+  std::vector<T> generators_data;
+  auto num_partitions = basn::divide_up(n, size_t{16});
+  if (n % 16 != 0) {
+    n = num_partitions * 16u;
+    generators_data.resize(n);
+    auto iter = std::copy(generators.begin(), generators.end(), generators_data.begin());
+    std::fill(iter, generators_data.end(), T::identity());
+    generators = generators_data;
+  }
+  auto num_entries = 1u << 16u;
+  memmg::managed_array<T> sums{num_entries * num_partitions, memr::get_pinned_resource()};
+  compute_partition_table<T>(sums, generators);
+  return std::make_unique<in_memory_partition_table_accessor<T>>(std::move(sums));
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
@@ -1,0 +1,63 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
+
+#include <random>
+#include <vector>
+
+#include "sxt/base/container/span_utility.h"
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can create a partition table accessor from given generators") {
+  using E = bascrv::element97;
+  std::vector<E> generators(32);
+  std::mt19937 rng{0};
+  for (auto& g : generators) {
+    g = std::uniform_int_distribution<unsigned>{0, 96}(rng);
+  }
+
+  basdv::stream stream;
+  memmg::managed_array<E> table_dev{1u << 16u, memr::get_device_resource()};
+  memmg::managed_array<E> table(table_dev.size());
+
+  SECTION("we can create an accessor from a single generators") {
+    auto accessor = make_in_memory_partition_table_accessor<E>(basct::subspan(generators, 0, 1));
+    accessor->async_copy_precomputed_sums_to_device(table_dev, stream, 0);
+    basdv::async_copy_device_to_host(table, table_dev, stream);
+    basdv::synchronize_stream(stream);
+    REQUIRE(table[1] == generators[0]);
+    REQUIRE(table[2] == E::identity());
+  }
+
+  SECTION("we can create an accessor from multiple generators") {
+    auto accessor = make_in_memory_partition_table_accessor<E>(generators);
+    accessor->async_copy_precomputed_sums_to_device(table_dev, stream, 0);
+    basdv::async_copy_device_to_host(table, table_dev, stream);
+    basdv::synchronize_stream(stream);
+    REQUIRE(table[1] == generators[0]);
+    REQUIRE(table[2] == generators[1]);
+    REQUIRE(table[3] == generators[0].value + generators[1].value);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

In order to make testing and benchmarking easier, this PR adds a utility function to create an in-memory accessor to precomputed partition sums given a span of generators. 

# What changes are included in this PR?

* A function to create an in memory partition table accessor.

# Are these changes tested?

Yes
