### PR TITLE
feat: use a more compact point form for curve-25519's partition sum table (PROOF-870)

### DIFF
--- a/benchmark/multi_exp_pip/benchmark.m.cc
+++ b/benchmark/multi_exp_pip/benchmark.m.cc
@@ -58,14 +58,18 @@ using namespace sxt;
 //--------------------------------------------------------------------------------------------------
 // make_partition_table_accessor
 //--------------------------------------------------------------------------------------------------
-template <typename T, typename GeneratorFunc>
-static std::unique_ptr<mtxpp2::partition_table_accessor<T>>
+template <class U, typename T, typename GeneratorFunc>
+static std::unique_ptr<mtxpp2::partition_table_accessor<U>>
 make_partition_table_accessor(unsigned n, GeneratorFunc generatorFunc) noexcept {
   std::vector<T> generators(n);
   for (unsigned i = 0; i < n; ++i) {
     generatorFunc(generators[i], i);
   }
-  return mtxpp2::make_in_memory_partition_table_accessor<T>(generators);
+  if constexpr (std::is_same_v<U, T>) {
+    return mtxpp2::make_in_memory_partition_table_accessor<T>(generators);
+  } else {
+    return mtxpp2::make_in_memory_partition_table_accessor<U, T>(generators);
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -148,8 +152,8 @@ static void print_elements(basct::cspan<cn1t::element_p2> elements) noexcept {
 //--------------------------------------------------------------------------------------------------
 // run_benchmark
 //--------------------------------------------------------------------------------------------------
-template <bascrv::element T>
-double run_benchmark(std::unique_ptr<mtxpp2::partition_table_accessor<T>>& accessor,
+template <bascrv::element T, class U>
+double run_benchmark(std::unique_ptr<mtxpp2::partition_table_accessor<U>>& accessor,
                      unsigned num_samples, unsigned num_outputs, unsigned element_num_bytes,
                      unsigned n, bool verbose) {
 
@@ -228,19 +232,24 @@ int main(int argc, char* argv[]) {
 
   if (curve_str == "curve25519") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor = make_partition_table_accessor<c21t::element_p3>(n, curve25519_generator);
+#if 0
+    auto accessor = make_partition_table_accessor<c21t::element_p3, c21t::element_p3>(n, curve25519_generator);
+#else
+    auto accessor = make_partition_table_accessor<c21t::compact_element, c21t::element_p3>(
+        n, curve25519_generator);
+#endif
     const auto average_time = run_benchmark<c21t::element_p3>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);
   } else if (curve_str == "bls12_381" || curve_str == "bls12-381") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor = make_partition_table_accessor<cg1t::element_p2>(n, bls12_381_generator);
+    auto accessor = make_partition_table_accessor<cg1t::element_p2, cg1t::element_p2>(n, bls12_381_generator);
     const auto average_time = run_benchmark<cg1t::element_p2>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);
   } else if (curve_str == "bn254") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor = make_partition_table_accessor<cn1t::element_p2>(n, bn254_generator);
+    auto accessor = make_partition_table_accessor<cn1t::element_p2, cn1t::element_p2>(n, bn254_generator);
     const auto average_time = run_benchmark<cn1t::element_p2>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);

--- a/benchmark/multi_exp_pip/benchmark.m.cc
+++ b/benchmark/multi_exp_pip/benchmark.m.cc
@@ -232,12 +232,8 @@ int main(int argc, char* argv[]) {
 
   if (curve_str == "curve25519") {
     std::println("running {} benchmark...", curve_str);
-#if 0
-    auto accessor = make_partition_table_accessor<c21t::element_p3, c21t::element_p3>(n, curve25519_generator);
-#else
     auto accessor = make_partition_table_accessor<c21t::compact_element, c21t::element_p3>(
         n, curve25519_generator);
-#endif
     const auto average_time = run_benchmark<c21t::element_p3>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);

--- a/benchmark/multi_exp_pip/benchmark.m.cc
+++ b/benchmark/multi_exp_pip/benchmark.m.cc
@@ -243,13 +243,15 @@ int main(int argc, char* argv[]) {
     std::println("compute duration (s): {}", average_time);
   } else if (curve_str == "bls12_381" || curve_str == "bls12-381") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor = make_partition_table_accessor<cg1t::element_p2, cg1t::element_p2>(n, bls12_381_generator);
+    auto accessor =
+        make_partition_table_accessor<cg1t::element_p2, cg1t::element_p2>(n, bls12_381_generator);
     const auto average_time = run_benchmark<cg1t::element_p2>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);
   } else if (curve_str == "bn254") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor = make_partition_table_accessor<cn1t::element_p2, cn1t::element_p2>(n, bn254_generator);
