### PR TITLE
feat: support specifying backend via an environmental variable(PROOF-903)

### DIFF
--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -46,6 +46,7 @@ sxt_cc_component(
         "//sxt/base/device:property",
         "//sxt/base/error:assert",
         "//sxt/base/error:panic",
+        "//sxt/base/log:log",
         "//sxt/cbindings/backend:gpu_backend",
         "//sxt/cbindings/backend:cpu_backend",
         "//sxt/seqcommit/generator:precomputed_initializer",

--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -16,7 +16,8 @@
  */
 #include "cbindings/backend.h"
 
-#include <iostream>
+#include <cstdlib>
+#include <cctype>
 
 #include "sxt/base/device/property.h"
 #include "sxt/base/error/assert.h"
@@ -57,16 +58,32 @@ static void initialize_gpu_backend(const sxt_config* config) noexcept {
   int num_devices = basdv::get_num_devices();
 
   if (num_devices == 0) {
-    initialize_cpu_backend(config);
-
-    // this message is used only to warn the user that gpu will not be used
-    std::cout << "WARN: Using pippenger cpu instead of naive gpu backend." << std::endl;
-
-    return;
+    baser::panic("no supported GPUs found");
   }
 
   backend = cbnbck::get_gpu_backend();
   sqcgn::init_precomputed_components(config->num_precomputed_generators, true);
+}
+
+//--------------------------------------------------------------------------------------------------
+// try_get_environ_backend 
+//--------------------------------------------------------------------------------------------------
+static void try_get_environ_backend(int& backend) noexcept {
+  auto val = std::getenv("BLITZAR_BACKEND");
+  if (val == nullptr) {
+    return;
+  }
+  std::string s{val};
+  for (auto& c : s) {
+    c = std::tolower(c);
+  }
+  if (s == "cpu") {
+    backend = SXT_CPU_BACKEND;
+  } else if (s == "gpu") {
+    backend = SXT_GPU_BACKEND;
+  } else {
+    baser::panic("invalid BLITZAR_BACKEND value {}", s);
+  }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -97,11 +114,13 @@ int sxt_init(const sxt_config* config) {
   SXT_RELEASE_ASSERT(cbn::backend == nullptr,
                      "trying to reinitialize the backend in the `sxt_init` c binding function");
 
-  if (config->backend == SXT_GPU_BACKEND) {
+  auto backend = config->backend;
+  sxt::cbn::try_get_environ_backend(backend);
+  if (backend == SXT_GPU_BACKEND) {
     cbn::initialize_gpu_backend(config);
 
     return 0;
-  } else if (config->backend == SXT_CPU_BACKEND) {
+  } else if (backend == SXT_CPU_BACKEND) {
     cbn::initialize_cpu_backend(config);
 
     return 0;

--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -16,8 +16,8 @@
  */
 #include "cbindings/backend.h"
 
-#include <cstdlib>
 #include <cctype>
+#include <cstdlib>
 
 #include "sxt/base/device/property.h"
 #include "sxt/base/error/assert.h"
@@ -66,7 +66,7 @@ static void initialize_gpu_backend(const sxt_config* config) noexcept {
 }
 
 //--------------------------------------------------------------------------------------------------
-// try_get_environ_backend 
+// try_get_environ_backend
 //--------------------------------------------------------------------------------------------------
 static void try_get_environ_backend(int& backend) noexcept {
   auto val = std::getenv("BLITZAR_BACKEND");

--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -22,6 +22,7 @@
 #include "sxt/base/device/property.h"
 #include "sxt/base/error/assert.h"
 #include "sxt/base/error/panic.h"
+#include "sxt/base/log/log.h"
 #include "sxt/cbindings/backend/computational_backend.h"
 #include "sxt/cbindings/backend/cpu_backend.h"
 #include "sxt/cbindings/backend/gpu_backend.h"
@@ -74,6 +75,7 @@ static void try_get_environ_backend(int& backend) noexcept {
     return;
   }
   std::string s{val};
+  basl::info("override default backend with environmental varaible BLITZAR_BACKEND={}", s);
   for (auto& c : s) {
     c = std::tolower(c);
   }
@@ -117,10 +119,12 @@ int sxt_init(const sxt_config* config) {
   auto backend = config->backend;
   sxt::cbn::try_get_environ_backend(backend);
   if (backend == SXT_GPU_BACKEND) {
+    basl::info("initializing GPU backend");
     cbn::initialize_gpu_backend(config);
 
     return 0;
   } else if (backend == SXT_CPU_BACKEND) {
+    basl::info("initializing CPU backend");
     cbn::initialize_cpu_backend(config);
 
     return 0;


### PR DESCRIPTION
# Rationale for this change

Support specifying the backend via an environmental variable

# What changes are included in this PR?

* add code to override default backend with the environmental variable BLITZAR_BACKEND
* panic if the GPU backend is selected but no GPUs are available
* add additional logging

# Are these changes tested?

Yes. Tested locally.
