### PR TITLE
fix: fix partition product when n is a multiple of 16 (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -75,7 +75,7 @@ partition_product_kernel(T* __restrict__ products, const T* __restrict__ partiti
   auto res = partition_table[partition_index];
 
   // sum remaining entries
-  while (n >= 16u) {
+  while (n > 16u) {
     n -= 16u;
     partition_table += num_partition_entries;
     scalars += 16u * step;

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -117,6 +117,18 @@ TEST_CASE("we can compute the product of partitions") {
     REQUIRE(products == expected);
   }
 
+  SECTION("we handle a product with more 16 scalars") {
+    scalars.resize(16);
+    scalars[0] = 1u;
+    scalars[15] = 1u;
+    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected[0] = partition_table[1 + (1u << 15u)].value;
+    REQUIRE(products == expected);
+  }
+
   SECTION("we handle a product with more than 16 scalars") {
     scalars.resize(32);
     scalars[0] = 1u;


### PR DESCRIPTION
# Rationale for this change

Fix termination condition for partition_product loop to properly abort when n is a multiple of 16.

# What changes are included in this PR?

Modify loop to abort when n is reduced to 16.

# Are these changes tested?

Yes. I added a test case with n=16.