+    auto accessor =
+        make_partition_table_accessor<cn1t::element_p2, cn1t::element_p2>(n, bn254_generator);
     const auto average_time = run_benchmark<cn1t::element_p2>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -129,7 +129,7 @@ std::unique_ptr<mtxpp2::partition_table_accessor_base>
 cpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                            unsigned n) const noexcept {
   std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
-  cbnb::switch_curve_type2(
+  cbnb::switch_curve_type(
       curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
         if constexpr (std::is_same_v<U, T>) {
           res = mtxpp2::make_in_memory_partition_table_accessor<T>(
@@ -149,7 +149,7 @@ void cpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
                                             const mtxpp2::partition_table_accessor_base& accessor,
                                             unsigned element_num_bytes, unsigned num_outputs,
                                             unsigned n, const uint8_t* scalars) const noexcept {
-  cbnb::switch_curve_type2(curve_id, [&]<class U, class T>(std::type_identity<U>,
+  cbnb::switch_curve_type(curve_id, [&]<class U, class T>(std::type_identity<U>,
                                                           std::type_identity<T>) noexcept {
     basct::span<T> res_span{static_cast<T*>(res), num_outputs};
     basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -129,10 +129,16 @@ std::unique_ptr<mtxpp2::partition_table_accessor_base>
 cpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                            unsigned n) const noexcept {
   std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
-  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
-    res = mtxpp2::make_in_memory_partition_table_accessor<T>(
-        basct::cspan<T>{static_cast<const T*>(generators), n}, basm::alloc_t{});
-  });
+  cbnb::switch_curve_type2(
+      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
+        if constexpr (std::is_same_v<U, T>) {
+          res = mtxpp2::make_in_memory_partition_table_accessor<T>(
+              basct::cspan<T>{static_cast<const T*>(generators), n}, basm::alloc_t{});
+        } else {
+          res = mtxpp2::make_in_memory_partition_table_accessor<U, T>(
+              basct::cspan<T>{static_cast<const T*>(generators), n}, basm::alloc_t{});
+        }
+      });
   return res;
 }
 
@@ -143,13 +149,13 @@ void cpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
                                             const mtxpp2::partition_table_accessor_base& accessor,
                                             unsigned element_num_bytes, unsigned num_outputs,
                                             unsigned n, const uint8_t* scalars) const noexcept {
-  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
+  cbnb::switch_curve_type2(curve_id, [&]<class U, class T>(std::type_identity<U>,
+                                                          std::type_identity<T>) noexcept {
     basct::span<T> res_span{static_cast<T*>(res), num_outputs};
     basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};
     mtxpp2::multiexponentiate<T>(res_span,
-                                 static_cast<const mtxpp2::partition_table_accessor<T>&>(accessor),
+                                 static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
                                  element_num_bytes, scalars_span);
-    xens::get_scheduler().run();
   });
 }
 

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -166,10 +166,16 @@ std::unique_ptr<mtxpp2::partition_table_accessor_base>
 gpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                            unsigned n) const noexcept {
   std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
-  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
-    res = mtxpp2::make_in_memory_partition_table_accessor<T>(
-        basct::cspan<T>{static_cast<const T*>(generators), n});
-  });
+  cbnb::switch_curve_type2(
+      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
+        if constexpr (std::is_same_v<U, T>) {
+          res = mtxpp2::make_in_memory_partition_table_accessor<T>(
+              basct::cspan<T>{static_cast<const T*>(generators), n});
+        } else {
+          res = mtxpp2::make_in_memory_partition_table_accessor<U, T>(
+              basct::cspan<T>{static_cast<const T*>(generators), n});
+        }
+      });
   return res;
 }
 
