### PR TITLE
build: make format scripts use the version of python3 available in PATH (PROOF-000)

### DIFF
--- a/tools/code_format/build_fixer.py
+++ b/tools/code_format/build_fixer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 ########################################
 # Adopted from Envoy

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 ########################################
 # Adopted from Envoy

--- a/tools/code_format/common.py
+++ b/tools/code_format/common.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 def include_dir_order():
     return (".")

--- a/tools/code_format/copyright_fixer.py
+++ b/tools/code_format/copyright_fixer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import re

--- a/tools/code_format/header_order.py
+++ b/tools/code_format/header_order.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 ########################################
 # Adopted from Envoy

--- a/tools/code_format/paths.py
+++ b/tools/code_format/paths.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import os.path


### PR DESCRIPTION
# Rationale for this change

Update the format scripts so that they use the version of python3 in PATH.

This makes the scripts more portable to environments where python3 isn't in /usr/bin/

# What changes are included in this PR?

* Modifies the #! path in various scripts.

# Are these changes tested?

Tested locally.
