### PR TITLE
feat: rework partition product so that num_products doesn't need to be a multiple of 8 (PROOF-877)

### DIFF
--- a/sxt/base/num/BUILD
+++ b/sxt/base/num/BUILD
@@ -49,6 +49,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "round_up",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "log2p1",
     impl_deps = [
         "//sxt/base/error:assert",

--- a/sxt/base/num/round_up.cc
+++ b/sxt/base/num/round_up.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/num/round_up.h"

--- a/sxt/base/num/round_up.h
+++ b/sxt/base/num/round_up.h
@@ -1,0 +1,31 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <concepts>
+
+namespace sxt::basn {
+//--------------------------------------------------------------------------------------------------
+// round_up
+//--------------------------------------------------------------------------------------------------
+template <class T>
+  requires std::is_integral_v<T>
+constexpr inline T round_up(T a, T multiple) noexcept {
+  auto t = (a + multiple - 1) / multiple;
+  return t * multiple;
+}
+} // namespace sxt::basn

--- a/sxt/base/num/round_up.t.cc
+++ b/sxt/base/num/round_up.t.cc
@@ -1,0 +1,37 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/num/round_up.h"
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::basn;
+
+TEST_CASE("we can round a number up to the nearest multiple") {
+  int x = 4;
+  int y;
+
+  SECTION("if x is already a multiple of y, we return the identity") {
+    y = 2;
+    REQUIRE(round_up(x, y) == x);
+  }
+
+  SECTION("if x is not already a multiple, we return the next multiple") {
+    y = 3;
+    REQUIRE(round_up(x, y) == 6);
+  }
+}

--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -57,6 +57,7 @@ sxt_cc_component(
         "//sxt/base/error:assert",
         "//sxt/base/macro:cuda_callable",
         "//sxt/base/num:divide_up",
+        "//sxt/base/num:round_up",
         "//sxt/execution/async:coroutine",
         "//sxt/execution/device:synchronization",
         "//sxt/memory/management:managed_array",

--- a/sxt/multiexp/pippenger2/partition_product.t.cc
+++ b/sxt/multiexp/pippenger2/partition_product.t.cc
@@ -96,6 +96,20 @@ TEST_CASE("we can compute the product of partitions") {
     REQUIRE(products == expected);
   }
 
+  SECTION("we can compute a multiproduct where the number of products is not a multiple of 8") {
+    scalars = {1u, 3u};
+    products.resize(2);
+    auto fut = async_partition_product<E>(products, accessor, scalars, 0);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    expected = {
+        partition_table[3],
+        partition_table[2],
+    };
+    REQUIRE(products == expected);
+  }
+
   SECTION("we handle a product with an offset") {
     scalars[0] = 1;
     auto fut = async_partition_product<E>(products, accessor, scalars, 16);


### PR DESCRIPTION
# Rationale for this change

In the new packed interface, the number of products may not be a multiple of 8. This PR reworks the partition_product component so that num_products doesn't need to be a multiple of 8.

# What changes are included in this PR?

* Adds a component round_up to round a number up to the next nearest multiple.
* Refactors partition_product so that num_products doesn't need to be a multiple of 8.

# Are these changes tested?

Yes
