### PR TITLE
feat: compute reductions for packed multi-exponentiations (PROOF-877)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -203,5 +203,8 @@ sxt_cc_component(
         "//sxt/base/device:memory_utility",
         "//sxt/base/macro:cuda_callable",
         "//sxt/base/type:raw_stream",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:pinned_resource",
     ],
 )

--- a/sxt/multiexp/pippenger2/reduce.h
+++ b/sxt/multiexp/pippenger2/reduce.h
@@ -16,6 +16,8 @@
  */
 #pragma once
 
+#include <numeric>
+
 #include "sxt/algorithm/iteration/for_each.h"
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"
@@ -90,12 +92,9 @@ void reduce_products(basct::span<T> reductions, bast::raw_stream_t stream,
 
   // make partial bit table sums
   memmg::managed_array<unsigned> bit_table_partial_sums{num_outputs, memr::get_pinned_resource()};
-  unsigned sum = 0;
-  for (unsigned output_index = 0; output_index < num_outputs; ++output_index) {
-    sum += output_bit_table[output_index];
-    bit_table_partial_sums[output_index] = sum;
-  }
-  SXT_DEBUG_ASSERT(products.size() == sum);
+  std::partial_sum(output_bit_table.begin(), output_bit_table.end(),
+                   bit_table_partial_sums.begin());
+  SXT_DEBUG_ASSERT(products.size() == bit_table_partial_sums[num_outputs - 1]);
   memmg::managed_array<unsigned> bit_table_partial_sums_dev{num_outputs, &resource};
   basdv::async_copy_host_to_device(bit_table_partial_sums_dev, bit_table_partial_sums, stream);
 

--- a/sxt/multiexp/pippenger2/reduce.h
+++ b/sxt/multiexp/pippenger2/reduce.h
@@ -23,6 +23,9 @@
 #include "sxt/base/error/assert.h"
 #include "sxt/base/macro/cuda_callable.h"
 #include "sxt/base/type/raw_stream.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/memory/resource/async_device_resource.h"
+#include "sxt/memory/resource/pinned_resource.h"
 
 namespace sxt::mtxpp2 {
 //--------------------------------------------------------------------------------------------------
@@ -66,6 +69,50 @@ void reduce_products(basct::span<T> reductions, bast::raw_stream_t stream,
            __host__(unsigned /*num_outputs*/, unsigned output_index) noexcept {
              reduce_output(reductions + output_index, products + output_index * reduction_size,
                            reduction_size);
+           };
+  algi::launch_for_each_kernel(stream, f, num_outputs);
+}
+
+template <bascrv::element T>
+void reduce_products(basct::span<T> reductions, bast::raw_stream_t stream,
+                     basct::cspan<unsigned> output_bit_table, basct::cspan<T> products) noexcept {
+  auto num_outputs = reductions.size();
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      basdv::is_active_device_pointer(reductions.data()) &&
+      reductions.size() == num_outputs &&
+      output_bit_table.size() == num_outputs &&
+      basdv::is_active_device_pointer(products.data())
+      // clang-format on
+  );
+
+  memr::async_device_resource resource{stream};
+
+  // make partial bit table sums
+  memmg::managed_array<unsigned> bit_table_partial_sums{num_outputs, memr::get_pinned_resource()};
+  unsigned sum = 0;
+  for (unsigned output_index = 0; output_index < num_outputs; ++output_index) {
+    sum += output_bit_table[output_index];
+    bit_table_partial_sums[output_index] = sum;
+  }
+  SXT_DEBUG_ASSERT(products.size() == sum);
+  memmg::managed_array<unsigned> bit_table_partial_sums_dev{num_outputs, &resource};
+  basdv::async_copy_host_to_device(bit_table_partial_sums_dev, bit_table_partial_sums, stream);
+
+  // reduce products
+  auto f = [
+               // clang-format off
+    reductions = reductions.data(),
+    bit_table_partial_sums = bit_table_partial_sums_dev.data(),
+    products = products.data()
+               // clang-format on
+  ] __device__
+           __host__(unsigned /*num_outputs*/, unsigned output_index) noexcept {
+             auto lookup_index = max(0, static_cast<int>(output_index) - 1);
+             auto offset =
+                 bit_table_partial_sums[lookup_index] * static_cast<unsigned>(output_index != 0);
+             auto reduction_size = bit_table_partial_sums[output_index] - offset;
+             reduce_output(reductions + output_index, products + offset, reduction_size);
            };
   algi::launch_for_each_kernel(stream, f, num_outputs);
 }

--- a/sxt/multiexp/pippenger2/reduce.t.cc
+++ b/sxt/multiexp/pippenger2/reduce.t.cc
@@ -115,7 +115,7 @@ TEST_CASE("we can reduce products with a bit table") {
     products = {123u, 456u};
     reduce_products<E>(outputs, stream, bit_table, products);
     basdv::synchronize_stream(stream);
-    expected = {123u, 456};
+    expected = {123u, 456u};
     REQUIRE(outputs == expected);
   }
 

--- a/sxt/multiexp/pippenger2/reduce.t.cc
+++ b/sxt/multiexp/pippenger2/reduce.t.cc
@@ -66,3 +66,66 @@ TEST_CASE("we can reduce products") {
     REQUIRE(outputs == expected);
   }
 }
