### PR TITLE
feat: support creating partition tables with different window widths (PROOF-893)

### DIFF
--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -51,7 +51,7 @@ make_in_memory_partition_table_accessor_impl(basct::cspan<T> generators,
     generators = generators_data;
   }
   memmg::managed_array<U> sums{partition_table_size_v * num_partitions, alloc};
-  compute_partition_table<U, T>(sums, generators);
+  compute_partition_table<U, T>(sums, 16, generators);
   return std::make_unique<in_memory_partition_table_accessor<U>>(std::move(sums));
 }
 

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -98,11 +98,15 @@ template <class U, bascrv::element T>
     static_cast<U>(e);
     T{u};
   }
-void compute_partition_table(basct::span<U> sums, unsigned partition_window,
+void compute_partition_table(basct::span<U> sums, unsigned window_width,
                              basct::cspan<T> generators) noexcept {
-  (void)sums;
-  (void)partition_window;
-  (void)generators;
+  auto table_size = 1u << window_width;
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+     sums.size() == partition_table_size_v * generators.size() / window_width &&
+     generators.size() % window_width == 0
+      // clang-format on
+  );
 }
 
 template <bascrv::element T>

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -93,6 +93,18 @@ void compute_partition_table(basct::span<U> sums, basct::cspan<T> generators) no
   }
 }
 
+template <class U, bascrv::element T>
+  requires requires(const U& u, const T& e) {
+    static_cast<U>(e);
+    T{u};
+  }
+void compute_partition_table(basct::span<U> sums, unsigned partition_window,
+                             basct::cspan<T> generators) noexcept {
+  (void)sums;
+  (void)partition_window;
+  (void)generators;
+}
+
 template <bascrv::element T>
 void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) noexcept {
   compute_partition_table<T, T>(sums, generators);

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -66,6 +66,48 @@ CUDA_CALLABLE void compute_partition_table_slice(U* __restrict__ sums,
   }
 }
 
+template <class U, bascrv::element T>
+  requires requires(const U& u, const T& e) {
+    static_cast<U>(e);
+    T{u};
+  }
+CUDA_CALLABLE void compute_partition_table_slice(U* __restrict__ sums, unsigned window_width,
+                                                 const T* __restrict__ generators) noexcept {
+  (void)sums;
+  (void)window_width;
+  (void)generators;
+#if 0
+  sums[0] = static_cast<U>(T::identity());
+
+  // single entry sums
+  for (unsigned i = 0; i < 16; ++i) {
+    sums[1 << i] = static_cast<U>(generators[i]);
+  }
+
+  // multi-entry sums
+  for (unsigned k = 2; k <= 16; ++k) {
+    unsigned partition = std::numeric_limits<uint16_t>::max() >> (16u - k);
+    auto partition_last = partition << (16u - k);
+
+    // iterate over all possible permutations with k bits set to 1
+    // until we reach partition_last
+    while (true) {
+      // compute the k bit sum from a (k-1) bit sum and a 1 bit sum
+      auto rest = partition & (partition - 1u);
+      auto t = partition ^ rest;
+      T sum{sums[rest]};
+      T e{sums[t]};
+      add_inplace(sum, e);
+      sums[partition] = static_cast<U>(sum);
+      if (partition == partition_last) {
+        break;
+      }
+      partition = basbt::next_permutation(partition);
+    }
+  }
+#endif
+}
+
 //--------------------------------------------------------------------------------------------------
 // compute_partition_table
 //--------------------------------------------------------------------------------------------------
