### PR TITLE
feat: add host support for multiexponentiations using precomputed partition method (PROOF-831)

### DIFF
--- a/benchmark/multi_exp_pip/benchmark.m.cc
+++ b/benchmark/multi_exp_pip/benchmark.m.cc
@@ -129,8 +129,8 @@ int main(int argc, char* argv[]) {
 
   // discard initial run
   {
-    auto fut =
-        mtxpp2::multiexponentiate<c21t::element_p3>(res, *accessor, element_num_bytes, exponents);
+    auto fut = mtxpp2::async_multiexponentiate<c21t::element_p3>(res, *accessor, element_num_bytes,
+                                                                 exponents);
     xens::get_scheduler().run();
   }
 
@@ -138,8 +138,8 @@ int main(int argc, char* argv[]) {
   double times = 0;
   for (unsigned i = 0; i < num_samples; ++i) {
     auto t1 = std::chrono::steady_clock::now();
-    auto fut =
-        mtxpp2::multiexponentiate<c21t::element_p3>(res, *accessor, element_num_bytes, exponents);
+    auto fut = mtxpp2::async_multiexponentiate<c21t::element_p3>(res, *accessor, element_num_bytes,
+                                                                 exponents);
     xens::get_scheduler().run();
     auto t2 = std::chrono::steady_clock::now();
     auto elapse = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);

--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -155,6 +155,7 @@ sxt_cc_component(
         "//sxt/cbindings/base:multiexp_handle",
     ],
     test_deps = [
+        ":backend",
         "//sxt/base/test:unit_test",
         "//sxt/curve21/operation:add",
         "//sxt/curve21/operation:double",

--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -77,9 +77,7 @@ cbnbck::computational_backend* get_backend() noexcept {
 //--------------------------------------------------------------------------------------------------
 // reset_backend_for_testing
 //--------------------------------------------------------------------------------------------------
-void reset_backend_for_testing() noexcept {
-  backend = nullptr;
-}
+void reset_backend_for_testing() noexcept { backend = nullptr; }
 } // namespace sxt::cbn
 
 //--------------------------------------------------------------------------------------------------

--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -78,8 +78,6 @@ cbnbck::computational_backend* get_backend() noexcept {
 // reset_backend_for_testing
 //--------------------------------------------------------------------------------------------------
 void reset_backend_for_testing() noexcept {
-  SXT_RELEASE_ASSERT(backend != nullptr);
-
   backend = nullptr;
 }
 } // namespace sxt::cbn

--- a/cbindings/fixed_pedersen.t.cc
+++ b/cbindings/fixed_pedersen.t.cc
@@ -18,6 +18,7 @@
 
 #include <vector>
 
+#include "cbindings/backend.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/curve21/operation/add.h"
 #include "sxt/curve21/operation/double.h"
@@ -45,13 +46,29 @@ TEST_CASE("we can compute multi-exponentiations with a fixed set of generators")
       0x456_c21,
   };
 
-  const sxt_config config = {SXT_GPU_BACKEND, 0};
-  REQUIRE(sxt_init(&config) == 0);
 
-  wrapped_handle h{generators.data(), 2};
-  REQUIRE(h.h != nullptr);
+  SECTION("we can compute a multiexponentiation with the gpu backend") {
+    cbn::reset_backend_for_testing();
+    const sxt_config config = {SXT_GPU_BACKEND, 0};
+    REQUIRE(sxt_init(&config) == 0);
 
-  SECTION("we can compute a multiexponentiation") {
+    wrapped_handle h{generators.data(), 2};
+    REQUIRE(h.h != nullptr);
+
+    uint8_t scalars[] = {1, 0, 0, 2};
+    c21t::element_p3 res;
+    sxt_fixed_multiexponentiation(&res, h.h, 2, 1, 2, scalars);
+    REQUIRE(res == generators[0] + 2 * 256 * generators[1]);
+  }
+
+  SECTION("we can compute a multiexponentiation with the cpu backend") {
+    cbn::reset_backend_for_testing();
+    const sxt_config config = {SXT_CPU_BACKEND, 0};
+    REQUIRE(sxt_init(&config) == 0);
+
+    wrapped_handle h{generators.data(), 2};
+    REQUIRE(h.h != nullptr);
+
     uint8_t scalars[] = {1, 0, 0, 2};
     c21t::element_p3 res;
     sxt_fixed_multiexponentiation(&res, h.h, 2, 1, 2, scalars);

--- a/cbindings/fixed_pedersen.t.cc
+++ b/cbindings/fixed_pedersen.t.cc
@@ -46,7 +46,6 @@ TEST_CASE("we can compute multi-exponentiations with a fixed set of generators")
       0x456_c21,
   };
 
-
   SECTION("we can compute a multiexponentiation with the gpu backend") {
     cbn::reset_backend_for_testing();
     const sxt_config config = {SXT_GPU_BACKEND, 0};

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -68,6 +68,7 @@ sxt_cc_component(
     name = "cpu_backend",
     impl_deps = [
         "//sxt/base/error:panic",
+        "//sxt/cbindings/base:curve_id_utility",
         "//sxt/proof/transcript:transcript",
         "//sxt/scalar25/type:element",
         "//sxt/curve_bng1/operation:add",
@@ -89,6 +90,7 @@ sxt_cc_component(
         "//sxt/execution/async:future",
         "//sxt/execution/schedule:scheduler",
         "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/pippenger2:multiexponentiation",
         "//sxt/ristretto/type:compressed_element",
         "//sxt/ristretto/operation:compression",
         "//sxt/multiexp/base:exponent_sequence",

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -168,7 +168,7 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
   cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
     basct::span<T> res_span{static_cast<T*>(res), num_outputs};
     basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};
-    auto fut = mtxpp2::multiexponentiate<T>(
+    auto fut = mtxpp2::async_multiexponentiate<T>(
         res_span, static_cast<const mtxpp2::partition_table_accessor<T>&>(accessor),
         element_num_bytes, scalars_span);
     xens::get_scheduler().run();

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -4,6 +4,11 @@ load(
 )
 
 sxt_cc_component(
+    name = "constants",
+    with_test = False,
+)
+
+sxt_cc_component(
     name = "combination",
     test_deps = [
         "//sxt/base/curve:example_element",
@@ -41,6 +46,7 @@ sxt_cc_component(
         "//sxt/memory/resource:managed_device_resource",
     ],
     deps = [
+        ":constants",
         "//sxt/algorithm/iteration:for_each",
         "//sxt/base/bit:iteration",
         "//sxt/base/bit:permutation",
@@ -69,6 +75,7 @@ sxt_cc_component(
         "//sxt/memory/resource:managed_device_resource",
     ],
     deps = [
+        ":constants",
         "//sxt/algorithm/iteration:for_each",
         "//sxt/base/bit:iteration",
         "//sxt/base/bit:permutation",
@@ -108,6 +115,7 @@ sxt_cc_component(
         "//sxt/memory/resource:device_resource",
     ],
     deps = [
+        ":constants",
         ":partition_table_accessor",
         "//sxt/base/container:span_utility",
         "//sxt/base/device:memory_utility",

--- a/sxt/multiexp/pippenger2/constants.cc
+++ b/sxt/multiexp/pippenger2/constants.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/constants.h"

--- a/sxt/multiexp/pippenger2/constants.h
+++ b/sxt/multiexp/pippenger2/constants.h
@@ -1,0 +1,24 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// partition_table_size_v
+//--------------------------------------------------------------------------------------------------
+constexpr unsigned partition_table_size_v = 1u << 16u;
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -19,6 +19,7 @@
 #include <cerrno>
 #include <cstring>
 #include <fstream>
+#include <print>
 #include <string_view>
 
 #include "sxt/base/container/span_utility.h"
@@ -65,9 +66,9 @@ public:
   }
 
   basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> /*alloc*/, unsigned first,
-                            unsigned n) const noexcept override {
-    SXT_RELEASE_ASSERT(table_.size() >= (n + first) * num_entries);
-    return basct::subspan(table_, first * num_entries, n * num_entries);
+                            unsigned size) const noexcept override {
+    SXT_RELEASE_ASSERT(table_.size() >= size + first * num_entries);
+    return basct::subspan(table_, first * num_entries, size);
   }
 
   void write_to_file(std::string_view filename) const noexcept override {

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -19,7 +19,6 @@
 #include <cerrno>
 #include <cstring>
 #include <fstream>
-#include <print>
 #include <string_view>
 
 #include "sxt/base/container/span_utility.h"

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -67,6 +67,11 @@ public:
                                      stream);
   }
 
+  basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> /*alloc*/, unsigned first,
+                            unsigned n) const noexcept override {
+    return basct::subspan(table_, first, n);
+  }
+
   void write_to_file(std::string_view filename) const noexcept override {
     std::ofstream out{filename, std::ios::binary};
     if (!out.good()) {

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -27,6 +27,7 @@
 #include "sxt/base/error/panic.h"
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/memory/resource/pinned_resource.h"
+#include "sxt/multiexp/pippenger2/constants.h"
 #include "sxt/multiexp/pippenger2/partition_table_accessor.h"
 
 namespace sxt::mtxpp2 {
@@ -35,7 +36,6 @@ namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T>
 class in_memory_partition_table_accessor final : public partition_table_accessor<T> {
-  static constexpr unsigned num_entries = 1u << 16u;
 
 public:
   explicit in_memory_partition_table_accessor(std::string_view filename) noexcept
@@ -58,16 +58,16 @@ public:
 
   void async_copy_to_device(basct::span<T> dest, bast::raw_stream_t stream,
                             unsigned first) const noexcept override {
-    SXT_RELEASE_ASSERT(table_.size() >= dest.size() + first * num_entries);
+    SXT_RELEASE_ASSERT(table_.size() >= dest.size() + first * partition_table_size_v);
     SXT_DEBUG_ASSERT(basdv::is_active_device_pointer(dest.data()));
-    basdv::async_copy_host_to_device(dest, basct::subspan(table_, first * num_entries, dest.size()),
-                                     stream);
+    basdv::async_copy_host_to_device(
+        dest, basct::subspan(table_, first * partition_table_size_v, dest.size()), stream);
   }
 
   basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> /*alloc*/, unsigned first,
                             unsigned size) const noexcept override {
-    SXT_RELEASE_ASSERT(table_.size() >= size + first * num_entries);
-    return basct::subspan(table_, first * num_entries, size);
+    SXT_RELEASE_ASSERT(table_.size() >= size + first * partition_table_size_v);
+    return basct::subspan(table_, first * partition_table_size_v, size);
   }
 
   void write_to_file(std::string_view filename) const noexcept override {

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -54,8 +54,8 @@ public:
   explicit in_memory_partition_table_accessor(memmg::managed_array<T>&& table) noexcept
       : table_{std::move(table)} {}
 
-  void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
-                                             unsigned first) const noexcept override {
+  void async_copy_to_device(basct::span<T> dest, bast::raw_stream_t stream,
+                            unsigned first) const noexcept override {
     static unsigned num_entries = 1u << 16u;
     SXT_DEBUG_ASSERT(
         // clang-format off

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -51,7 +51,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   }
 
   SECTION("we can access a elements with offset") {
-    std::vector<E> data((1u << 16u) * 2);
+    std::vector<E> data(partition_table_size_v * 2);
     data[1u << 16u] = 12u;
     temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
     temp_file.stream().close();
@@ -66,8 +66,8 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   }
 
   SECTION("we can access elements from the host") {
-    std::vector<E> data((1u << 16u) * 2);
-    data[1u << 16u] = 12;
+    std::vector<E> data(partition_table_size_v * 2);
+    data[partition_table_size_v] = 12;
     temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
@@ -78,7 +78,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   }
 
   SECTION("we can write an accessor to a file") {
-    memmg::managed_array<E> data((1u << 16u) * 2);
+    memmg::managed_array<E> data(partition_table_size_v * 2);
     unsigned cnt = 0;
     for (auto& val : data) {
       val = cnt++;

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -41,7 +41,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
     memmg::managed_array<E> v_dev{1, memr::get_device_resource()};
-    accessor.async_copy_precomputed_sums_to_device(v_dev, stream, 0);
+    accessor.async_copy_to_device(v_dev, stream, 0);
     std::vector<E> v(1);
     basdv::async_copy_device_to_host(v, v_dev, stream);
     basdv::synchronize_stream(stream);
@@ -56,7 +56,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
     memmg::managed_array<E> v_dev{1, memr::get_device_resource()};
-    accessor.async_copy_precomputed_sums_to_device(v_dev, stream, 1);
+    accessor.async_copy_to_device(v_dev, stream, 1);
     std::vector<E> v(1);
     basdv::async_copy_device_to_host(v, v_dev, stream);
     basdv::synchronize_stream(stream);
@@ -75,7 +75,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
     accessor.write_to_file(temp_file.name());
     in_memory_partition_table_accessor<E> accessor_p{temp_file.name()};
     memmg::managed_array<E> data_dev{data.size(), memr::get_device_resource()};
-    accessor_p.async_copy_precomputed_sums_to_device(data_dev, stream, 0);
+    accessor_p.async_copy_to_device(data_dev, stream, 0);
     memmg::managed_array<E> data_p(data.size());
     basdv::async_copy_device_to_host(data_p, data_dev, stream);
     basdv::synchronize_stream(stream);

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -43,8 +43,8 @@ make_in_memory_partition_table_accessor(basct::cspan<T> generators) noexcept {
     std::fill(iter, generators_data.end(), T::identity());
     generators = generators_data;
   }
-  auto num_entries = 1u << 16u;
-  memmg::managed_array<T> sums{num_entries * num_partitions, memr::get_pinned_resource()};
+  memmg::managed_array<T> sums{partition_table_size_v * num_partitions,
+                               memr::get_pinned_resource()};
   compute_partition_table<T>(sums, generators);
   return std::make_unique<in_memory_partition_table_accessor<T>>(std::move(sums));
 }

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
@@ -44,7 +44,7 @@ TEST_CASE("we can create a partition table accessor from given generators") {
 
   SECTION("we can create an accessor from a single generators") {
     auto accessor = make_in_memory_partition_table_accessor<E>(basct::subspan(generators, 0, 1));
-    accessor->async_copy_precomputed_sums_to_device(table_dev, stream, 0);
+    accessor->async_copy_to_device(table_dev, stream, 0);
     basdv::async_copy_device_to_host(table, table_dev, stream);
     basdv::synchronize_stream(stream);
     REQUIRE(table[1] == generators[0]);
@@ -53,7 +53,7 @@ TEST_CASE("we can create a partition table accessor from given generators") {
 
   SECTION("we can create an accessor from multiple generators") {
     auto accessor = make_in_memory_partition_table_accessor<E>(generators);
-    accessor->async_copy_precomputed_sums_to_device(table_dev, stream, 0);
+    accessor->async_copy_to_device(table_dev, stream, 0);
     basdv::async_copy_device_to_host(table, table_dev, stream);
     basdv::synchronize_stream(stream);
     REQUIRE(table[1] == generators[0]);

--- a/sxt/multiexp/pippenger2/multiexponentiation.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation.h
@@ -180,7 +180,7 @@ xena::future<> multiexponentiate_impl(basct::span<T> res,
 }
 
 //--------------------------------------------------------------------------------------------------
-// multiexponentiate
+// async_multiexponentiate
 //--------------------------------------------------------------------------------------------------
 /**
  * Compute a multi-exponentiation using an accessor to precompute sums of partition groups.
@@ -189,9 +189,9 @@ xena::future<> multiexponentiate_impl(basct::span<T> res,
  * https://cacr.uwaterloo.ca/techreports/2010/cacr2010-26.pdf
  */
 template <bascrv::element T>
-xena::future<> multiexponentiate(basct::span<T> res, const partition_table_accessor<T>& accessor,
-                                 unsigned element_num_bytes,
-                                 basct::cspan<uint8_t> scalars) noexcept {
+xena::future<>
+async_multiexponentiate(basct::span<T> res, const partition_table_accessor<T>& accessor,
+                        unsigned element_num_bytes, basct::cspan<uint8_t> scalars) noexcept {
   multiexponentiate_options options;
   options.split_factor = static_cast<unsigned>(basdv::get_num_devices());
   return multiexponentiate_impl(res, accessor, element_num_bytes, scalars, options);

--- a/sxt/multiexp/pippenger2/multiexponentiation.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation.h
@@ -70,7 +70,7 @@ multiexponentiate_no_chunks(basct::span<T> res, const partition_table_accessor<T
   // compute bitwise products
   basl::info("computing {} bitwise multiexponentiation products of length {}", num_products, n);
   memmg::managed_array<T> products(num_products, memr::get_device_resource());
-  co_await partition_product<T>(products, accessor, scalars, 0);
+  co_await async_partition_product<T>(products, accessor, scalars, 0);
 
   // reduce products
   basl::info("reducing {} products to {} outputs", num_products, num_products);
@@ -155,7 +155,7 @@ xena::future<> multiexponentiate_impl(basct::span<T> res,
         memmg::managed_array<T> products_dev{num_products, memr::get_device_resource()};
         auto scalars_slice = scalars.subspan(num_outputs * element_num_bytes * rng.a(),
                                              rng.size() * num_outputs * element_num_bytes);
-        co_await partition_product<T>(products_dev, accessor, scalars_slice, rng.a());
+        co_await async_partition_product<T>(products_dev, accessor, scalars_slice, rng.a());
         basdv::stream stream;
         basdv::async_copy_device_to_host(
             basct::subspan(products, num_products * chunk_index, num_products), products_dev,

--- a/sxt/multiexp/pippenger2/multiexponentiation.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation.h
@@ -196,4 +196,19 @@ async_multiexponentiate(basct::span<T> res, const partition_table_accessor<T>& a
   options.split_factor = static_cast<unsigned>(basdv::get_num_devices());
   return multiexponentiate_impl(res, accessor, element_num_bytes, scalars, options);
 }
+
+//--------------------------------------------------------------------------------------------------
+// multiexponentiate
+//--------------------------------------------------------------------------------------------------
+/**
+ * Host version of async_multiexponentiate.
+ */
+template <bascrv::element T>
+void multiexponentiate(basct::span<T> res, const partition_table_accessor<T>& accessor,
+                       unsigned element_num_bytes, basct::cspan<uint8_t> scalars) noexcept {
+  (void)res;
+  (void)accessor;
+  (void)element_num_bytes;
+  (void)scalars;
+}
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/multiexponentiation.t.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation.t.cc
@@ -50,7 +50,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
   std::vector<E> res(1);
 
   SECTION("we can compute a multiexponentiation with a zero scalar") {
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == E::identity());
@@ -58,7 +58,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
 
   SECTION("we can compute a multiexponentiation multiexponentiation with a scalar of one") {
     scalars[0] = 1;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == generators[0]);
@@ -66,7 +66,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
 
   SECTION("we can compute a multiexponentiation with a scalar of two") {
     scalars[0] = 2;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == 2u * generators[0].value);
@@ -74,7 +74,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
 
   SECTION("we can compute a multiexponentiation with a scalar of three") {
     scalars[0] = 3;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == 3u * generators[0].value);
@@ -84,7 +84,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
     scalars.resize(2);
     scalars[0] = 1;
     scalars[1] = 1;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == generators[0].value + generators[1].value);
@@ -94,7 +94,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
     scalars.resize(17);
     scalars[0] = 1;
     scalars[16] = 1;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == generators[0].value + generators[16].value);
@@ -105,7 +105,7 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
     scalars.resize(2);
     scalars[0] = 1u;
     scalars[1] = 2u;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == generators[0].value);
@@ -161,7 +161,7 @@ TEST_CASE("we can compute multiexponentiations with curve-21") {
 
   SECTION("we can compute a multiexponentiation multiexponentiation with a scalar of one") {
     scalars[0] = 1;
-    auto fut = multiexponentiate<E>(res, *accessor, 1, scalars);
+    auto fut = async_multiexponentiate<E>(res, *accessor, 1, scalars);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     REQUIRE(res[0] == generators[0]);

--- a/sxt/multiexp/pippenger2/multiexponentiation.t.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation.t.cc
@@ -112,6 +112,16 @@ TEST_CASE("we can compute multiexponentiations using a precomputed table of part
     REQUIRE(res[1] == 2u * generators[0].value);
   }
 
+  SECTION("we can compute a multiexponentiation on the host") {
+    res.resize(2);
+    scalars.resize(2);
+    scalars[0] = 1u;
+    scalars[1] = 2u;
+    multiexponentiate<E>(res, *accessor, 1, scalars);
+    REQUIRE(res[0] == generators[0].value);
+    REQUIRE(res[1] == 2u * generators[0].value);
+  }
+
   SECTION("we can split a multi-exponentiation") {
     multiexponentiate_options options{
         .split_factor = 2,

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -145,4 +145,20 @@ xena::future<> async_partition_product(basct::span<T> products,
   algi::launch_for_each_kernel(stream, f, num_products);
   co_await xendv::await_stream(stream);
 }
+
+//--------------------------------------------------------------------------------------------------
+// partition_product
+//--------------------------------------------------------------------------------------------------
+/**
+ * Compute the multiproduct for the bits of an array of scalars using an accessor to
+ * precomputed sums for each group of generators.
+ */
+template <bascrv::element T>
+void partition_product(basct::span<T> products, const partition_table_accessor<T>& accessor,
+                       basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
+  (void)products;
+  (void)accessor;
+  (void)scalars;
+  (void)offset;
+}
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -165,10 +165,10 @@ void partition_product(basct::span<T> products, const partition_table_accessor<T
       // clang-format on
   );
   std::pmr::monotonic_buffer_resource alloc;
-  
+
   auto partition_table = accessor.host_view(&alloc, offset, n);
 
-  for (unsigned product_index=0; product_index<num_products; ++product_index) {
+  for (unsigned product_index = 0; product_index < num_products; ++product_index) {
     auto byte_index = product_index / 8u;
     auto bit_offset = product_index % 8u;
     partition_product_kernel<T>(products.data(), partition_table.data(), scalars.data(), byte_index,

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -104,7 +104,13 @@ xena::future<> partition_product(basct::span<T> products,
   auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
   auto num_partitions = basn::divide_up(n, 16u);
   auto num_table_entries = 1u << 16u;
-  SXT_DEBUG_ASSERT(offset % 16u == 0);
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      offset % 16u == 0 &&
+      basdv::is_active_device_pointer(products.data()) &&
+      basdv::is_host_pointer(scalars.data())
+      // clang-format on
+  );
 
   // scalars_dev
   memmg::managed_array<uint8_t> scalars_dev{scalars.size(), memr::get_device_resource()};

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -104,7 +104,7 @@ xena::future<> async_partition_product(basct::span<T> products,
   auto num_products = products.size();
   auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
   auto num_partitions = basn::divide_up(n, 16u);
-  auto num_table_entries = 1u << 16u;
+  constexpr auto num_table_entries = 1u << 16u;
   SXT_DEBUG_ASSERT(
       // clang-format off
       offset % 16u == 0 &&
@@ -159,6 +159,7 @@ void partition_product(basct::span<T> products, const partition_table_accessor<T
                        basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
   auto num_products = products.size();
   auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
+  constexpr auto num_table_entries = 1u << 16u;
   SXT_DEBUG_ASSERT(
       // clang-format off
       offset % 16u == 0
@@ -166,7 +167,8 @@ void partition_product(basct::span<T> products, const partition_table_accessor<T
   );
   std::pmr::monotonic_buffer_resource alloc;
 
-  auto partition_table = accessor.host_view(&alloc, offset, n);
+  auto partition_table =
+      accessor.host_view(&alloc, offset, basn::divide_up(n, 16u) * num_table_entries);
 
   for (unsigned product_index = 0; product_index < num_products; ++product_index) {
     auto byte_index = product_index / 8u;

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -159,7 +159,6 @@ void partition_product(basct::span<T> products, const partition_table_accessor<T
                        basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
   auto num_products = products.size();
   auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
-  constexpr auto partition_table_size_v = 1u << 16u;
   SXT_DEBUG_ASSERT(
       // clang-format off
       offset % 16u == 0

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -125,7 +125,7 @@ xena::future<> async_partition_product(basct::span<T> products,
   basdv::stream stream;
   memr::async_device_resource resource{stream};
   memmg::managed_array<T> partition_table{num_partitions * num_table_entries, &resource};
-  accessor.async_copy_precomputed_sums_to_device(partition_table, stream, offset / 16u);
+  accessor.async_copy_to_device(partition_table, stream, offset / 16u);
   co_await std::move(scalars_fut);
 
   // product

--- a/sxt/multiexp/pippenger2/partition_product.h
+++ b/sxt/multiexp/pippenger2/partition_product.h
@@ -90,16 +90,16 @@ partition_product_kernel(T* __restrict__ products, const T* __restrict__ partiti
 }
 
 //--------------------------------------------------------------------------------------------------
-// partition_product
+// async_partition_product
 //--------------------------------------------------------------------------------------------------
 /**
  * Compute the multiproduct for the bits of an array of scalars using an accessor to
  * precomputed sums for each group of generators.
  */
 template <bascrv::element T>
-xena::future<> partition_product(basct::span<T> products,
-                                 const partition_table_accessor<T>& accessor,
-                                 basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
+xena::future<> async_partition_product(basct::span<T> products,
+                                       const partition_table_accessor<T>& accessor,
+                                       basct::cspan<uint8_t> scalars, unsigned offset) noexcept {
   auto num_products = products.size();
   auto n = static_cast<unsigned>(scalars.size() * 8u / num_products);
   auto num_partitions = basn::divide_up(n, 16u);

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -140,4 +140,13 @@ TEST_CASE("we can compute the product of partitions") {
     expected[0] = partition_table[1].value + partition_table[num_entries + 1].value;
     REQUIRE(products == expected);
   }
+
+  SECTION("we can compute products on the host") {
+    scalars.resize(32);
+    scalars[0] = 1u;
+    scalars[16] = 1u;
+    partition_product<E>(products, accessor, scalars, 0);
+    expected[0] = partition_table[1].value + partition_table[num_entries + 1].value;
+    REQUIRE(products == expected);
+  }
 }

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -88,7 +88,7 @@ TEST_CASE("we can compute the product of partitions") {
 
   SECTION("we handle a product with a single scalar") {
     scalars[0] = 1;
-    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 0);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
@@ -98,7 +98,7 @@ TEST_CASE("we can compute the product of partitions") {
 
   SECTION("we handle a product with an offset") {
     scalars[0] = 1;
-    auto fut = partition_product<E>(products, accessor, scalars, 16);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 16);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
@@ -108,7 +108,7 @@ TEST_CASE("we can compute the product of partitions") {
 
   SECTION("we handle a product with two scalars") {
     scalars = {1u, 3u};
-    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 0);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
@@ -121,7 +121,7 @@ TEST_CASE("we can compute the product of partitions") {
     scalars.resize(16);
     scalars[0] = 1u;
     scalars[15] = 1u;
-    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 0);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
@@ -133,7 +133,7 @@ TEST_CASE("we can compute the product of partitions") {
     scalars.resize(32);
     scalars[0] = 1u;
     scalars[16] = 1u;
-    auto fut = partition_product<E>(products, accessor, scalars, 0);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 0);
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -25,6 +25,7 @@
 #include "sxt/execution/schedule/scheduler.h"
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/memory/resource/managed_device_resource.h"
+#include "sxt/multiexp/pippenger2/constants.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 
 using namespace sxt;
@@ -66,7 +67,6 @@ TEST_CASE("we can compute the index used to lookup the precomputed sum for a par
 }
 
 TEST_CASE("we can compute the product of partitions") {
-  constexpr auto num_entries = 1u << 16u;
   using E = bascrv::element97;
   memmg::managed_array<E> products{8, memr::get_managed_device_resource()};
   std::vector<uint8_t> scalars(1);
@@ -102,7 +102,7 @@ TEST_CASE("we can compute the product of partitions") {
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
-    expected[0] = partition_table[num_entries + 1];
+    expected[0] = partition_table[partition_table_size_v + 1];
     REQUIRE(products == expected);
   }
 
@@ -137,7 +137,7 @@ TEST_CASE("we can compute the product of partitions") {
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
     basdv::synchronize_device();
-    expected[0] = partition_table[1].value + partition_table[num_entries + 1].value;
+    expected[0] = partition_table[1].value + partition_table[partition_table_size_v + 1].value;
     REQUIRE(products == expected);
   }
 
@@ -146,7 +146,7 @@ TEST_CASE("we can compute the product of partitions") {
     scalars[0] = 1u;
     scalars[16] = 1u;
     partition_product<E>(products, accessor, scalars, 0);
-    expected[0] = partition_table[1].value + partition_table[num_entries + 1].value;
+    expected[0] = partition_table[1].value + partition_table[partition_table_size_v + 1].value;
     REQUIRE(products == expected);
   }
 }

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -23,6 +23,7 @@
 #include "sxt/base/curve/element.h"
 #include "sxt/base/error/assert.h"
 #include "sxt/base/macro/cuda_callable.h"
+#include "sxt/multiexp/pippenger2/constants.h"
 
 namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
@@ -70,16 +71,15 @@ CUDA_CALLABLE void compute_partition_table_slice(T* __restrict__ sums,
  */
 template <bascrv::element T>
 void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) noexcept {
-  auto num_entries = 1u << 16u;
   SXT_DEBUG_ASSERT(
       // clang-format off
-     sums.size() == num_entries * generators.size() / 16u &&
+     sums.size() == partition_table_size_v * generators.size() / 16u &&
      generators.size() % 16 == 0
       // clang-format on
   );
   auto n = generators.size() / 16u;
   for (unsigned i = 0; i < n; ++i) {
-    auto sums_slice = sums.subspan(i * num_entries, num_entries);
+    auto sums_slice = sums.subspan(i * partition_table_size_v, partition_table_size_v);
     auto generators_slice = generators.subspan(i * 16u, 16u);
     compute_partition_table_slice<T>(sums_slice.data(), generators_slice.data());
   }

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -21,6 +21,7 @@
 #include "sxt/base/bit/iteration.h"
 #include "sxt/base/curve/example_element.h"
 #include "sxt/base/test/unit_test.h"
+#include "sxt/multiexp/pippenger2/constants.h"
 
 using namespace sxt;
 using namespace sxt::mtxpp2;
@@ -44,13 +45,12 @@ TEST_CASE("we can compute a slice of the partition table") {
 TEST_CASE("we can compute the full partition table") {
   using E = bascrv::element97;
   auto n = 2u;
-  auto num_entries = 1u << 16u;
-  std::vector<E> sums(num_entries * n);
+  std::vector<E> sums(partition_table_size_v * n);
   std::vector<E> generators(16u * n);
   for (unsigned i = 0; i < generators.size(); ++i) {
     generators[i] = i + 1u;
   }
   compute_partition_table<E>(sums, generators);
   REQUIRE(sums[1] == generators[0]);
-  REQUIRE(sums[num_entries + 1] == generators[16]);
+  REQUIRE(sums[partition_table_size_v + 1] == generators[16]);
 }

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <string_view>
+#include <memory>
 
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"
@@ -32,6 +33,9 @@ public:
 
   virtual void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
                                                      unsigned first) const noexcept = 0;
+
+  virtual basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> alloc, unsigned first,
+                                    unsigned n) const noexcept = 0;
 
   virtual void write_to_file(std::string_view filename) const noexcept = 0;
 };

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -30,8 +30,8 @@ namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T> class partition_table_accessor : public partition_table_accessor_base {
 public:
-  virtual void async_copy_precomputed_sums_to_device(basct::span<T> dest, bast::raw_stream_t stream,
-                                                     unsigned first) const noexcept = 0;
+  virtual void async_copy_to_device(basct::span<T> dest, bast::raw_stream_t stream,
+                                    unsigned first) const noexcept = 0;
 
   virtual basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> alloc, unsigned first,
                                     unsigned n) const noexcept = 0;

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -16,8 +16,8 @@
  */
 #pragma once
 
-#include <string_view>
 #include <memory>
+#include <string_view>
 
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"

--- a/sxt/multiexp/pippenger2/partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/partition_table_accessor.h
@@ -28,13 +28,35 @@ namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
 // partition_table_accessor
 //--------------------------------------------------------------------------------------------------
+/**
+ * Support accessing precomputed sums for groups of 16 generators.
+ *
+ * For example, if there are 32 generators
+ *
+ *    g0, ..., g15, g16, ..., g31
+ *
+ * an accessor will contain two tables each of 2^16 entries with all the sums of
+ * generators g0 to g15 and all the sums of generators g16 to g31, respectively.
+ */
 template <bascrv::element T> class partition_table_accessor : public partition_table_accessor_base {
 public:
+  /**
+   * Asynchronously copy precomputed sums of partitions to device.
+   *
+   * `first` specifies the partition group offset to use.
+   */
   virtual void async_copy_to_device(basct::span<T> dest, bast::raw_stream_t stream,
                                     unsigned first) const noexcept = 0;
 
+  /**
+   * Make a view into precomputed sums of partitions available to host memory.
+   *
+   * `first` specifies the partition group offset to use. If memory needs to be allocated
+   * to make the view available, it will be allocated using alloc. Make sure that alloc uses
+   * a resource that frees memory upon destruction (e.g. std::pmr::monotonic_buffer_resource).
+   */
   virtual basct::cspan<T> host_view(std::pmr::polymorphic_allocator<> alloc, unsigned first,
-                                    unsigned n) const noexcept = 0;
+                                    unsigned size) const noexcept = 0;
 
   virtual void write_to_file(std::string_view filename) const noexcept = 0;
 };

--- a/sxt/multiexp/pippenger2/reduce.h
+++ b/sxt/multiexp/pippenger2/reduce.h
@@ -76,7 +76,7 @@ void reduce_products(basct::span<T> reductions, basct::cspan<T> products) noexce
   auto reduction_size = products.size() / reductions.size();
   SXT_DEBUG_ASSERT(products.size() == reduction_size * num_outputs);
   for (unsigned output_index=0; output_index<num_outputs; ++output_index) {
-    reduce_output(reductions + output_index, products + output_index * reduction_size,
+    reduce_output(reductions.data() + output_index, products.data() + output_index * reduction_size,
                   reduction_size);
   }
 }

--- a/sxt/multiexp/pippenger2/reduce.h
+++ b/sxt/multiexp/pippenger2/reduce.h
@@ -69,4 +69,15 @@ void reduce_products(basct::span<T> reductions, bast::raw_stream_t stream,
            };
   algi::launch_for_each_kernel(stream, f, num_outputs);
 }
+
+template <bascrv::element T>
+void reduce_products(basct::span<T> reductions, basct::cspan<T> products) noexcept {
+  auto num_outputs = reductions.size();
+  auto reduction_size = products.size() / reductions.size();
+  SXT_DEBUG_ASSERT(products.size() == reduction_size * num_outputs);
+  for (unsigned output_index=0; output_index<num_outputs; ++output_index) {
+    reduce_output(reductions + output_index, products + output_index * reduction_size,
+                  reduction_size);
+  }
+}
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/reduce.h
+++ b/sxt/multiexp/pippenger2/reduce.h
@@ -75,7 +75,7 @@ void reduce_products(basct::span<T> reductions, basct::cspan<T> products) noexce
   auto num_outputs = reductions.size();
   auto reduction_size = products.size() / reductions.size();
   SXT_DEBUG_ASSERT(products.size() == reduction_size * num_outputs);
-  for (unsigned output_index=0; output_index<num_outputs; ++output_index) {
+  for (unsigned output_index = 0; output_index < num_outputs; ++output_index) {
     reduce_output(reductions.data() + output_index, products.data() + output_index * reduction_size,
                   reduction_size);
   }

--- a/sxt/multiexp/pippenger2/reduce.t.cc
+++ b/sxt/multiexp/pippenger2/reduce.t.cc
@@ -55,4 +55,14 @@ TEST_CASE("we can reduce products") {
     expected = {123u + 2u * 456u};
     REQUIRE(outputs == expected);
   }
+
+  SECTION("we can reduce products on the host") {
+    outputs.resize(1);
+    products.resize(2);
+    products[0] = 123u;
+    products[1] = 456u;
+    reduce_products<E>(outputs, products);
+    expected = {123u + 2u * 456u};
+    REQUIRE(outputs == expected);
+  }
 }


### PR DESCRIPTION
# Rationale for this change

Support computing multiexponentiations using Pippenger's partition algorithm for the host side. This is the cpu version of https://github.com/spaceandtimelabs/blitzar/pull/130

# What changes are included in this PR?

* add cpu versions of Pippenger algorithms
* add more documentation
* minor renaming
* minor changes to make testing easier

# Are these changes tested?

Yes