### PR TITLE
feat: add component for combining partial multi-product results (PROOF-831)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -4,6 +4,26 @@ load(
 )
 
 sxt_cc_component(
+    name = "combination",
+    test_deps = [
+        "//sxt/base/curve:example_element",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/algorithm/iteration:for_each",
+        "//sxt/base/container:span",
+        "//sxt/base/curve:element",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/error:assert",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/base/type:raw_stream",
+    ],
+)
+
+sxt_cc_component(
     name = "partition_product",
     test_deps = [
         ":in_memory_partition_table_accessor",

--- a/sxt/multiexp/pippenger2/combination.cc
+++ b/sxt/multiexp/pippenger2/combination.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/combination.h"

--- a/sxt/multiexp/pippenger2/combination.h
+++ b/sxt/multiexp/pippenger2/combination.h
@@ -1,0 +1,69 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/algorithm/iteration/for_each.h"
+#include "sxt/base/container/span.h"
+#include "sxt/base/curve/element.h"
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/base/type/raw_stream.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// combine_impl
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+CUDA_CALLABLE void combine_impl(T* __restrict__ reduction, const T* __restrict__ elements,
+                                unsigned step, unsigned reduction_size) noexcept {
+  T res = elements[0];
+  for (unsigned i = 1; i < reduction_size; ++i) {
+    auto e = elements[step * i];
+    add_inplace(res, e);
+  }
+  *reduction = res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// combine
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T>
+void combine(basct::span<T> res, bast::raw_stream_t stream, basct::cspan<T> elements) noexcept {
+  auto n = static_cast<unsigned>(res.size());
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      elements.size() >= n && 
+      elements.size() % n == 0 &&
+      basdv::is_active_device_pointer(res.data()) &&
+      basdv::is_active_device_pointer(elements.data())
+      // clang-format on
+  );
+  auto reduction_size = static_cast<unsigned>(elements.size() / n);
+  auto f = [
+               // clang-format off
+    reductions = res.data(),
+    elements = elements.data(),
+    reduction_size = reduction_size
+               // clang-format on
+  ] __device__
+           __host__(unsigned n, unsigned index) noexcept {
+             combine_impl(reductions + index, elements + index, n, reduction_size);
+           };
+  algi::launch_for_each_kernel(stream, f, n);
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/combination.t.cc
+++ b/sxt/multiexp/pippenger2/combination.t.cc
@@ -1,0 +1,67 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/combination.h"
+
+#include <vector>
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("todo") {
+  using E = bascrv::element97;
+
+  std::pmr::vector<E> reduction{1, memr::get_managed_device_resource()};
+  std::pmr::vector<E> elements{memr::get_managed_device_resource()};
+
+  std::pmr::vector<E> expected;
+
+  basdv::stream stream;
+
+  SECTION("we can reduce a single element") {
+    elements = {123u};
+    combine<E>(reduction, stream, elements);
+    basdv::synchronize_stream(stream);
+
+    expected = {123u};
+    REQUIRE(reduction == expected);
+  }
+
+  SECTION("we can reduce two elements") {
+    elements = {3u, 4u};
+    combine<E>(reduction, stream, elements);
+    basdv::synchronize_stream(stream);
+
+    expected = {7u};
+    REQUIRE(reduction == expected);
+  }
+
+  SECTION("we can reduce multiple elements") {
+    reduction.resize(3);
+    elements = {3u, 4u, 1u, 2u, 6u, 5u};
+    combine<E>(reduction, stream, elements);
+    basdv::synchronize_stream(stream);
+
+    expected = {3 + 2, 4 + 6, 1 + 5};
+    REQUIRE(reduction == expected);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a function to combine partial results of a multi-product. This will be used to make a multi-gpu version of the Pippenger partition step algorithm.

# What changes are included in this PR?

Adds a new component for combining partial multi-product results.

# Are these changes tested?

Yes
