### PR TITLE
feat: compute product lengths for variable length multiexponentiations (PROOF-896)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -212,3 +212,13 @@ sxt_cc_component(
         "//sxt/memory/resource:pinned_resource",
     ],
 )
+
+sxt_cc_component(
+    name = "variable_length_computation",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)

--- a/sxt/multiexp/pippenger2/variable_length_computation.cc
+++ b/sxt/multiexp/pippenger2/variable_length_computation.cc
@@ -1,0 +1,60 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/variable_length_computation.h"
+
+#include <algorithm>
+
+#include "sxt/base/error/assert.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// compute_product_length_table
+//--------------------------------------------------------------------------------------------------
+void compute_product_length_table(basct::span<unsigned>& product_lengths,
+                                  basct::cspan<unsigned> bit_widths,
+                                  basct::cspan<unsigned> output_lengths, unsigned first,
+                                  unsigned length) noexcept {
+  auto num_products = product_lengths.size();
+  auto num_outputs = bit_widths.size();
+  SXT_DEBUG_ASSERT(
+      // clang-format off
+      num_products >= num_outputs &&
+      product_lengths.size() == num_products &&
+      bit_widths.size() == num_outputs &&
+      output_lengths.size() == num_outputs
+      // clang-format on
+  );
+
+  // find first output with longer than <length>
+  auto output_first =
+      std::count_if(output_lengths.begin(), output_lengths.end(),
+                    [&](double output_length) noexcept { return output_length <= first; });
+
+  // fill in product lengths
+  unsigned product_index = 0;
+  for (auto output_index = output_first; output_index < num_outputs; ++output_index) {
+    auto output_length = output_lengths[output_index];
+    SXT_DEBUG_ASSERT(output_length > first);
+    auto product_length = std::min(output_length - first, length);
+    auto bit_width = bit_widths[output_index];
+    for (unsigned bit_index = 0; bit_index < bit_width; ++bit_index) {
+      product_lengths[product_index++] = product_length;
+    }
+  }
+  product_lengths = product_lengths.subspan(0, product_index);
+}
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/variable_length_computation.cc
+++ b/sxt/multiexp/pippenger2/variable_length_computation.cc
@@ -39,10 +39,12 @@ void compute_product_length_table(basct::span<unsigned>& product_lengths,
       // clang-format on
   );
 
-  // find first output with longer than <length>
-  auto output_first =
-      std::count_if(output_lengths.begin(), output_lengths.end(),
-                    [&](double output_length) noexcept { return output_length <= first; });
+  // find the index of the first output longer than <first>
+  auto output_first = [&] noexcept {
+    auto iter = std::find_if(output_lengths.begin(), output_lengths.end(),
+                             [&](double output_length) noexcept { return output_length > first; });
+    return static_cast<unsigned>(std::distance(output_lengths.begin(), iter));
+  }();
 
   // fill in product lengths
   unsigned product_index = 0;

--- a/sxt/multiexp/pippenger2/variable_length_computation.h
+++ b/sxt/multiexp/pippenger2/variable_length_computation.h
@@ -1,0 +1,29 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// compute_product_length_table
+//--------------------------------------------------------------------------------------------------
+void compute_product_length_table(basct::span<unsigned>& product_lengths,
+                                  basct::cspan<unsigned> bit_widths,
+                                  basct::cspan<unsigned> output_lengths, unsigned first,
+                                  unsigned length) noexcept;
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/variable_length_computation.t.cc
+++ b/sxt/multiexp/pippenger2/variable_length_computation.t.cc
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/variable_length_computation.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can fill in the table of product lengths") {
+  std::vector<unsigned> product_lengths_data(10);
+  std::vector<unsigned> bit_widths;
+  std::vector<unsigned> output_lengths;
+
+  basct::span<unsigned> product_lengths = {product_lengths_data.data(), 1};
+
+  SECTION("we can compute the product length of a single output of a single bit") {
+    bit_widths = {1};
+    output_lengths = {10};
+    compute_product_length_table(product_lengths, bit_widths, output_lengths, 0, 5);
+    REQUIRE(product_lengths.size() == 1);
+    REQUIRE(product_lengths[0] == 5);
+  }
+
+  SECTION("we handle the case when output_length is less than length") {
+    bit_widths = {1};
+    output_lengths = {10};
+    compute_product_length_table(product_lengths, bit_widths, output_lengths, 0, 20);
+    REQUIRE(product_lengths.size() == 1);
+    REQUIRE(product_lengths[0] == 10);
+  }
+
+  SECTION("we handle output of more than a single bit") {
+    bit_widths = {2};
+    product_lengths = {product_lengths_data.data(), 2};
+    output_lengths = {10};
+    compute_product_length_table(product_lengths, bit_widths, output_lengths, 0, 5);
+    REQUIRE(product_lengths.size() == 2);
+    REQUIRE(product_lengths[0] == 5);
+    REQUIRE(product_lengths[1] == 5);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a function to compute the lengths of products in a variable length multiexponentiation.

This will be used to build a more efficient function for multiexponentiation of varying lengths.

# What changes are included in this PR?

Adds a component with a function to fill in product lengths.

# Are these changes tested?

Yes
