### PR TITLE
chore: remove CUDA_CALLABLE from constexpr functions (PROOF-890)

### DIFF
--- a/sxt/field12/type/BUILD
+++ b/sxt/field12/type/BUILD
@@ -14,9 +14,6 @@ sxt_cc_component(
         "//sxt/base/test:unit_test",
         "//sxt/field12/base:constants",
     ],
-    deps = [
-        "//sxt/base/macro:cuda_callable",
-    ],
 )
 
 sxt_cc_component(

--- a/sxt/field12/type/element.cc
+++ b/sxt/field12/type/element.cc
@@ -55,16 +55,4 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept {
   out.flags(flags);
   return out;
 }
-
-//--------------------------------------------------------------------------------------------------
-// operator==
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept {
-  for (size_t i = 0; i < element::num_limbs_v; ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
-}
 } // namespace sxt::f12t

--- a/sxt/field12/type/element.h
+++ b/sxt/field12/type/element.h
@@ -19,8 +19,6 @@
 #include <cstdint>
 #include <iosfwd>
 
-#include "sxt/base/macro/cuda_callable.h"
-
 namespace sxt::f12t {
 //--------------------------------------------------------------------------------------------------
 // element
@@ -57,10 +55,17 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept;
 //--------------------------------------------------------------------------------------------------
 // operator==
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept;
+inline constexpr bool operator==(const element& lhs, const element& rhs) noexcept {
+  for (size_t i = 0; i < element::num_limbs_v; ++i) {
+    if (lhs[i] != rhs[i]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 //--------------------------------------------------------------------------------------------------
 // operator!=
 //--------------------------------------------------------------------------------------------------
-inline bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
+inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
 } // namespace sxt::f12t

--- a/sxt/field12/type/element.h
+++ b/sxt/field12/type/element.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <iosfwd>
 
@@ -56,12 +57,7 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept;
 // operator==
 //--------------------------------------------------------------------------------------------------
 inline constexpr bool operator==(const element& lhs, const element& rhs) noexcept {
-  for (size_t i = 0; i < element::num_limbs_v; ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
+  return std::equal(lhs.data(), lhs.data() + element::num_limbs_v, rhs.data());
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/field12/type/element.h
+++ b/sxt/field12/type/element.h
@@ -31,22 +31,19 @@ public:
 
   element() noexcept = default;
 
-  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5,
-                                  uint64_t x6) noexcept
+  constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5,
+                    uint64_t x6) noexcept
       : data_{x1, x2, x3, x4, x5, x6} {}
 
-  CUDA_CALLABLE constexpr element(const uint64_t x[6]) noexcept
-      : data_{x[0], x[1], x[2], x[3], x[4], x[5]} {}
+  constexpr element(const uint64_t x[6]) noexcept : data_{x[0], x[1], x[2], x[3], x[4], x[5]} {}
 
-  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
-    return data_[index];
-  }
+  constexpr const uint64_t& operator[](int index) const noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+  constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+  constexpr const uint64_t* data() const noexcept { return data_; }
 
-  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+  constexpr uint64_t* data() noexcept { return data_; }
 
 private:
   uint64_t data_[num_limbs_v];

--- a/sxt/field12/type/element.h
+++ b/sxt/field12/type/element.h
@@ -67,5 +67,7 @@ inline constexpr bool operator==(const element& lhs, const element& rhs) noexcep
 //--------------------------------------------------------------------------------------------------
 // operator!=
 //--------------------------------------------------------------------------------------------------
-inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
+inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept {
+  return !(lhs == rhs);
+}
 } // namespace sxt::f12t

--- a/sxt/field25/type/BUILD
+++ b/sxt/field25/type/BUILD
@@ -14,9 +14,6 @@ sxt_cc_component(
         "//sxt/base/test:unit_test",
         "//sxt/field25/base:constants",
     ],
-    deps = [
-        "//sxt/base/macro:cuda_callable",
-    ],
 )
 
 sxt_cc_component(

--- a/sxt/field25/type/element.cc
+++ b/sxt/field25/type/element.cc
@@ -55,16 +55,4 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept {
   out.flags(flags);
   return out;
 }
-
-//--------------------------------------------------------------------------------------------------
-// operator==
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept {
-  for (size_t i = 0; i < element::num_limbs_v; ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
-}
 } // namespace sxt::f25t

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -60,11 +60,13 @@ inline constexpr bool operator==(const element& lhs, const element& rhs) noexcep
       return false;
     }
   }
-  return true;  
+  return true;
 }
 
 //--------------------------------------------------------------------------------------------------
 // operator!=
 //--------------------------------------------------------------------------------------------------
-inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
+inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept {
+  return !(lhs == rhs);
+}
 } // namespace sxt::f25t

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -16,6 +16,7 @@
  */
 #pragma once
 
+#include <algorithm>
 #include <cstdint>
 #include <iosfwd>
 
@@ -55,12 +56,7 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept;
 // operator==
 //--------------------------------------------------------------------------------------------------
 inline constexpr bool operator==(const element& lhs, const element& rhs) noexcept {
-  for (size_t i = 0; i < element::num_limbs_v; ++i) {
-    if (lhs[i] != rhs[i]) {
-      return false;
-    }
-  }
-  return true;
+  return std::equal(lhs.data(), lhs.data() + element::num_limbs_v, rhs.data());
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -31,20 +31,18 @@ public:
 
   element() noexcept = default;
 
-  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4) noexcept
+  constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4) noexcept
       : data_{x1, x2, x3, x4} {}
 
-  CUDA_CALLABLE constexpr element(const uint64_t x[4]) noexcept : data_{x[0], x[1], x[2], x[3]} {}
+  constexpr element(const uint64_t x[4]) noexcept : data_{x[0], x[1], x[2], x[3]} {}
 
-  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
-    return data_[index];
-  }
+  constexpr const uint64_t& operator[](int index) const noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+  constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+  constexpr const uint64_t* data() const noexcept { return data_; }
 
-  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+  constexpr uint64_t* data() noexcept { return data_; }
 
 private:
   uint64_t data_[num_limbs_v];

--- a/sxt/field25/type/element.h
+++ b/sxt/field25/type/element.h
@@ -19,8 +19,6 @@
 #include <cstdint>
 #include <iosfwd>
 
-#include "sxt/base/macro/cuda_callable.h"
-
 namespace sxt::f25t {
 //--------------------------------------------------------------------------------------------------
 // element
@@ -56,10 +54,17 @@ std::ostream& operator<<(std::ostream& out, const element& e) noexcept;
 //--------------------------------------------------------------------------------------------------
 // operator==
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE bool operator==(const element& lhs, const element& rhs) noexcept;
+inline constexpr bool operator==(const element& lhs, const element& rhs) noexcept {
+  for (size_t i = 0; i < element::num_limbs_v; ++i) {
+    if (lhs[i] != rhs[i]) {
+      return false;
+    }
+  }
+  return true;  
+}
 
 //--------------------------------------------------------------------------------------------------
 // operator!=
 //--------------------------------------------------------------------------------------------------
-inline bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
+inline constexpr bool operator!=(const element& lhs, const element& rhs) noexcept { return !(lhs == rhs); }
 } // namespace sxt::f25t

--- a/sxt/field51/type/BUILD
+++ b/sxt/field51/type/BUILD
@@ -9,9 +9,6 @@ sxt_cc_component(
         "//sxt/field51/base:byte_conversion",
         "//sxt/field51/base:reduce",
     ],
-    deps = [
-        "//sxt/base/macro:cuda_callable",
-    ],
 )
 
 sxt_cc_component(

--- a/sxt/field51/type/element.h
+++ b/sxt/field51/type/element.h
@@ -20,8 +20,6 @@
 #include <cstdint>
 #include <iosfwd>
 
-#include "sxt/base/macro/cuda_callable.h"
-
 namespace sxt::f51t {
 //--------------------------------------------------------------------------------------------------
 // element

--- a/sxt/field51/type/element.h
+++ b/sxt/field51/type/element.h
@@ -32,19 +32,16 @@ public:
 
   element() noexcept = default;
 
-  CUDA_CALLABLE constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4,
-                                  uint64_t x5) noexcept
+  constexpr element(uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5) noexcept
       : data_{x1, x2, x3, x4, x5} {}
 
-  CUDA_CALLABLE constexpr const uint64_t& operator[](int index) const noexcept {
-    return data_[index];
-  }
+  constexpr const uint64_t& operator[](int index) const noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
+  constexpr uint64_t& operator[](int index) noexcept { return data_[index]; }
 
-  CUDA_CALLABLE constexpr const uint64_t* data() const noexcept { return data_; }
+  constexpr const uint64_t* data() const noexcept { return data_; }
 
-  CUDA_CALLABLE constexpr uint64_t* data() noexcept { return data_; }
+  constexpr uint64_t* data() noexcept { return data_; }
 
 private:
   uint64_t data_[num_limbs_v];


### PR DESCRIPTION
# Rationale for this change
`CUDA_CALLABLE` is not needed on `constexpr` functions.

# What changes are included in this PR?
- `CUDA_CALLABLE` is removed from `constexpr` functions.
- The `CUDA_CALLABLE` header is removed from element components.
- `field12` and `field25` element components now use `std::equal` to verify equality.

# Are these changes tested?
Yes