### PR TITLE
feat: add variable length multiexponentiation (PROOF-896)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -181,9 +181,15 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "multiexponentiation_options",
+    with_test = False,
+)
+
+sxt_cc_component(
     name = "multiexponentiation",
     test_deps = [
         ":in_memory_partition_table_accessor_utility",
+        ":multiexponentiation_options",
         "//sxt/base/curve:example_element",
         "//sxt/base/num:fast_random_number_generator",
         "//sxt/base/test:unit_test",
@@ -200,6 +206,42 @@ sxt_cc_component(
         ":partition_product",
         ":partition_table_accessor",
         ":reduce",
+        ":variable_length_computation",
+        "//sxt/base/container:span",
+        "//sxt/base/container:span_utility",
+        "//sxt/base/curve:element",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:property",
+        "//sxt/base/device:state",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/iterator:index_range_iterator",
+        "//sxt/base/iterator:index_range_utility",
+        "//sxt/base/log",
+        "//sxt/execution/async:coroutine",
+        "//sxt/execution/device:for_each",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:async_device_resource",
+        "//sxt/memory/resource:device_resource",
+        "//sxt/memory/resource:pinned_resource",
+    ],
+)
+
+sxt_cc_component(
+    name = "variable_length_multiexponentiation",
+    test_deps = [
+        ":in_memory_partition_table_accessor_utility",
+        "//sxt/base/curve:example_element",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/ristretto/random:element",
+    ],
+    deps = [
+        ":combination",
+        ":partition_table_accessor",
+        ":reduce",
+        ":variable_length_computation",
+        ":variable_length_partition_product",
         "//sxt/base/container:span",
         "//sxt/base/container:span_utility",
         "//sxt/base/curve:element",

--- a/sxt/multiexp/pippenger2/multiexponentiation_options.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation_options.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/multiexponentiation_options.h"

--- a/sxt/multiexp/pippenger2/multiexponentiation_options.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_options.h
@@ -1,0 +1,28 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// multiexponentiate_options
+//--------------------------------------------------------------------------------------------------
+struct multiexponentiate_options {
+  unsigned split_factor = 1;
+  unsigned min_chunk_size = 64;
+  unsigned max_chunk_size = 1024;
+};
+} // namespace sxt::mtxpp2

--- a/sxt/multiexp/pippenger2/variable_length_multiexponentiation.cc
+++ b/sxt/multiexp/pippenger2/variable_length_multiexponentiation.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/variable_length_multiexponentiation.h"

--- a/sxt/multiexp/pippenger2/variable_length_multiexponentiation.t.cc
+++ b/sxt/multiexp/pippenger2/variable_length_multiexponentiation.t.cc
@@ -1,0 +1,124 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/multiexp/pippenger2/variable_length_multiexponentiation.h"
+
+#include <random>
+#include <vector>
+
+#include "sxt/base/curve/example_element.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
+#include "sxt/ristretto/random/element.h"
+
+using namespace sxt;
+using namespace sxt::mtxpp2;
+
+TEST_CASE("we can compute multiexponentiations with varying lengths") {
+  using E = bascrv::element97;
+
+  std::vector<E> generators(32);
+  std::mt19937 rng{0};
+  for (auto& g : generators) {
+    g = std::uniform_int_distribution<unsigned>{0, 96}(rng);
+  }
+
+  auto accessor = make_in_memory_partition_table_accessor<E>(generators);
+
+  std::vector<uint8_t> scalars(1);
+  std::vector<E> res(1);
+  std::vector<unsigned> output_bit_table(1);
+  std::vector<unsigned> output_lengths(1);
+
+  SECTION("we can compute a multiexponentiation of length zero") {
+    output_bit_table[0] = 1;
+    output_lengths[0] = 0;
+    scalars[0] = 1;
+    auto fut =
+        async_multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == E::identity());
+  }
+
+  SECTION("we can compute a host multiexponentiation of length zero") {
+    output_bit_table[0] = 1;
+    output_lengths[0] = 0;
+    scalars[0] = 1;
+    multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    REQUIRE(res[0] == E::identity());
+  }
+
+  SECTION("we can compute a multiexponentiation for a single bit scalar") {
+    output_bit_table[0] = 1;
+    output_lengths[0] = 1;
+    auto fut =
+        async_multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == E::identity());
+  }
+
+  SECTION("we can compute a multiexponentiation of length two") {
+    output_bit_table[0] = 1;
+    output_lengths[0] = 2;
+    scalars = {0, 1};
+    auto fut =
+        async_multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[1]);
+  }
+
+  SECTION("we can compute a multiexponentiation on the host") {
+    output_bit_table[0] = 1;
+    output_lengths[0] = 2;
+    scalars = {0, 1};
+    multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    REQUIRE(res[0] == generators[1]);
+  }
+
+  SECTION("we can compute a multiexponentiation with two products of different lengths") {
+    output_bit_table = {1, 1};
+    output_lengths = {1, 2};
+    scalars = {3, 3};
+    res.resize(2);
+    auto fut =
+        async_multiexponentiate<E>(res, *accessor, output_bit_table, output_lengths, scalars);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0]);
+    REQUIRE(res[1] == generators[0].value + generators[1].value);
+  }
+
+  SECTION("we can split a multiexponentiation") {
+    multiexponentiate_options options{
+        .split_factor = 2,
+        .min_chunk_size = 16u,
+    };
+    output_bit_table[0] = 8;
+    output_lengths[0] = 17;
+    scalars.resize(32);
+    scalars[0] = 1;
+    scalars[16] = 1;
+    auto fut = multiexponentiate_impl<E>(res, *accessor, output_bit_table, output_lengths, scalars,
+                                         options);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(res[0] == generators[0].value + generators[16].value);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add multi-exponentiation functions that are more efficient for variable length problems.

This uses a simple implementation that I'm sure can be improved quite a bit. But the benchmarking shows it still leads to significant improvements (~30%) for triangularly structured multi-exponentiations.

# What changes are included in this PR?

Adds new multi-exponentiation functions.

# Are these changes tested?

Yes
