### PR TITLE
build: simplify build for libbacktrace (PROOF-899)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,30 +24,6 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 rules_foreign_cc_dependencies()
 
 # libbacktrace
-# git_repository(
-#     name = "com_github_ianlancetaylor_libbacktrace",
-#     build_file_content = """
-# load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
-# 
-# package(default_visibility = ["//visibility:public"])
-# 
-# filegroup(
-#   name = "all_srcs",
-#   srcs = glob(
-#       include = ["**"],
-#       exclude = ["*.bazel"],
-#   ),
-# )
-# 
-# configure_make(
-#   name = "libbacktrace",
-#   lib_source = ":all_srcs",
-# )
-#   """,
-#     commit = "14818b7",
-#     remote = "https://github.com/ianlancetaylor/libbacktrace",
-# )
-
 git_repository(
     name = "com_github_ianlancetaylor_libbacktrace",
     build_file = "//bazel/libbacktrace:libbacktrace.BUILD",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,26 +24,33 @@ load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_depende
 rules_foreign_cc_dependencies()
 
 # libbacktrace
+# git_repository(
+#     name = "com_github_ianlancetaylor_libbacktrace",
+#     build_file_content = """
+# load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
+# 
+# package(default_visibility = ["//visibility:public"])
+# 
+# filegroup(
+#   name = "all_srcs",
+#   srcs = glob(
+#       include = ["**"],
+#       exclude = ["*.bazel"],
+#   ),
+# )
+# 
+# configure_make(
+#   name = "libbacktrace",
+#   lib_source = ":all_srcs",
+# )
+#   """,
+#     commit = "14818b7",
+#     remote = "https://github.com/ianlancetaylor/libbacktrace",
+# )
+
 git_repository(
     name = "com_github_ianlancetaylor_libbacktrace",
-    build_file_content = """
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "configure_make")
-
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-  name = "all_srcs",
-  srcs = glob(
-      include = ["**"],
-      exclude = ["*.bazel"],
-  ),
-)
-
-configure_make(
-  name = "libbacktrace",
-  lib_source = ":all_srcs",
-)
-  """,
+    build_file = "//bazel/libbacktrace:libbacktrace.BUILD",
     commit = "14818b7",
     remote = "https://github.com/ianlancetaylor/libbacktrace",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -27,7 +27,7 @@ rules_foreign_cc_dependencies()
 git_repository(
     name = "com_github_ianlancetaylor_libbacktrace",
     build_file = "//bazel/libbacktrace:libbacktrace.BUILD",
-    commit = "14818b7",
+    commit = "86885d1",
     remote = "https://github.com/ianlancetaylor/libbacktrace",
 )
 

--- a/bazel/libbacktrace/BUILD
+++ b/bazel/libbacktrace/BUILD
@@ -1,0 +1,5 @@
+exports_files([
+    "config.h",
+    "backtrace-supported.h",
+    "libbacktrace.BUILD",
+])

--- a/bazel/libbacktrace/backtrace-supported.h
+++ b/bazel/libbacktrace/backtrace-supported.h
@@ -1,0 +1,66 @@
+/* backtrace-supported.h.in -- Whether stack backtrace is supported.
+   Copyright (C) 2012-2024 Free Software Foundation, Inc.
+   Written by Ian Lance Taylor, Google.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+    (1) Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+
+    (2) Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in
+    the documentation and/or other materials provided with the
+    distribution.
+
+    (3) The name of the author may not be used to
+    endorse or promote products derived from this software without
+    specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.  */
+
+/* The file backtrace-supported.h.in is used by configure to generate
+   the file backtrace-supported.h.  The file backtrace-supported.h may
+   be #include'd to see whether the backtrace library will be able to
+   get a backtrace and produce symbolic information.  */
+
+
+/* BACKTRACE_SUPPORTED will be #define'd as 1 if the backtrace library
+   should work, 0 if it will not.  Libraries may #include this to make
+   other arrangements.  */
+
+#define BACKTRACE_SUPPORTED 1
+
+/* BACKTRACE_USES_MALLOC will be #define'd as 1 if the backtrace
+   library will call malloc as it works, 0 if it will call mmap
+   instead.  This may be used to determine whether it is safe to call
+   the backtrace functions from a signal handler.  In general this
+   only applies to calls like backtrace and backtrace_pcinfo.  It does
+   not apply to backtrace_simple, which never calls malloc.  It does
+   not apply to backtrace_print, which always calls fprintf and
+   therefore malloc.  */
+
+#define BACKTRACE_USES_MALLOC 0
+
+/* BACKTRACE_SUPPORTS_THREADS will be #define'd as 1 if the backtrace
+   library is configured with threading support, 0 if not.  If this is
+   0, the threaded parameter to backtrace_create_state must be passed
+   as 0.  */
+
+#define BACKTRACE_SUPPORTS_THREADS 1
+
+/* BACKTRACE_SUPPORTS_DATA will be #defined'd as 1 if the backtrace_syminfo
+   will work for variables.  It will always work for functions.  */
+
+#define BACKTRACE_SUPPORTS_DATA 1

--- a/bazel/libbacktrace/config.h
+++ b/bazel/libbacktrace/config.h
@@ -1,0 +1,186 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* ELF size: 32 or 64 */
+#define BACKTRACE_ELF_SIZE 64
+
+/* XCOFF size: 32 or 64 */
+#define BACKTRACE_XCOFF_SIZE unused
+
+/* Define to 1 if you have the __atomic functions */
+#define HAVE_ATOMIC_FUNCTIONS 1
+
+/* Define to 1 if you have the `clock_gettime' function. */
+#define HAVE_CLOCK_GETTIME 1
+
+/* Define to 1 if you have the declaration of `getpagesize', and to 0 if you
+   don't. */
+#define HAVE_DECL_GETPAGESIZE 1
+
+/* Define to 1 if you have the declaration of `strnlen', and to 0 if you
+   don't. */
+#define HAVE_DECL_STRNLEN 1
+
+/* Define to 1 if you have the declaration of `_pgmptr', and to 0 if you
+   don't. */
+#define HAVE_DECL__PGMPTR 0
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define if dl_iterate_phdr is available. */
+#define HAVE_DL_ITERATE_PHDR 1
+
+/* Define to 1 if you have the fcntl function */
+#define HAVE_FCNTL 1
+
+/* Define if getexecname is available. */
+/* #undef HAVE_GETEXECNAME */
+
+/* Define if _Unwind_GetIPInfo is available. */
+#define HAVE_GETIPINFO 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have KERN_PROC and KERN_PROC_PATHNAME in <sys/sysctl.h>.
+   */
+/* #undef HAVE_KERN_PROC */
+
+/* Define to 1 if you have KERN_PROCARGS and KERN_PROC_PATHNAME in
+   <sys/sysctl.h>. */
+/* #undef HAVE_KERN_PROC_ARGS */
+
+/* Define if -llzma is available. */
+/* #undef HAVE_LIBLZMA */
+
+/* Define to 1 if you have the <link.h> header file. */
+#define HAVE_LINK_H 1
+
+/* Define if AIX loadquery is available. */
+/* #undef HAVE_LOADQUERY */
+
+/* Define to 1 if you have the `lstat' function. */
+#define HAVE_LSTAT 1
+
+/* Define to 1 if you have the <mach-o/dyld.h> header file. */
+/* #undef HAVE_MACH_O_DYLD_H */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if you have the `readlink' function. */
+#define HAVE_READLINK 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the __sync functions */
+#define HAVE_SYNC_FUNCTIONS 1
+
+/* Define to 1 if you have the <sys/ldr.h> header file. */
+/* #undef HAVE_SYS_LDR_H */
+
+/* Define to 1 if you have the <sys/link.h> header file. */
+/* #undef HAVE_SYS_LINK_H */
+
+/* Define to 1 if you have the <sys/mman.h> header file. */
+#define HAVE_SYS_MMAN_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <tlhelp32.h> header file. */
+/* #undef HAVE_TLHELP32_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define if -lz is available. */
+/* #undef HAVE_ZLIB */
+
+/* Define if -lzstd is available. */
+/* #undef HAVE_ZSTD */
+
+/* Define to the sub-directory in which libtool stores uninstalled libraries.
+   */
+#define LT_OBJDIR ".libs/"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT ""
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "package-unused"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "package-unused version-unused"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "libbacktrace"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "version-unused"
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1
+
+/* Enable extensions on AIX 3, Interix.  */
+#ifndef _ALL_SOURCE
+# define _ALL_SOURCE 1
+#endif
+/* Enable GNU extensions on systems that have them.  */
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE 1
+#endif
+/* Enable threading extensions on Solaris.  */
+#ifndef _POSIX_PTHREAD_SEMANTICS
+# define _POSIX_PTHREAD_SEMANTICS 1
+#endif
+/* Enable extensions on HP NonStop.  */
+#ifndef _TANDEM_SOURCE
+# define _TANDEM_SOURCE 1
+#endif
+/* Enable general extensions on Solaris.  */
+#ifndef __EXTENSIONS__
+# define __EXTENSIONS__ 1
+#endif
+
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+/* #undef _FILE_OFFSET_BITS */
+
+/* Define for large files, on AIX-style hosts. */
+/* #undef _LARGE_FILES */
+
+/* Define to 1 if on MINIX. */
+/* #undef _MINIX */
+
+/* Define to 2 if the system does not provide POSIX.1 features except with
+   this defined. */
+/* #undef _POSIX_1_SOURCE */
+
+/* Define to 1 if you need to in order for `stat' and other things to work. */
+/* #undef _POSIX_SOURCE */

--- a/bazel/libbacktrace/libbacktrace.BUILD
+++ b/bazel/libbacktrace/libbacktrace.BUILD
@@ -3,6 +3,8 @@ cc_library(
     srcs = [
         "atomic.c",
         "backtrace.c",
+        "backtrace-supported.h",
+        "config.h",
         "dwarf.c",
         "elf.c",
         "fileline.c",
@@ -15,30 +17,28 @@ cc_library(
         "simple.c",
         "sort.c",
         "state.c",
-        "backtrace-supported.h",
-        "config.h",
     ],
     hdrs = [
         "backtrace.h",
     ],
+    includes = [
+        ".",
+    ],
     visibility = [
         "//visibility:public",
     ],
-    includes = [
-        ".",
-    ]
 )
 
 genrule(
-  name = "config",
-  srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:config.h"],
-  outs = ["config.h"],
-  cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:config.h) > $@",
+    name = "config",
+    srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:config.h"],
+    outs = ["config.h"],
+    cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:config.h) > $@",
 )
 
 genrule(
-  name = "backtrace-supported",
-  srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h"],
-  outs = ["backtrace-supported.h"],
-  cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h) > $@",
+    name = "backtrace-supported",
+    srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h"],
+    outs = ["backtrace-supported.h"],
+    cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h) > $@",
 )

