### PR TITLE
feat: add multiexponentiation function for Pippenger's partition method (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -105,6 +105,34 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "multiexponentiation",
+    test_deps = [
+        ":in_memory_partition_table_accessor_utility",
+        "//sxt/base/num:fast_random_number_generator",
+        "//sxt/base/test:unit_test",
+        "//sxt/curve21/operation:add",
+        "//sxt/curve21/operation:double",
+        "//sxt/curve21/operation:neg",
+        "//sxt/curve21/type:element_p3",
+        "//sxt/curve21/type:literal",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/ristretto/random:element",
+    ],
+    deps = [
+        ":partition_product",
+        ":partition_table_accessor",
+        ":reduce",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/curve:example_element",
+        "//sxt/execution/async:future",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:device_resource",
+    ],
+)
+
+sxt_cc_component(
     name = "reduce",
     test_deps = [
         "//sxt/base/curve:example_element",

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -108,6 +108,7 @@ sxt_cc_component(
     name = "multiexponentiation",
     test_deps = [
         ":in_memory_partition_table_accessor_utility",
+        "//sxt/base/curve:example_element",
         "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
         "//sxt/curve21/operation:add",
@@ -124,7 +125,6 @@ sxt_cc_component(
         ":reduce",
         "//sxt/base/container:span",
         "//sxt/base/curve:element",
-        "//sxt/base/curve:example_element",
         "//sxt/execution/async:future",
         "//sxt/memory/management:managed_array",
         "//sxt/memory/resource:async_device_resource",

--- a/sxt/multiexp/pippenger2/multiexponentiation.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/multiexponentiation.h"

--- a/sxt/multiexp/pippenger2/multiexponentiation.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation.h
@@ -1,0 +1,67 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/device_resource.h"
+#include "sxt/multiexp/pippenger2/partition_product.h"
+#include "sxt/multiexp/pippenger2/partition_table_accessor.h"
+#include "sxt/multiexp/pippenger2/reduce.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// multiexponentiate
+//--------------------------------------------------------------------------------------------------
+/**
+ * Compute a multi-exponentiation using an accessor to precompute sums of partition groups.
+ *
+ * This implements the partition part of Pipenger's algorithm. See Algorithm 7 of
+ * https://cacr.uwaterloo.ca/techreports/2010/cacr2010-26.pdf
+ */
+template <bascrv::element T>
+xena::future<> multiexponentiate(basct::span<T> res, const partition_table_accessor<T>& accessor,
+                                 unsigned element_num_bytes,
+                                 basct::cspan<uint8_t> scalars) noexcept {
+  auto num_outputs = res.size();
+  auto num_products = num_outputs * element_num_bytes * 8u;
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      scalars.size() % (num_outputs * element_num_bytes) == 0
+      // clang-format on
+  );
+
+  // compute bitwise products
+  memmg::managed_array<T> products(num_products, memr::get_device_resource());
+  co_await partition_product<T>(products, accessor, scalars, 0);
+
+  // reduce products
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  memmg::managed_array<T> res_dev{num_outputs, &resource};
+  reduce_products<T>(res_dev, stream, products);
+  products.reset();
+
+  // copy result
+  basdv::async_copy_device_to_host(res, res_dev, stream);
+  co_await xendv::await_stream(stream);
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/multiexponentiation.t.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation.t.cc
@@ -1,0 +1,137 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/multiexponentiation.h"
+
+#include <random>
+#include <vector>
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/num/fast_random_number_generator.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/curve21/operation/add.h"
+#include "sxt/curve21/operation/double.h"
+#include "sxt/curve21/operation/neg.h"
+#include "sxt/curve21/type/element_p3.h"
+#include "sxt/curve21/type/literal.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/field51/type/literal.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
+#include "sxt/ristretto/random/element.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can compute multiexponentiations using a precomputed table of partition sums") {
+  using E = bascrv::element97;
+
+  std::vector<E> generators(32);
+  std::mt19937 rng{0};
+  for (auto& g : generators) {
+    g = std::uniform_int_distribution<unsigned>{0, 96}(rng);
+  }
+
+  auto accessor = make_in_memory_partition_table_accessor<E>(generators);
+
+  std::vector<uint8_t> scalars(1);
+  std::vector<E> res(1);
+
+  SECTION("we can compute a multiexponentiation with a zero scalar") {
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == E::identity());
+  }
+
+  SECTION("we can compute a multiexponentiation multiexponentiation with a scalar of one") {
+    scalars[0] = 1;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0]);
+  }
+
+  SECTION("we can compute a multiexponentiation with a scalar of two") {
+    scalars[0] = 2;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == 2u * generators[0].value);
+  }
+
+  SECTION("we can compute a multiexponentiation with a scalar of three") {
+    scalars[0] = 3;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == 3u * generators[0].value);
+  }
+
+  SECTION("we can compute a multiexponentiation with two scalars") {
+    scalars.resize(2);
+    scalars[0] = 1;
+    scalars[1] = 1;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0].value + generators[1].value);
+  }
+
+  SECTION("we can compute a multiexponentiation with more than 16 scalars") {
+    scalars.resize(17);
+    scalars[0] = 1;
+    scalars[16] = 1;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0].value + generators[16].value);
+  }
+
+  SECTION("we can compute a multiexponentiation with more than one output") {
+    res.resize(2);
+    scalars.resize(2);
+    scalars[0] = 1u;
+    scalars[1] = 2u;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0].value);
+    REQUIRE(res[1] == 2u * generators[0].value);
+  }
+}
+
+TEST_CASE("we can compute multiexponentiations with curve-21") {
+  using E = c21t::element_p3;
+
+  std::vector<E> generators(32);
+  basn::fast_random_number_generator rng{1, 2};
+  for (auto& g : generators) {
+    rstrn::generate_random_element(g, rng);
+  }
+
+  auto accessor = make_in_memory_partition_table_accessor<E>(generators);
+
+  std::vector<uint8_t> scalars(1);
+  std::vector<E> res(1);
+
+  SECTION("we can compute a multiexponentiation multiexponentiation with a scalar of one") {
+    scalars[0] = 1;
+    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0]);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a component to compute multiexponentiations using Pippenger's partition algorithm and precomputed generator sums.

# What changes are included in this PR?

A new component for computing multiexponentiations.

# Are these changes tested?

Yes.