+
+TEST_CASE("we can reduce products with a bit table") {
+  using E = bascrv::element97;
+
+  std::pmr::vector<E> outputs{memr::get_managed_device_resource()};
+  std::pmr::vector<E> products{memr::get_managed_device_resource()};
+  basdv::stream stream;
+
+  std::vector<unsigned> bit_table;
+
+  std::pmr::vector<E> expected;
+
+  SECTION("we can reduce a single output of one bit") {
+    outputs.resize(1);
+    products.resize(1);
+    bit_table = {1};
+    products[0] = 123u;
+    reduce_products<E>(outputs, stream, bit_table, products);
+    basdv::synchronize_stream(stream);
+    expected = {123u};
+    REQUIRE(outputs == expected);
+  }
+
+  SECTION("we can reduce a single output of two bits") {
+    outputs.resize(1);
+    bit_table = {2};
+    products = {123, 456};
+    reduce_products<E>(outputs, stream, bit_table, products);
+    basdv::synchronize_stream(stream);
+    expected = {123u + 2u * 456u};
+    REQUIRE(outputs == expected);
+  }
+
+  SECTION("we can reduce a single output of three bits") {
+    outputs.resize(1);
+    bit_table = {3};
+    products = {1, 3, 7};
+    reduce_products<E>(outputs, stream, bit_table, products);
+    basdv::synchronize_stream(stream);
+    expected = {1u + 2u * 3u + 4u * 7u};
+    REQUIRE(outputs == expected);
+  }
+
+  SECTION("we can reduce two outputs of 1 bit each") {
+    outputs.resize(2);
+    bit_table = {1, 1};
+    products = {123u, 456u};
+    reduce_products<E>(outputs, stream, bit_table, products);
+    basdv::synchronize_stream(stream);
+    expected = {123u, 456};
+    REQUIRE(outputs == expected);
+  }
+
+  SECTION("we can reduce multiple outputs with varying numbers of bits") {
+    outputs.resize(3);
+    bit_table = {3, 1, 2};
+    products = {2u, 7u, 5u, 3u, 9u, 11u};
+    reduce_products<E>(outputs, stream, bit_table, products);
+    basdv::synchronize_stream(stream);
+    expected = {2u + 2u * 7u + 4u * 5u, 3u, 9u + 2u * 11u};
+    REQUIRE(outputs == expected);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

In order to support a more efficient interface for outputs of varying bit size, we need to do reductions with varying bit sizes.

This PR adds a version of reduce that can work with outputs of different bit lengths.

# What changes are included in this PR?

* Adds a new reduce function that takes a bit size table.

# Are these changes tested?

Yes
