### PR TITLE
feat: don't use pinned memory for cpu backend (PROOF-831)

### DIFF
--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -90,6 +90,7 @@ sxt_cc_component(
         "//sxt/execution/async:future",
         "//sxt/execution/schedule:scheduler",
         "//sxt/memory/management:managed_array",
+        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor_utility",
         "//sxt/multiexp/pippenger2:multiexponentiation",
         "//sxt/ristretto/type:compressed_element",
         "//sxt/ristretto/operation:compression",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -51,6 +51,7 @@ sxt_cc_component(
         "//sxt/ristretto/operation:compression",
         "//sxt/multiexp/base:exponent_sequence",
         "//sxt/multiexp/curve:multiexponentiation",
+        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor_utility",
         "//sxt/multiexp/pippenger2:multiexponentiation",
         "//sxt/seqcommit/generator:precomputed_generators",
         "//sxt/proof/inner_product:proof_descriptor",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -5,10 +5,6 @@ load(
 
 sxt_cc_component(
     name = "computational_backend",
-    impl_deps = [
-        "//sxt/cbindings/base:curve_id_utility",
-        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor_utility",
-    ],
     with_test = False,
     deps = [
         "//sxt/base/container:span",

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -15,23 +15,3 @@
  * limitations under the License.
  */
 #include "sxt/cbindings/backend/computational_backend.h"
-
-#include "sxt/cbindings/base/curve_id_utility.h"
-#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
-
-namespace sxt::cbnbck {
-//--------------------------------------------------------------------------------------------------
-// make_partition_table_accessor
-//--------------------------------------------------------------------------------------------------
-std::unique_ptr<mtxpp2::partition_table_accessor_base>
-computational_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id,
-                                                     const void* generators,
-                                                     unsigned n) const noexcept {
-  std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
-  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
-    res = mtxpp2::make_in_memory_partition_table_accessor<T>(
-        basct::cspan<T>{static_cast<const T*>(generators), n});
-  });
-  return res;
-}
-} // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -97,7 +97,7 @@ public:
 
   virtual std::unique_ptr<mtxpp2::partition_table_accessor_base>
   make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
-                                unsigned n) const noexcept;
+                                unsigned n) const noexcept = 0;
 
   virtual void fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id,
                                          const mtxpp2::partition_table_accessor_base& accessor,

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -131,7 +131,7 @@ cpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void
   std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
   cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
     res = mtxpp2::make_in_memory_partition_table_accessor<T>(
-        basct::cspan<T>{static_cast<const T*>(generators), n});
+        basct::cspan<T>{static_cast<const T*>(generators), n}, basm::alloc_t{});
   });
   return res;
 }

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -41,6 +41,7 @@
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/multiexp/base/exponent_sequence.h"
 #include "sxt/multiexp/curve/multiexponentiation.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
 #include "sxt/multiexp/pippenger2/multiexponentiation.h"
 #include "sxt/proof/inner_product/cpu_driver.h"
 #include "sxt/proof/inner_product/proof_computation.h"
@@ -119,6 +120,20 @@ bool cpu_backend::verify_inner_product(prft::transcript& transcript,
   return prfip::verify_inner_product(transcript, drv, descriptor, product, a_commit, l_vector,
                                      r_vector, ap_value)
       .value();
+}
+
+//--------------------------------------------------------------------------------------------------
+// make_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+std::unique_ptr<mtxpp2::partition_table_accessor_base>
+cpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
+                                           unsigned n) const noexcept {
+  std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
+  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
+    res = mtxpp2::make_in_memory_partition_table_accessor<T>(
+        basct::cspan<T>{static_cast<const T*>(generators), n});
+  });
+  return res;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/cpu_backend.h
+++ b/sxt/cbindings/backend/cpu_backend.h
@@ -55,6 +55,10 @@ public:
                             basct::cspan<rstt::compressed_element> r_vector,
                             const s25t::element& ap_value) const noexcept override;
 
+  std::unique_ptr<mtxpp2::partition_table_accessor_base>
+  make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
+                                unsigned n) const noexcept override;
+
   void fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id,
                                  const mtxpp2::partition_table_accessor_base& accessor,
                                  unsigned element_num_bytes, unsigned num_outputs, unsigned n,

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -41,6 +41,7 @@
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/multiexp/base/exponent_sequence.h"
 #include "sxt/multiexp/curve/multiexponentiation.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
 #include "sxt/multiexp/pippenger2/multiexponentiation.h"
 #include "sxt/proof/inner_product/gpu_driver.h"
 #include "sxt/proof/inner_product/proof_computation.h"
