### PR TITLE
build: drop foreign_rules dependency (PROOF-899)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -51,29 +51,8 @@ configure_make(
 # spdlog
 git_repository(
     name = "com_github_gabime_spdlog",
-    build_file_content = """
-load("@rules_foreign_cc//foreign_cc:defs.bzl", "cmake")
-
-package(default_visibility = ["//visibility:public"])
-
-filegroup(
-  name = "all_srcs",
-  srcs = glob(
-      include = ["**"],
-      exclude = ["*.bazel"],
-  ),
-)
-
-cmake(
-  name = "libspdlog",
-  cache_entries = {
-    "SPDLOG_BUILD_EXAMPLE": "OFF",
-    "CMAKE_CXX_FLAGS": "-stdlib=libc++",
-  },
-  lib_source = ":all_srcs",
-)
-  """,
-    commit = "7c02e20",
+    build_file = "//bazel:spdlog.BUILD",
+    commit = "5ebfc92",
     remote = "https://github.com/gabime/spdlog",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,16 +1,6 @@
 workspace(name = "dev_spaceandtime_blitzar")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.2/bazel-skylib-1.4.2.tar.gz",
-    ],
-)
 
 # libbacktrace
 git_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,17 +12,6 @@ http_archive(
     ],
 )
 
-# rules_foreign_cc
-git_repository(
-    name = "rules_foreign_cc",
-    commit = "a87e754",
-    remote = "https://github.com/bazelbuild/rules_foreign_cc",
-)
-
-load("@rules_foreign_cc//foreign_cc:repositories.bzl", "rules_foreign_cc_dependencies")
-
-rules_foreign_cc_dependencies()
-
 # libbacktrace
 git_repository(
     name = "com_github_ianlancetaylor_libbacktrace",

--- a/bazel/spdlog.BUILD
+++ b/bazel/spdlog.BUILD
@@ -1,0 +1,10 @@
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "libspdlog",
+    hdrs = glob([
+        "include/**/*.h",
+    ]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/bazel/spdlog.BUILD
+++ b/bazel/spdlog.BUILD
@@ -6,5 +6,6 @@ cc_library(
         "include/**/*.h",
     ]),
     includes = ["include"],
+    linkstatic = 1,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Drops foreign rules dependency to simplify the build environment.