@@ -180,11 +186,12 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
                                             const mtxpp2::partition_table_accessor_base& accessor,
                                             unsigned element_num_bytes, unsigned num_outputs,
                                             unsigned n, const uint8_t* scalars) const noexcept {
-  cbnb::switch_curve_type(curve_id, [&]<class T>(std::type_identity<T>) noexcept {
+  cbnb::switch_curve_type2(curve_id, [&]<class U, class T>(std::type_identity<U>,
+                                                          std::type_identity<T>) noexcept {
     basct::span<T> res_span{static_cast<T*>(res), num_outputs};
     basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};
     auto fut = mtxpp2::async_multiexponentiate<T>(
-        res_span, static_cast<const mtxpp2::partition_table_accessor<T>&>(accessor),
+        res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
         element_num_bytes, scalars_span);
     xens::get_scheduler().run();
   });

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -166,7 +166,7 @@ std::unique_ptr<mtxpp2::partition_table_accessor_base>
 gpu_backend::make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                            unsigned n) const noexcept {
   std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
-  cbnb::switch_curve_type2(
+  cbnb::switch_curve_type(
       curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
         if constexpr (std::is_same_v<U, T>) {
           res = mtxpp2::make_in_memory_partition_table_accessor<T>(
@@ -186,15 +186,15 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
                                             const mtxpp2::partition_table_accessor_base& accessor,
                                             unsigned element_num_bytes, unsigned num_outputs,
                                             unsigned n, const uint8_t* scalars) const noexcept {
-  cbnb::switch_curve_type2(curve_id, [&]<class U, class T>(std::type_identity<U>,
-                                                          std::type_identity<T>) noexcept {
-    basct::span<T> res_span{static_cast<T*>(res), num_outputs};
-    basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};
-    auto fut = mtxpp2::async_multiexponentiate<T>(
-        res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
-        element_num_bytes, scalars_span);
-    xens::get_scheduler().run();
-  });
+  cbnb::switch_curve_type(
+      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
+        basct::span<T> res_span{static_cast<T*>(res), num_outputs};
+        basct::cspan<uint8_t> scalars_span{scalars, element_num_bytes * num_outputs * n};
+        auto fut = mtxpp2::async_multiexponentiate<T>(
+            res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
+            element_num_bytes, scalars_span);
+        xens::get_scheduler().run();
+      });
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/base/curve_id_utility.h
+++ b/sxt/cbindings/base/curve_id_utility.h
@@ -52,4 +52,20 @@ template <class F> void switch_curve_type(curve_id_t id, F f) {
     baser::panic("unsupported curve id {}", static_cast<unsigned>(id));
   }
 }
+
+template <class F> void switch_curve_type2(curve_id_t id, F f) {
+  switch (id) {
+  case curve_id_t::curve25519:
+    f(std::type_identity<c21t::compact_element>{}, std::type_identity<c21t::element_p3>{});
+    break;
+  case curve_id_t::bls12_381:
+    f(std::type_identity<cg1t::element_p2>{}, std::type_identity<cg1t::element_p2>{});
+    break;
+  case curve_id_t::bn254:
+    f(std::type_identity<cn1t::element_p2>{}, std::type_identity<cn1t::element_p2>{});
+    break;
+  default:
+    baser::panic("unsupported curve id {}", static_cast<unsigned>(id));
+  }
+}
 } // namespace sxt::cbnb

--- a/sxt/cbindings/base/curve_id_utility.h
+++ b/sxt/cbindings/base/curve_id_utility.h
@@ -40,22 +40,6 @@ namespace sxt::cbnb {
 template <class F> void switch_curve_type(curve_id_t id, F f) {
   switch (id) {
   case curve_id_t::curve25519:
-    f(std::type_identity<c21t::element_p3>{});
-    break;
-  case curve_id_t::bls12_381:
-    f(std::type_identity<cg1t::element_p2>{});
-    break;
-  case curve_id_t::bn254:
-    f(std::type_identity<cn1t::element_p2>{});
-    break;
-  default:
-    baser::panic("unsupported curve id {}", static_cast<unsigned>(id));
-  }
-}
-
-template <class F> void switch_curve_type2(curve_id_t id, F f) {
-  switch (id) {
-  case curve_id_t::curve25519:
     f(std::type_identity<c21t::compact_element>{}, std::type_identity<c21t::element_p3>{});
     break;
   case curve_id_t::bls12_381:

--- a/sxt/cbindings/base/curve_id_utility.t.cc
+++ b/sxt/cbindings/base/curve_id_utility.t.cc
@@ -24,7 +24,9 @@ using namespace sxt;
 using namespace sxt::cbnb;
 
 TEST_CASE("we can translate a runtime curve id value to a compile-time type") {
-  switch_curve_type(curve_id_t::curve25519, [&]<class T>(std::type_identity<T>) {
-    REQUIRE(std::is_same_v<T, c21t::element_p3>);
-  });
+  switch_curve_type(curve_id_t::curve25519,
+                    [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) {
+                      REQUIRE(std::is_same_v<U, c21t::compact_element>);
+                      REQUIRE(std::is_same_v<T, c21t::element_p3>);
+                    });
 }


### PR DESCRIPTION
# Rationale for this change

This PR updates curve25519 to use a more compact point form for its partition table accessor. Benchmarking shows this improves multiexponentiation performance by ~20%.

# What changes are included in this PR?

Updates GPU and CPU backends and benchmark to use the compact point form for curve25519.

# Are these changes tested?

Reuses existing tests.
