### PR TITLE
perf: inline mul_3b and neg components (PROOF-851)

### DIFF
--- a/sxt/curve_bng1/operation/BUILD
+++ b/sxt/curve_bng1/operation/BUILD
@@ -80,11 +80,6 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "mul_by_3b",
-    impl_deps = [
-        "//sxt/field25/operation:add",
-        "//sxt/field25/type:element",
-    ],
-    is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field25/constant:one",
@@ -93,6 +88,8 @@ sxt_cc_component(
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
+        "//sxt/field25/operation:add",
+        "//sxt/field25/type:element",
     ],
 )
 

--- a/sxt/curve_bng1/operation/mul_by_3b.cc
+++ b/sxt/curve_bng1/operation/mul_by_3b.cc
@@ -15,23 +15,3 @@
  * limitations under the License.
  */
 #include "sxt/curve_bng1/operation/mul_by_3b.h"
-
-#include "sxt/field25/operation/add.h"
-#include "sxt/field25/type/element.h"
-
-namespace sxt::cn1o {
-//--------------------------------------------------------------------------------------------------
-// mul_by_3b
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void mul_by_3b(f25t::element& h, const f25t::element& p) noexcept {
-  f25t::element p2;
-  f25t::element p4;
-  f25t::element p8;
-
-  f25o::add(p2, p, p);
-  f25o::add(p4, p2, p2);
-  f25o::add(p8, p4, p4);
-  f25o::add(h, p8, p);
-}
-} // namespace sxt::cn1o

--- a/sxt/curve_bng1/operation/mul_by_3b.h
+++ b/sxt/curve_bng1/operation/mul_by_3b.h
@@ -17,10 +17,8 @@
 #pragma once
 
 #include "sxt/base/macro/cuda_callable.h"
-
-namespace sxt::f25t {
-class element;
-}
+#include "sxt/field25/operation/add.h"
+#include "sxt/field25/type/element.h"
 
 namespace sxt::cn1o {
 //--------------------------------------------------------------------------------------------------
@@ -31,5 +29,14 @@ namespace sxt::cn1o {
  * See Algorithm 9 for details, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
-void mul_by_3b(f25t::element& h, const f25t::element& p) noexcept;
+inline void mul_by_3b(f25t::element& h, const f25t::element& p) noexcept {
+  f25t::element p2;
+  f25t::element p4;
+  f25t::element p8;
+
+  f25o::add(p2, p, p);
+  f25o::add(p4, p2, p2);
+  f25o::add(p8, p4, p4);
+  f25o::add(h, p8, p);
+}
 } // namespace sxt::cn1o

--- a/sxt/curve_g1/operation/BUILD
+++ b/sxt/curve_g1/operation/BUILD
@@ -107,11 +107,6 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "mul_by_3b",
-    impl_deps = [
-        "//sxt/field12/operation:add",
-        "//sxt/field12/type:element",
-    ],
-    is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field12/constant:one",
@@ -120,6 +115,8 @@ sxt_cc_component(
     ],
     deps = [
         "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/operation:add",
+        "//sxt/field12/type:element",
     ],
 )
 

--- a/sxt/curve_g1/operation/mul_by_3b.cc
+++ b/sxt/curve_g1/operation/mul_by_3b.cc
@@ -15,23 +15,3 @@
  * limitations under the License.
  */
 #include "sxt/curve_g1/operation/mul_by_3b.h"
-
-#include "sxt/field12/operation/add.h"
-#include "sxt/field12/type/element.h"
-
-namespace sxt::cg1o {
-//--------------------------------------------------------------------------------------------------
-// mul_by_3b
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void mul_by_3b(f12t::element& h, const f12t::element& p) noexcept {
-  f12t::element p2;
-  f12t::element p4;
-  f12t::element p8;
-
-  f12o::add(p2, p, p);
-  f12o::add(p4, p2, p2);
-  f12o::add(p8, p4, p4);
-  f12o::add(h, p8, p4);
-}
-} // namespace sxt::cg1o

--- a/sxt/curve_g1/operation/mul_by_3b.h
+++ b/sxt/curve_g1/operation/mul_by_3b.h
@@ -17,10 +17,8 @@
 #pragma once
 
 #include "sxt/base/macro/cuda_callable.h"
-
-namespace sxt::f12t {
-class element;
-}
+#include "sxt/field12/operation/add.h"
+#include "sxt/field12/type/element.h"
 
 namespace sxt::cg1o {
 //--------------------------------------------------------------------------------------------------
@@ -31,5 +29,14 @@ namespace sxt::cg1o {
  * See Algorithm 9 for details, https://eprint.iacr.org/2015/1060.pdf
  */
 CUDA_CALLABLE
-void mul_by_3b(f12t::element& h, const f12t::element& p) noexcept;
+inline void mul_by_3b(f12t::element& h, const f12t::element& p) noexcept {
+  f12t::element p2;
+  f12t::element p4;
+  f12t::element p8;
+
+  f12o::add(p2, p, p);
+  f12o::add(p4, p2, p2);
+  f12o::add(p8, p4, p4);
+  f12o::add(h, p8, p4);
+}
 } // namespace sxt::cg1o

--- a/sxt/field12/operation/neg.h
+++ b/sxt/field12/operation/neg.h
@@ -50,8 +50,11 @@ inline void neg(f12t::element& h, const f12t::element& f) noexcept {
   // the result of the subtraction is p.
   uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3] | f[4] | f[5]) == 0)} - uint64_t{1};
 
