### PR TITLE
feat: update multiexponentiation code to use compact point form for BLS12-381 (PROOF-870)

### DIFF
--- a/benchmark/multi_exp_pip/benchmark.m.cc
+++ b/benchmark/multi_exp_pip/benchmark.m.cc
@@ -239,8 +239,8 @@ int main(int argc, char* argv[]) {
     std::println("compute duration (s): {}", average_time);
   } else if (curve_str == "bls12_381" || curve_str == "bls12-381") {
     std::println("running {} benchmark...", curve_str);
-    auto accessor =
-        make_partition_table_accessor<cg1t::element_p2, cg1t::element_p2>(n, bls12_381_generator);
+    auto accessor = make_partition_table_accessor<cg1t::compact_element, cg1t::element_p2>(
+        n, bls12_381_generator);
     const auto average_time = run_benchmark<cg1t::element_p2>(accessor, num_samples, num_outputs,
                                                               element_num_bytes, n, verbose);
     std::println("compute duration (s): {}", average_time);

--- a/sxt/cbindings/base/curve_id_utility.h
+++ b/sxt/cbindings/base/curve_id_utility.h
@@ -43,7 +43,7 @@ template <class F> void switch_curve_type(curve_id_t id, F f) {
     f(std::type_identity<c21t::compact_element>{}, std::type_identity<c21t::element_p3>{});
     break;
   case curve_id_t::bls12_381:
-    f(std::type_identity<cg1t::element_p2>{}, std::type_identity<cg1t::element_p2>{});
+    f(std::type_identity<cg1t::compact_element>{}, std::type_identity<cg1t::element_p2>{});
     break;
   case curve_id_t::bn254:
     f(std::type_identity<cn1t::element_p2>{}, std::type_identity<cn1t::element_p2>{});

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -6,9 +6,6 @@ load(
 sxt_cc_component(
     name = "compact_element",
     with_test = False,
-    # test_deps = [
-    #     "//sxt/base/test:unit_test",
-    # ],
     deps = [
         "//sxt/base/macro:cuda_callable",
         "//sxt/field12/constant:one",

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -71,6 +71,8 @@ sxt_cc_component(
     deps = [
         ":operation_adl_stub",
         ":compact_element",
+        "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/operation:cmov",
         "//sxt/field12/constant:one",
         "//sxt/field12/constant:zero",
         "//sxt/field12/type:element",

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -4,6 +4,17 @@ load(
 )
 
 sxt_cc_component(
+    name = "compact_element",
+    with_test = False,
+    # test_deps = [
+    #     "//sxt/base/test:unit_test",
+    # ],
+    deps = [
+        "//sxt/base/macro:cuda_callable",
+    ],
+)
+
+sxt_cc_component(
     name = "compressed_element",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -62,6 +62,7 @@ sxt_cc_component(
     name = "element_p2",
     impl_deps = [
         "//sxt/field12/operation:mul",
+        "//sxt/field12/operation:invert",
         "//sxt/field12/property:zero",
     ],
     test_deps = [

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -68,6 +68,7 @@ sxt_cc_component(
     test_deps = [
         "//sxt/base/test:unit_test",
         "//sxt/field12/operation:mul",
+        "//sxt/field12/type:literal",
     ],
     deps = [
         ":operation_adl_stub",

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -11,6 +11,9 @@ sxt_cc_component(
     # ],
     deps = [
         "//sxt/base/macro:cuda_callable",
+        "//sxt/field12/constant:one",
+        "//sxt/field12/constant:zero",
+        "//sxt/field12/type:element",
     ],
 )
 
@@ -67,6 +70,7 @@ sxt_cc_component(
     ],
     deps = [
         ":operation_adl_stub",
+        ":compact_element",
         "//sxt/field12/constant:one",
         "//sxt/field12/constant:zero",
         "//sxt/field12/type:element",

--- a/sxt/curve_g1/type/BUILD
+++ b/sxt/curve_g1/type/BUILD
@@ -71,12 +71,12 @@ sxt_cc_component(
         "//sxt/field12/type:literal",
     ],
     deps = [
-        ":operation_adl_stub",
         ":compact_element",
+        ":operation_adl_stub",
         "//sxt/base/macro:cuda_callable",
-        "//sxt/field12/operation:cmov",
         "//sxt/field12/constant:one",
         "//sxt/field12/constant:zero",
+        "//sxt/field12/operation:cmov",
         "//sxt/field12/type:element",
     ],
 )

--- a/sxt/curve_g1/type/compact_element.cc
+++ b/sxt/curve_g1/type/compact_element.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/curve_g1/type/compact_element.h"

--- a/sxt/curve_g1/type/compact_element.cc
+++ b/sxt/curve_g1/type/compact_element.cc
@@ -1,0 +1,1 @@
+#include "sxt/curve_g1/type/compact_element.h"

--- a/sxt/curve_g1/type/compact_element.h
+++ b/sxt/curve_g1/type/compact_element.h
@@ -1,4 +1,26 @@
 #pragma once
 
+#include "sxt/field12/constant/one.h"
+#include "sxt/field12/constant/zero.h"
+#include "sxt/field12/type/element.h"
+
 namespace sxt::cg1t {
+//--------------------------------------------------------------------------------------------------
+// compact_element
+//--------------------------------------------------------------------------------------------------
+struct compact_element {
+  f12t::element X;
+  f12t::element Y;
+
+  constexpr bool is_identity() const noexcept {
+    return X[5] == static_cast<uint64_t>(-1);
+  }
+
+  static constexpr compact_element identity() noexcept {
+    return {
+        {0, 0, 0, 0, 0, static_cast<uint64_t>(-1)},
+        f12cn::one_v,
+    };
+  }
+};
 } // namespace sxt::cg1t

--- a/sxt/curve_g1/type/compact_element.h
+++ b/sxt/curve_g1/type/compact_element.h
@@ -1,0 +1,4 @@
+#pragma once
+
+namespace sxt::cg1t {
+} // namespace sxt::cg1t

--- a/sxt/curve_g1/type/compact_element.h
+++ b/sxt/curve_g1/type/compact_element.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/field12/constant/one.h"
@@ -12,9 +28,7 @@ struct compact_element {
   f12t::element X;
   f12t::element Y;
 
-  constexpr bool is_identity() const noexcept {
-    return X[5] == static_cast<uint64_t>(-1);
-  }
+  constexpr bool is_identity() const noexcept { return X[5] == static_cast<uint64_t>(-1); }
 
   static constexpr compact_element identity() noexcept {
     return {

--- a/sxt/curve_g1/type/element_p2.cc
+++ b/sxt/curve_g1/type/element_p2.cc
@@ -58,7 +58,7 @@ CUDA_CALLABLE element_p2::operator compact_element() const noexcept {
   f12t::element y;
   f12o::mul(x, X, z_inv);
   f12o::mul(y, Y, z_inv);
-  
+
   f12o::cmov(x, compact_element::identity().X, is_zero);
   f12o::cmov(y, compact_element::identity().Y, is_zero);
 

--- a/sxt/curve_g1/type/element_p2.h
+++ b/sxt/curve_g1/type/element_p2.h
@@ -46,6 +46,8 @@ struct element_p2 : cg1o::operation_adl_stub {
     f12o::cmov(Z, f12cn::zero_v, is_identity);
   }
 
+  CUDA_CALLABLE explicit operator compact_element() const noexcept;
+
   f12t::element X;
   f12t::element Y;
   f12t::element Z;

--- a/sxt/curve_g1/type/element_p2.h
+++ b/sxt/curve_g1/type/element_p2.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include "sxt/curve_g1/type/compact_element.h"
 #include "sxt/curve_g1/type/operation_adl_stub.h"
 #include "sxt/field12/constant/one.h"
 #include "sxt/field12/constant/zero.h"

--- a/sxt/curve_g1/type/element_p2.h
+++ b/sxt/curve_g1/type/element_p2.h
@@ -16,10 +16,12 @@
  */
 #pragma once
 
+#include "sxt/base/macro/cuda_callable.h"
 #include "sxt/curve_g1/type/compact_element.h"
 #include "sxt/curve_g1/type/operation_adl_stub.h"
 #include "sxt/field12/constant/one.h"
 #include "sxt/field12/constant/zero.h"
+#include "sxt/field12/operation/cmov.h"
 #include "sxt/field12/type/element.h"
 
 namespace sxt::cg1t {
@@ -36,6 +38,13 @@ struct element_p2 : cg1o::operation_adl_stub {
   constexpr element_p2(const f12t::element& X, const f12t::element& Y,
                        const f12t::element& Z) noexcept
       : X{X}, Y{Y}, Z{Z} {}
+
+  CUDA_CALLABLE explicit element_p2(const compact_element& e) noexcept
+      : X{e.X}, Y{e.Y}, Z{f12cn::one_v} {
+    auto is_identity = e.is_identity();
+    f12o::cmov(X, f12cn::zero_v, is_identity);
+    f12o::cmov(Z, f12cn::zero_v, is_identity);
+  }
 
   f12t::element X;
   f12t::element Y;

--- a/sxt/curve_g1/type/element_p2.t.cc
+++ b/sxt/curve_g1/type/element_p2.t.cc
@@ -30,9 +30,11 @@
 #include "sxt/field12/constant/zero.h"
 #include "sxt/field12/operation/mul.h"
 #include "sxt/field12/type/element.h"
+#include "sxt/field12/type/literal.h"
 
 using namespace sxt;
 using namespace sxt::cg1t;
+using f12t::operator""_f12;
 
 TEST_CASE("projective element equality") {
   SECTION("can distinguish the generator from the identity") {
@@ -71,5 +73,14 @@ TEST_CASE("we can convert between elements") {
     auto id = element_p2::identity();
     auto id_p = element_p2{static_cast<compact_element>(id)};
     REQUIRE(id == id_p);
+  }
+
+  SECTION("we can covert an arbitrary element") {
+    element_p2 e{
+        0x17f7b262294ef7b666e940cecd80b68f5f84158fbb044c0e7f4c4fb15c4b58679609c912fd8648e9c121e09dfbc0141c_f12,
+        0x2caf9ee971b3d3212363b9b76bdb02c3ec2736aef5e37dd205099ab55cc2b3950c3a01d27db55031ffc1872a669a8c0_f12,
+        0x15ee88dd9836d9791f49e2a9702f040484db019beea103a5d68a4bce2e0fecc878970c1f2dc242111146f26916b000b6_f12};
+    auto ep = element_p2{static_cast<compact_element>(e)};
+    REQUIRE(e == ep);
   }
 }

--- a/sxt/curve_g1/type/element_p2.t.cc
+++ b/sxt/curve_g1/type/element_p2.t.cc
@@ -65,3 +65,11 @@ TEST_CASE("projective element equality") {
     REQUIRE(c != b);
   }
 }
+
+TEST_CASE("we can convert between elements") {
+  SECTION("we can convert the identity element") {
+    auto id = element_p2::identity();
+    auto id_p = element_p2{static_cast<compact_element>(id)};
+    REQUIRE(id == id_p);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Make multiexponentiation more memory efficient for bls12-381

# What changes are included in this PR?

* adds a compact point for for bls12-381 elements. This is similar to element_affine but is written so that it doesn't need an extra boolean to identity the identity element.
* updates the multiexponentiation code to use the bls12-381 compact elements

# Are these changes tested?

Yes