@@ -156,6 +157,20 @@ bool gpu_backend::verify_inner_product(prft::transcript& transcript,
                                          r_vector, ap_value);
   xens::get_scheduler().run();
   return fut.value();
+}
+
+//--------------------------------------------------------------------------------------------------
+// make_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+std::unique_ptr<mtxpp2::partition_table_accessor_base>
+gpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
+                                           unsigned n) const noexcept {
+  std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
+  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
+    res = mtxpp2::make_in_memory_partition_table_accessor<T>(
+        basct::cspan<T>{static_cast<const T*>(generators), n});
+  });
+  return res;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/gpu_backend.h
+++ b/sxt/cbindings/backend/gpu_backend.h
@@ -57,6 +57,10 @@ public:
                             basct::cspan<rstt::compressed_element> r_vector,
                             const s25t::element& ap_value) const noexcept override;
 
+  std::unique_ptr<mtxpp2::partition_table_accessor_base>
+  make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
+                                unsigned n) const noexcept override;
+
   void fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id,
                                  const mtxpp2::partition_table_accessor_base& accessor,
                                  unsigned element_num_bytes, unsigned num_outputs, unsigned n,

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -141,8 +141,8 @@ sxt_cc_component(
         ":partition_table",
         "//sxt/base/container:span",
         "//sxt/base/curve:element",
-        "//sxt/base/num:divide_up",
         "//sxt/base/memory:alloc",
+        "//sxt/base/num:divide_up",
         "//sxt/memory/resource:pinned_resource",
     ],
 )

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -142,6 +142,7 @@ sxt_cc_component(
         "//sxt/base/container:span",
         "//sxt/base/curve:element",
         "//sxt/base/num:divide_up",
+        "//sxt/base/memory:alloc",
         "//sxt/memory/resource:pinned_resource",
     ],
 )

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -21,8 +21,8 @@
 
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"
-#include "sxt/base/num/divide_up.h"
 #include "sxt/base/memory/alloc.h"
+#include "sxt/base/num/divide_up.h"
 #include "sxt/memory/resource/pinned_resource.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 #include "sxt/multiexp/pippenger2/partition_table.h"

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -22,6 +22,7 @@
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"
 #include "sxt/base/num/divide_up.h"
+#include "sxt/base/memory/alloc.h"
 #include "sxt/memory/resource/pinned_resource.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 #include "sxt/multiexp/pippenger2/partition_table.h"
@@ -31,8 +32,8 @@ namespace sxt::mtxpp2 {
 // make_in_memory_partition_table_accessor
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T>
-std::unique_ptr<partition_table_accessor<T>>
-make_in_memory_partition_table_accessor(basct::cspan<T> generators) noexcept {
+std::unique_ptr<partition_table_accessor<T>> make_in_memory_partition_table_accessor(
+    basct::cspan<T> generators, basm::alloc_t alloc = memr::get_pinned_resource()) noexcept {
   auto n = generators.size();
   std::vector<T> generators_data;
   auto num_partitions = basn::divide_up(n, size_t{16});
@@ -43,8 +44,7 @@ make_in_memory_partition_table_accessor(basct::cspan<T> generators) noexcept {
     std::fill(iter, generators_data.end(), T::identity());
     generators = generators_data;
   }
-  memmg::managed_array<T> sums{partition_table_size_v * num_partitions,
-                               memr::get_pinned_resource()};
+  memmg::managed_array<T> sums{partition_table_size_v * num_partitions, alloc};
   compute_partition_table<T>(sums, generators);
   return std::make_unique<in_memory_partition_table_accessor<T>>(std::move(sums));
 }


### PR DESCRIPTION
# Rationale for this change

Rework cpu backend so that it doesn't use pinned memory. Pinned memory requires that CUDA drivers be up-to-date which makes the library less portable. And if the GPU isn't available there's no benefit for it anyways.

# What changes are included in this PR?

Customize computational backend so that it only uses pinned memory for the gpu backend.

# Are these changes tested?

Yes