-  for (int i = 0; i < 6; ++i) {
-    h[i] = d[i] & mask;
-  }
+  h[0] = d[0] & mask;
+  h[1] = d[1] & mask;
+  h[2] = d[2] & mask;
+  h[3] = d[3] & mask;
+  h[4] = d[4] & mask;
+  h[5] = d[5] & mask;
 }
 } // namespace sxt::f12o

--- a/sxt/field25/operation/BUILD
+++ b/sxt/field25/operation/BUILD
@@ -82,12 +82,6 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "neg",
-    impl_deps = [
-        "//sxt/base/field:arithmetic_utility",
-        "//sxt/field25/base:constants",
-        "//sxt/field25/type:element",
-    ],
-    is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field25/base:constants",
@@ -95,7 +89,10 @@ sxt_cc_component(
         "//sxt/field25/type:element",
     ],
     deps = [
+        "//sxt/base/field:arithmetic_utility",
         "//sxt/base/macro:cuda_callable",
+        "//sxt/field25/base:constants",
+        "//sxt/field25/type:element",
     ],
 )
 

--- a/sxt/field25/operation/neg.cc
+++ b/sxt/field25/operation/neg.cc
@@ -14,41 +14,4 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
- * Adopted from zkcrypto/bls12_381
- *
- * Copyright (c) 2021
- * Sean Bowe <ewillbefull@gmail.com>
- * Jack Grigg <thestr4d@gmail.com>
- *
- * See third_party/license/zkcrypto.LICENSE
- */
 #include "sxt/field25/operation/neg.h"
-
-#include "sxt/base/field/arithmetic_utility.h"
-#include "sxt/field25/base/constants.h"
-#include "sxt/field25/type/element.h"
-
-namespace sxt::f25o {
-//--------------------------------------------------------------------------------------------------
-// neg
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void neg(f25t::element& h, const f25t::element& f) noexcept {
-  uint64_t d[4] = {};
-  uint64_t borrow{0};
-
-  basfld::sbb(d[0], borrow, f25b::p_v[0], f[0]);
-  basfld::sbb(d[1], borrow, f25b::p_v[1], f[1]);
-  basfld::sbb(d[2], borrow, f25b::p_v[2], f[2]);
-  basfld::sbb(d[3], borrow, f25b::p_v[3], f[3]);
-
-  // Let's use a mask if f was zero, which would mean
-  // the result of the subtraction is p.
-  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3]) == 0)} - uint64_t{1};
-
-  for (size_t i = 0; i < f.num_limbs_v; ++i) {
-    h[i] = d[i] & mask;
-  }
-}
-} // namespace sxt::f25o

--- a/sxt/field25/operation/neg.h
+++ b/sxt/field25/operation/neg.h
@@ -14,18 +14,43 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * Adopted from zkcrypto/bls12_381
+ *
+ * Copyright (c) 2021
+ * Sean Bowe <ewillbefull@gmail.com>
+ * Jack Grigg <thestr4d@gmail.com>
+ *
+ * See third_party/license/zkcrypto.LICENSE
+ */
 #pragma once
 
+#include "sxt/base/field/arithmetic_utility.h"
 #include "sxt/base/macro/cuda_callable.h"
-
-namespace sxt::f25t {
-class element;
-}
+#include "sxt/field25/base/constants.h"
+#include "sxt/field25/type/element.h"
 
 namespace sxt::f25o {
 //--------------------------------------------------------------------------------------------------
 // neg
 //--------------------------------------------------------------------------------------------------
 CUDA_CALLABLE
-void neg(f25t::element& h, const f25t::element& f) noexcept;
+inline void neg(f25t::element& h, const f25t::element& f) noexcept {
+  uint64_t d[4] = {};
+  uint64_t borrow{0};
+
+  basfld::sbb(d[0], borrow, f25b::p_v[0], f[0]);
+  basfld::sbb(d[1], borrow, f25b::p_v[1], f[1]);
+  basfld::sbb(d[2], borrow, f25b::p_v[2], f[2]);
+  basfld::sbb(d[3], borrow, f25b::p_v[3], f[3]);
+
+  // Let's use a mask if f was zero, which would mean
+  // the result of the subtraction is p.
+  uint64_t mask = uint64_t{((f[0] | f[1] | f[2] | f[3]) == 0)} - uint64_t{1};
+
+  h[0] = d[0] & mask;
+  h[1] = d[1] & mask;
+  h[2] = d[2] & mask;
+  h[3] = d[3] & mask;
+}
 } // namespace sxt::f25o


### PR DESCRIPTION
# Rationale for this change
In an effort to improve performance of curve operations for the pairing friendly curves, the `mul_3b` and `neg` components should be inlined. 

This PR improves the performance of curve addition by 1.06x.

# What changes are included in this PR?
- The `mul_3b` components for `curve_g1` and `curve_bng1` packages are inlined.
- The `neg` component is inlined in the `field24` package. It is already inlined in the `field12` package.
- A loop is unrolled in the `neg` component.

# Are these changes tested?
Yes