--- a/bazel/libbacktrace/libbacktrace.BUILD
+++ b/bazel/libbacktrace/libbacktrace.BUILD
@@ -1,0 +1,44 @@
+cc_library(
+    name = "libbacktrace",
+    srcs = [
+        "atomic.c",
+        "backtrace.c",
+        "dwarf.c",
+        "elf.c",
+        "fileline.c",
+        "filenames.h",
+        "internal.h",
+        "mmap.c",
+        "mmapio.c",
+        "posix.c",
+        "print.c",
+        "simple.c",
+        "sort.c",
+        "state.c",
+        "backtrace-supported.h",
+        "config.h",
+    ],
+    hdrs = [
+        "backtrace.h",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+    includes = [
+        ".",
+    ]
+)
+
+genrule(
+  name = "config",
+  srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:config.h"],
+  outs = ["config.h"],
+  cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:config.h) > $@",
+)
+
+genrule(
+  name = "backtrace-supported",
+  srcs = ["@dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h"],
+  outs = ["backtrace-supported.h"],
+  cmd = "cat $(location @dev_spaceandtime_blitzar//bazel/libbacktrace:backtrace-supported.h) > $@",
+)

--- a/tools/code_format/check_format.py
+++ b/tools/code_format/check_format.py
@@ -30,7 +30,7 @@ SUBDIR_SET = set(common.include_dir_order())
 
 SUFFIXES = ("BUILD", "WORKSPACE", ".bzl", ".cc", ".h")
 
-EXCLUDED_PREFIXES = ("./third_party/", "./.git/", "./bazel-", "./.cache", "./ci", "./rust")
+EXCLUDED_PREFIXES = ("./third_party/", "./bazel", "./.git/", "./bazel-", "./.cache", "./ci", "./rust")
 
 class FormatChecker:
     def __init__(self, args):


### PR DESCRIPTION
Simplify the bazel build by dropping the foreign rules dependency for libbacktrace. This makes it easier to update the build environment. I plan to follow up with an additional PR to remove foreign rules completely.

