### PR TITLE
fix: avoid extra step value setting in field25 square component (PROOF-883)

### DIFF
--- a/sxt/field25/operation/square.cc
+++ b/sxt/field25/operation/square.cc
@@ -53,10 +53,6 @@ void square(f25t::element& h, const f25t::element& f) noexcept {
   t[6] = carry;
   carry = 0;
 
-  basfld::mac(t[7], carry, t[7], f[3], f[4]);
-  t[7] = carry;
-  carry = 0;
-
   t[7] = t[6] >> 63;
   t[6] = (t[6] << 1) | (t[5] >> 63);
   t[5] = (t[5] << 1) | (t[4] >> 63);


### PR DESCRIPTION
# Rationale for this change
The `square` component has an extra multiply and carry call setting the `t[7]` value. Luckily the `t[7]` value is set to the correct value a few lines later, avoiding a bug. This PR removes the unnecessary setting of `t[7]`.

# What changes are included in this PR?
- Setting the `t[7]` values with both `mac` output and the carry output is removed.

# Are these changes tested?
Yes