### PR TITLE
fix: fix size calculation in bindings (PROOF-877)

### DIFF
--- a/cbindings/fixed_pedersen.t.cc
+++ b/cbindings/fixed_pedersen.t.cc
@@ -44,6 +44,7 @@ TEST_CASE("we can compute multi-exponentiations with a fixed set of generators")
   std::vector<c21t::element_p3> generators = {
       0x123_c21,
       0x456_c21,
+      0x789_c21,
   };
 
   SECTION("we can compute a multiexponentiation with the gpu backend") {
@@ -88,6 +89,21 @@ TEST_CASE("we can compute multi-exponentiations with a fixed set of generators")
     sxt_fixed_packed_multiexponentiation(res, h.h, bit_table, 2, 2, scalars);
     REQUIRE(res[0] == 2 * generators[0] + 5 * generators[1]);
     REQUIRE(res[1] == generators[0]);
+  }
+
+  SECTION("we can compute a multiexponentiation in packed form with three generators") {
+    cbn::reset_backend_for_testing();
+    const sxt_config config = {SXT_GPU_BACKEND, 0};
+    REQUIRE(sxt_init(&config) == 0);
+
+    wrapped_handle h{generators.data(), 3};
+    REQUIRE(h.h != nullptr);
+
+    uint8_t scalars[] = {1, 1, 1};
+    unsigned bit_table[] = {8};
+    c21t::element_p3 res[1];
+    sxt_fixed_packed_multiexponentiation(res, h.h, bit_table, 1, 3, scalars);
+    REQUIRE(res[0] == generators[0] + generators[1] + generators[2]);
   }
 
   SECTION("we can compute a multiexponentiation in packed form with the cpu backend") {

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -20,7 +20,7 @@ sxt_cc_component(
     name = "gpu_backend",
     impl_deps = [
         "//sxt/base/error:assert",
-        "//sxt/base/num:round_up",
+        "//sxt/base/num:divide_up",
         "//sxt/proof/transcript:transcript",
         "//sxt/scalar25/type:element",
         "//sxt/cbindings/base:curve_id_utility",

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -22,7 +22,7 @@
 
 #include "sxt/base/error/assert.h"
 #include "sxt/base/error/panic.h"
-#include "sxt/base/num/round_up.h"
+#include "sxt/base/num/divide_up.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
 #include "sxt/curve21/operation/add.h"
 #include "sxt/curve21/operation/double.h"
@@ -186,8 +186,8 @@ void cpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
     basct::span<T> res_span{static_cast<T*>(res), num_outputs};
     basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
     auto output_num_bytes =
-        basn::round_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
-    basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n / 8u};
+        basn::divide_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
+    basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
     mtxpp2::multiexponentiate<T>(res_span,
                                  static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
                                  output_bit_table_span, scalars_span);

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -187,7 +187,7 @@ void cpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
     basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
     auto output_num_bytes =
         basn::round_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
-    basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
+    basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n / 8u};
     mtxpp2::multiexponentiate<T>(res_span,
                                  static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
                                  output_bit_table_span, scalars_span);

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -227,7 +227,7 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
         basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
         auto output_num_bytes =
             basn::round_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
-        basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
+        basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n / 8u};
         auto fut = mtxpp2::async_multiexponentiate<T>(
             res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
             output_bit_table_span, scalars_span);

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "sxt/base/error/assert.h"
-#include "sxt/base/num/round_up.h"
+#include "sxt/base/num/divide_up.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
 #include "sxt/curve21/operation/add.h"
 #include "sxt/curve21/operation/double.h"
@@ -226,8 +226,8 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
         basct::span<T> res_span{static_cast<T*>(res), num_outputs};
         basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
         auto output_num_bytes =
-            basn::round_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
-        basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n / 8u};
+            basn::divide_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
+        basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
         auto fut = mtxpp2::async_multiexponentiate<T>(
             res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
             output_bit_table_span, scalars_span);

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -221,18 +221,18 @@ void gpu_backend::fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id
                                             const mtxpp2::partition_table_accessor_base& accessor,
                                             const unsigned* output_bit_table, unsigned num_outputs,
                                             unsigned n, const uint8_t* scalars) const noexcept {
-  cbnb::switch_curve_type(
-      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
-        basct::span<T> res_span{static_cast<T*>(res), num_outputs};
-        basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
-        auto output_num_bytes =
-            basn::divide_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
-        basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
-        auto fut = mtxpp2::async_multiexponentiate<T>(
-            res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
-            output_bit_table_span, scalars_span);
-        xens::get_scheduler().run();
-      });
+  cbnb::switch_curve_type(curve_id, [&]<class U, class T>(std::type_identity<U>,
+                                                          std::type_identity<T>) noexcept {
+    basct::span<T> res_span{static_cast<T*>(res), num_outputs};
+    basct::cspan<unsigned> output_bit_table_span{output_bit_table, num_outputs};
+    auto output_num_bytes =
+        basn::divide_up(std::accumulate(output_bit_table, output_bit_table + num_outputs, 0), 8);
+    basct::cspan<uint8_t> scalars_span{scalars, output_num_bytes * n};
+    auto fut = mtxpp2::async_multiexponentiate<T>(
+        res_span, static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor),
+        output_bit_table_span, scalars_span);
+    xens::get_scheduler().run();
+  });
 }
 
 //--------------------------------------------------------------------------------------------------


### PR DESCRIPTION
# Rationale for this change

In the cbindings for packed multiexponentiations with generators, the size of the scalars span is calculated incorrect.

# What changes are included in this PR?

Correct the scalar size computation in the GPU and CPU backends.

# Are these changes tested?

Yes
