### PR TITLE
ci: source nix before develop call in workflow (PROOF-912)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Semantic release
         run: |
           nix develop --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,9 @@ jobs:
 
       - name: Semantic release
         run: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
           nix develop --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command npx semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -18,11 +18,12 @@ jobs:
     timeout-minutes: 600
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3      
   
       - name: Run check
-        run: >
-          /usr/bin/nix develop --command ./tools/code_format/check_format.py check
+        run: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
+          nix develop --command ./tools/code_format/check_format.py check
   
   test-cpp:
     name: C++ code
@@ -31,10 +32,11 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-  
+      
       - name: Run cpp tests
-        run: >
-          TEST_TMPDIR=$HOME/.bazel_test /usr/bin/nix develop --command bazel test //...
+        run: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
+          TEST_TMPDIR=$HOME/.bazel_test nix develop --command bazel test //...
   
           # Note: There are some steps we need to our
           # to our custom nix derivation from https://github.com/spaceandtimelabs/blitzar/pull/96
@@ -69,11 +71,12 @@ jobs:
     timeout-minutes: 600
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3        
   
       - name: Run cpp tests with optimization flags on
-        run: >
-          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command bazel test --jobs=1 -c opt //...
+        run: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command bazel test --jobs=1 -c opt //...
   
   test-cpp-asan:
     name: C++ code with address sanitizer
@@ -84,8 +87,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run cpp-asan tests
-        run: >
-          TEST_TMPDIR=$HOME/.bazel_test_asan /usr/bin/nix develop --command bazel test --config=asan //...
+        run: |
+          source ~/.nix-profile/etc/profile.d/nix.sh
+          TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --command bazel test --config=asan //...
 
   test-rust:
     name: Rust Sys Crate
@@ -97,5 +101,6 @@ jobs:
 
       - name: Run rust tests
         run: |
-          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
-          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command cargo test --manifest-path rust/tests/Cargo.toml
+          source ~/.nix-profile/etc/profile.d/nix.sh
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/tests/Cargo.toml

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -22,7 +22,7 @@ jobs:
   
       - name: Run check
         run: >
-          nix develop --command ./tools/code_format/check_format.py check
+          /usr/bin/nix develop --command ./tools/code_format/check_format.py check
   
   test-cpp:
     name: C++ code
@@ -34,7 +34,7 @@ jobs:
   
       - name: Run cpp tests
         run: >
-          TEST_TMPDIR=$HOME/.bazel_test nix develop --command bazel test //...
+          TEST_TMPDIR=$HOME/.bazel_test /usr/bin/nix develop --command bazel test //...
   
           # Note: There are some steps we need to our
           # to our custom nix derivation from https://github.com/spaceandtimelabs/blitzar/pull/96
@@ -73,7 +73,7 @@ jobs:
   
       - name: Run cpp tests with optimization flags on
         run: >
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command bazel test --jobs=1 -c opt //...
+          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command bazel test --jobs=1 -c opt //...
   
   test-cpp-asan:
     name: C++ code with address sanitizer
@@ -85,7 +85,7 @@ jobs:
 
       - name: Run cpp-asan tests
         run: >
-          TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --command bazel test --config=asan //...
+          TEST_TMPDIR=$HOME/.bazel_test_asan /usr/bin/nix develop --command bazel test --config=asan //...
 
   test-rust:
     name: Rust Sys Crate
@@ -97,5 +97,5 @@ jobs:
 
       - name: Run rust tests
         run: |
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/tests/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt /usr/bin/nix develop --command cargo test --manifest-path rust/tests/Cargo.toml

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -32,7 +32,7 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-      
+
       - name: Run cpp tests
         run: |
           source ~/.nix-profile/etc/profile.d/nix.sh

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 600
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3      
+        uses: actions/checkout@v3
   
       - name: Run check
         run: |
@@ -71,7 +71,7 @@ jobs:
     timeout-minutes: 600
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3        
+        uses: actions/checkout@v3
   
       - name: Run cpp tests with optimization flags on
         run: |


### PR DESCRIPTION
# Rationale for this change
The CI workflow will fail to find `nix` sometimes, causing the CI to fail. This PR sources `nix` before calling things like `nix develop`.

# What changes are included in this PR?
- The workflow now sources `nix` before calling `nix`.

# Are these changes tested?
Yes