### PR TITLE
feat: change default partition window width (PROOF-893)

### DIFF
--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -47,10 +47,11 @@ public:
     in.seekg(0, std::ios::end);
     auto size = in.tellg() - pos;
     in.seekg(pos);
+    in.read(reinterpret_cast<char*>(&window_width_), sizeof(unsigned));
+    size -= sizeof(unsigned);
     SXT_RELEASE_ASSERT(size % sizeof(T) == 0);
     table_.resize(size / sizeof(T));
     in.read(reinterpret_cast<char*>(table_.data()), size);
-    window_width_ = 16;
     partition_table_size_ = 1u << window_width_;
   }
 
@@ -81,6 +82,7 @@ public:
     if (!out.good()) {
       baser::panic("failed to open {}: {}", filename, std::strerror(errno));
     }
+    out.write(reinterpret_cast<const char*>(&window_width_), sizeof(unsigned));
     out.write(reinterpret_cast<const char*>(table_.data()), table_.size() * sizeof(T));
   }
 

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -56,7 +56,7 @@ public:
   }
 
   explicit in_memory_partition_table_accessor(memmg::managed_array<T>&& table,
-                                              unsigned window_width = 16) noexcept
+                                              unsigned window_width) noexcept
       : window_width_{window_width}, partition_table_size_{1u << window_width},
         table_{std::move(table)} {}
 

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -40,6 +40,8 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
 
   SECTION("we can access a single element") {
     E e{11};
+    unsigned window_width = 16;
+    temp_file.stream().write(reinterpret_cast<const char*>(&window_width), sizeof(unsigned));
     temp_file.stream().write(reinterpret_cast<const char*>(&e), sizeof(e));
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
@@ -53,8 +55,10 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   }
 
   SECTION("we can access a elements with offset") {
+    unsigned window_width = 16;
     std::vector<E> data(partition_table_size * 2);
-    data[1u << 16u] = 12u;
+    data[1u << window_width] = 12u;
+    temp_file.stream().write(reinterpret_cast<const char*>(&window_width), sizeof(unsigned));
     temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};
@@ -70,6 +74,8 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
   SECTION("we can access elements from the host") {
     std::vector<E> data(partition_table_size * 2);
     data[partition_table_size] = 12;
+    unsigned window_width = 16;
+    temp_file.stream().write(reinterpret_cast<const char*>(&window_width), sizeof(unsigned));
     temp_file.stream().write(reinterpret_cast<const char*>(data.data()), sizeof(E) * data.size());
     temp_file.stream().close();
     in_memory_partition_table_accessor<E> accessor{temp_file.name()};

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.t.cc
@@ -91,7 +91,7 @@ TEST_CASE("we can provide access to precomputed partition sums stored on disk") 
     for (auto& val : data) {
       val = cnt++;
     }
-    in_memory_partition_table_accessor<E> accessor{memmg::managed_array<E>{data}};
+    in_memory_partition_table_accessor<E> accessor{memmg::managed_array<E>{data}, 16};
     temp_file.stream().close();
     accessor.write_to_file(temp_file.name());
     in_memory_partition_table_accessor<E> accessor_p{temp_file.name()};

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -39,7 +39,7 @@ template <class U, bascrv::element T>
   }
 std::unique_ptr<partition_table_accessor<U>>
 make_in_memory_partition_table_accessor_impl(basct::cspan<T> generators, basm::alloc_t alloc,
-                                             unsigned window_width = 16u) noexcept {
+                                             unsigned window_width = 13) noexcept {
   auto n = generators.size();
   auto partition_table_size = 1u << window_width;
   std::vector<T> generators_data;
@@ -64,7 +64,7 @@ template <class U, class T>
 std::unique_ptr<partition_table_accessor<U>>
 make_in_memory_partition_table_accessor(basct::cspan<T> generators,
                                         basm::alloc_t alloc = memr::get_pinned_resource(),
-                                        unsigned window_width = 16) noexcept {
+                                        unsigned window_width = 13) noexcept {
   return make_in_memory_partition_table_accessor_impl<U, T>(generators, alloc, window_width);
 }
 
@@ -72,7 +72,7 @@ template <class T>
 std::unique_ptr<partition_table_accessor<T>>
 make_in_memory_partition_table_accessor(basct::cspan<T> generators,
                                         basm::alloc_t alloc = memr::get_pinned_resource(),
-                                        unsigned window_width = 16) noexcept {
+                                        unsigned window_width = 13) noexcept {
   return make_in_memory_partition_table_accessor_impl<T, T>(generators, alloc, window_width);
 }
 } // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.t.cc
@@ -38,12 +38,14 @@ TEST_CASE("we can create a partition table accessor from given generators") {
     g = std::uniform_int_distribution<unsigned>{0, 96}(rng);
   }
 
+  unsigned window_width = 16;
   basdv::stream stream;
-  memmg::managed_array<E> table_dev{1u << 16u, memr::get_device_resource()};
+  memmg::managed_array<E> table_dev{1u << window_width, memr::get_device_resource()};
   memmg::managed_array<E> table(table_dev.size());
 
   SECTION("we can create an accessor from a single generators") {
-    auto accessor = make_in_memory_partition_table_accessor<E>(basct::subspan(generators, 0, 1));
+    auto accessor = make_in_memory_partition_table_accessor<E>(basct::subspan(generators, 0, 1), {},
+                                                               window_width);
     accessor->async_copy_to_device(table_dev, stream, 0);
     basdv::async_copy_device_to_host(table, table_dev, stream);
     basdv::synchronize_stream(stream);
@@ -52,7 +54,7 @@ TEST_CASE("we can create a partition table accessor from given generators") {
   }
 
   SECTION("we can create an accessor from multiple generators") {
-    auto accessor = make_in_memory_partition_table_accessor<E>(generators);
+    auto accessor = make_in_memory_partition_table_accessor<E>(generators, {}, window_width);
     accessor->async_copy_to_device(table_dev, stream, 0);
     basdv::async_copy_device_to_host(table, table_dev, stream);
     basdv::synchronize_stream(stream);


### PR DESCRIPTION
# Rationale for this change

Benchmarking indicates that a smaller window width for the partition algorithm give better performance. This PR changes the default window width from 16 to 13.

# What changes are included in this PR?

* Update default parameters to use 13 instead of 16
* Rework the file system persistence code to store the window width.

# Are these changes tested?

Yes