@@ -103,10 +145,16 @@ void compute_partition_table(basct::span<U> sums, unsigned window_width,
   auto table_size = 1u << window_width;
   SXT_DEBUG_ASSERT(
       // clang-format off
-     sums.size() == partition_table_size_v * generators.size() / window_width &&
+     sums.size() == table_size * generators.size() / window_width &&
      generators.size() % window_width == 0
       // clang-format on
   );
+  auto n = generators.size() / window_width;
+  for (unsigned i = 0; i < n; ++i) {
+    auto sums_slice = sums.subspan(i * table_size, table_size);
+    auto generators_slice = generators.subspan(i * window_width, window_width);
+    compute_partition_table_slice(sums_slice.data(), window_width, generators_slice.data());
+  }
 }
 
 template <bascrv::element T>

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -72,29 +72,9 @@ CUDA_CALLABLE void compute_partition_table_slice(U* __restrict__ sums, unsigned 
 // compute_partition_table
 //--------------------------------------------------------------------------------------------------
 /**
- * Compute table of sums used for Pippenger's partition step with a width of 16. Each slice of the
- * table contains all possible sums of a group of 16 generators.
+ * Compute table of sums used for Pippenger's partition step with a given window width. Each
+ * slice of the table contains all possible sums of a group of `window_width` generators.
  */
-template <class U, bascrv::element T>
-  requires requires(const U& u, const T& e) {
-    static_cast<U>(e);
-    T{u};
-  }
-void compute_partition_table(basct::span<U> sums, basct::cspan<T> generators) noexcept {
-  SXT_DEBUG_ASSERT(
-      // clang-format off
-     sums.size() == partition_table_size_v * generators.size() / 16u &&
-     generators.size() % 16 == 0
-      // clang-format on
-  );
-  auto n = generators.size() / 16u;
-  for (unsigned i = 0; i < n; ++i) {
-    auto sums_slice = sums.subspan(i * partition_table_size_v, partition_table_size_v);
-    auto generators_slice = generators.subspan(i * 16u, 16u);
-    compute_partition_table_slice(sums_slice.data(), 16u, generators_slice.data());
-  }
-}
-
 template <class U, bascrv::element T>
   requires requires(const U& u, const T& e) {
     static_cast<U>(e);

--- a/sxt/multiexp/pippenger2/partition_table.h
+++ b/sxt/multiexp/pippenger2/partition_table.h
@@ -120,6 +120,12 @@ void compute_partition_table(basct::span<U> sums, unsigned window_width,
 
 template <bascrv::element T>
 void compute_partition_table(basct::span<T> sums, basct::cspan<T> generators) noexcept {
-  compute_partition_table<T, T>(sums, generators);
+  compute_partition_table<T, T>(sums, 16u, generators);
+}
+
+template <bascrv::element T>
+void compute_partition_table(basct::span<T> sums, unsigned window_width,
+                             basct::cspan<T> generators) noexcept {
+  compute_partition_table<T, T>(sums, window_width, generators);
 }
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -54,3 +54,15 @@ TEST_CASE("we can compute the full partition table") {
   REQUIRE(sums[1] == generators[0]);
   REQUIRE(sums[partition_table_size_v + 1] == generators[16]);
 }
+
+TEST_CASE("we can compute a slice of the partition table with a width of 1") {
+  using E = bascrv::element97;
+  std::vector<E> generators = {1u, 2u,  3u,  4u,  5u,  6u,  7u,  8u,
+                               9u, 10u, 11u, 12u, 13u, 14u, 15u, 16u};
+  std::vector<E> sums(2 * generators.size());
+  compute_partition_table<E>(sums, 1u, generators);
+  for (unsigned i=0; i<generators.size(); ++i) {
+    REQUIRE(sums[2 * i] == 0u);
+    REQUIRE(sums[2 * i + 1] == generators[i]);
+  }
+}

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -61,7 +61,7 @@ TEST_CASE("we can compute a slice of the partition table with a width of 1") {
                                9u, 10u, 11u, 12u, 13u, 14u, 15u, 16u};
   std::vector<E> sums(2 * generators.size());
   compute_partition_table<E>(sums, 1u, generators);
-  for (unsigned i=0; i<generators.size(); ++i) {
+  for (unsigned i = 0; i < generators.size(); ++i) {
     REQUIRE(sums[2 * i] == 0u);
     REQUIRE(sums[2 * i + 1] == generators[i]);
   }
@@ -69,12 +69,12 @@ TEST_CASE("we can compute a slice of the partition table with a width of 1") {
 
 TEST_CASE("we can compute a slice of the partition table with a width of 2") {
   using E = bascrv::element97;
-  std::vector<E> generators = {1u, 2u,  3u,  4u};
+  std::vector<E> generators = {1u, 2u, 3u, 4u};
   std::vector<E> sums(4 * generators.size() / 2);
   compute_partition_table<E>(sums, 2u, generators);
   std::vector<E> expected = {
-    0, generators[0], generators[1], generators[0].value + generators[1].value,
-    0, generators[2], generators[3], generators[2].value + generators[3].value,
+      0, generators[0], generators[1], generators[0].value + generators[1].value,
+      0, generators[2], generators[3], generators[2].value + generators[3].value,
   };
   REQUIRE(sums == expected);
 }

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -31,7 +31,7 @@ TEST_CASE("we can compute a slice of the partition table") {
   std::vector<E> sums(1u << 16);
   std::vector<E> generators = {1u, 2u,  3u,  4u,  5u,  6u,  7u,  8u,
                                9u, 10u, 11u, 12u, 13u, 14u, 15u, 16u};
-  compute_partition_table_slice(sums.data(), generators.data());
+  compute_partition_table_slice(sums.data(), 16u, generators.data());
   for (unsigned i = 0; i < sums.size(); ++i) {
     auto expected = E::identity();
     basbt::for_each_bit(reinterpret_cast<uint8_t*>(&i), sizeof(i), [&](unsigned index) noexcept {

--- a/sxt/multiexp/pippenger2/partition_table.t.cc
+++ b/sxt/multiexp/pippenger2/partition_table.t.cc
@@ -66,3 +66,15 @@ TEST_CASE("we can compute a slice of the partition table with a width of 1") {
     REQUIRE(sums[2 * i + 1] == generators[i]);
   }
 }
+
+TEST_CASE("we can compute a slice of the partition table with a width of 2") {
+  using E = bascrv::element97;
+  std::vector<E> generators = {1u, 2u,  3u,  4u};
+  std::vector<E> sums(4 * generators.size() / 2);
+  compute_partition_table<E>(sums, 2u, generators);
+  std::vector<E> expected = {
+    0, generators[0], generators[1], generators[0].value + generators[1].value,
+    0, generators[2], generators[3], generators[2].value + generators[3].value,
+  };
+  REQUIRE(sums == expected);
+}


### PR DESCRIPTION
# Rationale for this change

In order to experiment with different window widths for partition tables and perhaps find values that lead to better performance, this PR makes the window width an option when creating partition tables instead of fixing it to 16.

# What changes are included in this PR?

* rework functions to creating partition tables to accept a window width argument

# Are these changes tested?

Yes
