### PR TITLE
build: update nixpkgsDrv to use Nvidia driver version 555.58 (PROOF-894)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgsDrv": {
       "locked": {
-        "lastModified": 1709150264,
-        "narHash": "sha256-HofykKuisObPUfj0E9CJVfaMhawXkYx3G8UIFR/XQ38=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "9099616b93301d5cf84274b184a3a5ec69e94e08",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Rationale for this change
In an effort to keep blitzar up-to-date, the nixpkgDrv should be updated to point to the latest Nvidia driver.

# What changes are included in this PR?
- The Nvidia driver now points to driver version 555.58.

# Are these changes tested?
Yes, locally on a system with the 555.58 driver.