### PR TITLE
chore: minor changes for build update (PROOF-899)

### DIFF
--- a/app/blitzar/main.cc
+++ b/app/blitzar/main.cc
@@ -52,7 +52,7 @@ static void make_partition_table(std::string_view filename, unsigned n) noexcept
   mtxpp2::compute_partition_table<c21t::element_p3>(sums, generators);
 
   // write table
-  std::ofstream out{filename, std::ios::binary};
+  std::ofstream out{std::string{filename}, std::ios::binary};
   if (!out.good()) {
     baser::panic("failed to open {}: {}", filename, std::strerror(errno));
   }

--- a/bazel/libbacktrace/libbacktrace.BUILD
+++ b/bazel/libbacktrace/libbacktrace.BUILD
@@ -1,5 +1,6 @@
 cc_library(
     name = "libbacktrace",
+    linkstatic = 1,
     srcs = [
         "atomic.c",
         "backtrace.c",

--- a/sxt/base/log/BUILD
+++ b/sxt/base/log/BUILD
@@ -18,6 +18,7 @@ cc_library(
     implementation_deps = [
         "@com_github_gabime_spdlog//:libspdlog",
     ],
+    linkstatic = 1,
 )
 
 cc_library(
@@ -36,6 +37,7 @@ cc_library(
         ":setup",
         "@com_github_gabime_spdlog//:libspdlog",
     ],
+    linkstatic = 1,
 )
 
 sxt_cc_component(

--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h
@@ -39,7 +39,7 @@ class in_memory_partition_table_accessor final : public partition_table_accessor
 public:
   explicit in_memory_partition_table_accessor(std::string_view filename) noexcept
       : table_{memr::get_pinned_resource()} {
-    std::ifstream in{filename, std::ios::binary};
+    std::ifstream in{std::string{filename}, std::ios::binary};
     if (!in.good()) {
       baser::panic("failed to open {}: {}", filename, std::strerror(errno));
     }
@@ -78,7 +78,7 @@ public:
   }
 
   void write_to_file(std::string_view filename) const noexcept override {
-    std::ofstream out{filename, std::ios::binary};
+    std::ofstream out{std::string{filename}, std::ios::binary};
     if (!out.good()) {
       baser::panic("failed to open {}: {}", filename, std::strerror(errno));
     }


### PR DESCRIPTION
* make some minor tweaks to fix code that errors on the latest version of clang
* set `linkstatic=1` attribute to make build faster.