### PR TITLE
build: revert CUDA and clang (PROOF-916)

### DIFF
--- a/nix/clang.nix
+++ b/nix/clang.nix
@@ -9,8 +9,8 @@ stdenvNoCC.mkDerivation {
   src = pkgs.fetchFromGitHub {
     owner = "llvm";
     repo = "llvm-project";
-    rev = "bde2357";
-    hash = "sha256-eWqHYSEHl+YAx3qeabsCY0OKHySEsjNqvbEcYrMucKU=";
+    rev = "fdbff88";
+    hash = "sha256-kipkrgqzSgdsHwYz5P2NpUo6miulE/Nd9zRgeKAHeHM=";
   };
   nativeBuildInputs = [
     cmake
@@ -21,7 +21,6 @@ stdenvNoCC.mkDerivation {
   ];
   buildInputs = [
     gcc
-    zlib
   ];
   NIX_LDFLAGS = "-L${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version} -L${gcc.libc}/lib";
   CFLAGS = "-B${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version} -B${gcc.libc}/lib";
@@ -35,69 +34,46 @@ stdenvNoCC.mkDerivation {
   postPatch = ''
     substituteInPlace clang/lib/Driver/ToolChains/Gnu.cpp \
       --replace 'GLIBC_PATH_ABC123' '${gcc.libc}/lib'
-    substituteInPlace clang/lib/Driver/ToolChains/Gnu.cpp \
-      --replace 'GCCLIB_PATH_ABC123' '${gccForLibs}/lib/gcc/${targetPlatform.config}/${gccForLibs.version}'
   '';
   configurePhase = pkgs.lib.strings.concatStringsSep " " [
     "mkdir build; cd build;"
     "cmake"
-    "-G \"Ninja\""
+    "-G \"Unix Makefiles\""
+    "-DGCC_INSTALL_PREFIX=${gccForLibs}"
     "-DC_INCLUDE_DIRS=${gcc.libc.dev}/include"
     "-DLLVM_TARGETS_TO_BUILD=\"host;NVPTX\""
     "-DLLVM_BUILTIN_TARGETS=\"x86_64-unknown-linux-gnu\""
     "-DLLVM_RUNTIME_TARGETS=\"x86_64-unknown-linux-gnu\""
-    "-DLLVM_ENABLE_PROJECTS=\"clang;lld;clang-tools-extra\""
-    "-DLLVM_ENABLE_ZLIB=ON"
-
-    # clang
-    "-DCLANG_DEFAULT_CXX_STDLIB=libc++"
+    "-DLLVM_ENABLE_PROJECTS=\"clang;clang-tools-extra\""
 
     "-DLLVM_ENABLE_RUNTIMES=\"libcxx;libcxxabi;libunwind;compiler-rt\""
     "-DLLVM_ENABLE_PER_TARGET_RUNTIME_DIR=OFF"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_CMAKE_BUILD_TYPE=Release"
 
     # libcxx
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXX_ENABLE_SHARED=OFF"
+    "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXX_ENABLE_SHARED=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXX_ENABLE_STATIC=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXX_ENABLE_STATIC_ABI_LIBRARY=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXX_STATICALLY_LINK_ABI_IN_STATIC_LIBRARY=ON"
 
     # libcxxabi
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXXABI_USE_LLVM_UNWINDER=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXXABI_ENABLE_SHARED=OFF"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXXABI_ENABLE_STATIC=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXXABI_ENABLE_STATIC_UNWINDER=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBCXXABI_STATICALLY_LINK_UNWINDER_IN_STATIC_LIBRARY=ON"
 
     # libunwind
     "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBUNWIND_ENABLE_STATIC=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_LIBUNWIND_ENABLE_SHARED=OFF"
 
     # compiler-rt
     "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_CXX_LIBRARY=libcxx"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_USE_LIBCXX=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_STATIC_CXX_LIBRARY=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_SANITIZER_USE_STATIC_CXX_ABI=ON"
     "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_USE_LLVM_UNWINDER=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_SANITIZER_USE_STATIC_LLVM_UNWINDER=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_BUILTINS=ON"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_SANITIZERS_TO_BUILD=\"asan;msan\""
     "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_LIBFUZZER=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_XRAY=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_XRAY_NO_PREINIT=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_PROFILE=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_CTX_PROFILE=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_MEMPROF=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_ORC=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_BUILD_GWP_ASAN=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_TEST_STANDALONE_BUILD_LIBS=OFF"
-    "-DRUNTIMES_x86_64-unknown-linux-gnu_COMPILER_RT_INCLUDE_TESTS=OFF"
 
     "-DCMAKE_BUILD_TYPE=Release"
     "-DCMAKE_INSTALL_PREFIX=\"$out\""
     "../llvm"
   ];
-  buildPhase = "ninja -j4";
-  installPhase = "ninja install";
+  buildPhase = "make";
+  installPhase = "make install";
 }

--- a/nix/clang_driver.patch
+++ b/nix/clang_driver.patch
@@ -1,8 +1,8 @@
 diff --git a/clang/lib/Driver/ToolChains/CommonArgs.cpp b/clang/lib/Driver/ToolChains/CommonArgs.cpp
-index 0601016c3b14..53aa54f73b79 100644
+index 7b2966f70bf6..e31145124c2d 100644
 --- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
 +++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
-@@ -2151,14 +2151,7 @@ enum class LibGccType { UnspecifiedLibGcc, StaticLibGcc, SharedLibGcc };
+@@ -1802,14 +1802,7 @@ enum class LibGccType { UnspecifiedLibGcc, StaticLibGcc, SharedLibGcc };
  
  static LibGccType getLibGccType(const ToolChain &TC, const Driver &D,
                                  const ArgList &Args) {
@@ -19,12 +19,12 @@ index 0601016c3b14..53aa54f73b79 100644
  
  // Gcc adds libgcc arguments in various ways:
 diff --git a/clang/lib/Driver/ToolChains/Gnu.cpp b/clang/lib/Driver/ToolChains/Gnu.cpp
-index 52c2ee90b1b2..1cce19951f6c 100644
+index cdd911af9a73..d629ff8abb27 100644
 --- a/clang/lib/Driver/ToolChains/Gnu.cpp
 +++ b/clang/lib/Driver/ToolChains/Gnu.cpp
-@@ -451,8 +451,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
-       if (IsPIE)
-         CmdArgs.push_back("-pie");
+@@ -467,8 +467,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+     if (!Args.hasArg(options::OPT_shared) && !IsStaticPIE &&
+         !Args.hasArg(options::OPT_r)) {
        CmdArgs.push_back("-dynamic-linker");
 -      CmdArgs.push_back(Args.MakeArgString(Twine(D.DyldPrefix) +
 -                                           ToolChain.getDynamicLinker(Args)));
@@ -32,7 +32,7 @@ index 52c2ee90b1b2..1cce19951f6c 100644
      }
    }
  
-@@ -474,10 +473,14 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+@@ -490,10 +489,12 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
            crt1 = "crt1.o";
        }
        if (crt1)
@@ -44,27 +44,10 @@ index 52c2ee90b1b2..1cce19951f6c 100644
      }
 +    CmdArgs.push_back("-L");
 +    CmdArgs.push_back("GLIBC_PATH_ABC123");
-+    CmdArgs.push_back("-L");
-+    CmdArgs.push_back("GCCLIB_PATH_ABC123");
  
      if (IsVE) {
        CmdArgs.push_back("-z");
-@@ -505,7 +508,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
-           crtbegin = isAndroid ? "crtbegin_dynamic.o" : "crtbeginS.o";
-         else
-           crtbegin = isAndroid ? "crtbegin_dynamic.o" : "crtbegin.o";
--        P = ToolChain.GetFilePath(crtbegin);
-+        P = std::string("GCCLIB_PATH_ABC123/") + crtbegin;
-       }
-       CmdArgs.push_back(Args.MakeArgString(P));
-     }
-@@ -663,12 +666,12 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
-             crtend = isAndroid ? "crtend_android.o" : "crtendS.o";
-           else
-             crtend = isAndroid ? "crtend_android.o" : "crtend.o";
--          P = ToolChain.GetFilePath(crtend);
-+          P = std::string("GCCLIB_PATH_ABC123/") + crtend;
-         }
+@@ -671,7 +672,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
          CmdArgs.push_back(Args.MakeArgString(P));
        }
        if (!isAndroid)
@@ -72,4 +55,3 @@ index 52c2ee90b1b2..1cce19951f6c 100644
 +        CmdArgs.push_back(Args.MakeArgString(Twine("GLIBC_PATH_ABC123/") + "crtn.o"));
      }
    }
- 

--- a/nix/compiler_rt.patch
+++ b/nix/compiler_rt.patch
@@ -1,8 +1,8 @@
 diff --git a/compiler-rt/lib/asan/CMakeLists.txt b/compiler-rt/lib/asan/CMakeLists.txt
-index fb3d74283a61..13534ddd8547 100644
+index 48d0e91052d7..323e0441daea 100644
 --- a/compiler-rt/lib/asan/CMakeLists.txt
 +++ b/compiler-rt/lib/asan/CMakeLists.txt
-@@ -209,22 +209,22 @@ if(APPLE)
+@@ -183,22 +183,22 @@ if(APPLE)
    add_weak_symbols("sanitizer_common" WEAK_SYMBOL_LINK_FLAGS)
    add_weak_symbols("xray" WEAK_SYMBOL_LINK_FLAGS)
  
@@ -41,10 +41,10 @@ index fb3d74283a61..13534ddd8547 100644
  
    add_compiler_rt_runtime(clang_rt.asan_static
      STATIC
-@@ -308,25 +308,25 @@ else()
+@@ -291,25 +291,25 @@ else()
+           SanitizerCommonWeakInterception)
      endif()
  
-     set(ASAN_DYNAMIC_WEAK_INTERCEPTION)
 -    add_compiler_rt_runtime(clang_rt.asan
 -      SHARED
 -      ARCHS ${arch}
@@ -87,10 +87,10 @@ index fb3d74283a61..13534ddd8547 100644
      if (SANITIZER_USE_SYMBOLS AND NOT ${arch} STREQUAL "i386")
        add_sanitizer_rt_symbols(clang_rt.asan_cxx
 diff --git a/compiler-rt/lib/hwasan/CMakeLists.txt b/compiler-rt/lib/hwasan/CMakeLists.txt
-index 086079c7536e..f029acf4bb24 100644
+index 6f75baa7e354..dbe1e69487b1 100644
 --- a/compiler-rt/lib/hwasan/CMakeLists.txt
 +++ b/compiler-rt/lib/hwasan/CMakeLists.txt
-@@ -204,32 +204,32 @@ function(add_hwasan_runtimes arch use_aliases)
+@@ -192,32 +192,32 @@ function(add_hwasan_runtimes arch use_aliases)
    endif()
  
  
@@ -150,47 +150,47 @@ index 086079c7536e..f029acf4bb24 100644
    if(SANITIZER_USE_SYMBOLS)
      add_sanitizer_rt_symbols(${hwasan_runtime}
 diff --git a/compiler-rt/lib/scudo/standalone/CMakeLists.txt b/compiler-rt/lib/scudo/standalone/CMakeLists.txt
-index dc700cec9bec..112d8d77c3ed 100644
+index 60092005cc33..72c2b83a2dad 100644
 --- a/compiler-rt/lib/scudo/standalone/CMakeLists.txt
 +++ b/compiler-rt/lib/scudo/standalone/CMakeLists.txt
-@@ -232,19 +232,19 @@ add_compiler_rt_runtime(clang_rt.scudo_standalone_cxx
-   DEPS ${SCUDO_DEPS}
-   PARENT_TARGET scudo_standalone)
+@@ -232,19 +232,19 @@ if(COMPILER_RT_HAS_SCUDO_STANDALONE)
+     DEPS ${SCUDO_DEPS}
+     PARENT_TARGET scudo_standalone)
  
--if(COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED)
--  add_compiler_rt_runtime(clang_rt.scudo_standalone
--    SHARED
--    ARCHS ${SCUDO_STANDALONE_SUPPORTED_ARCH}
--    SOURCES ${SCUDO_SOURCES} ${SCUDO_SOURCES_C_WRAPPERS} ${SCUDO_SOURCES_CXX_WRAPPERS}
--    ADDITIONAL_HEADERS ${SCUDO_HEADERS}
--    CFLAGS ${SCUDO_CFLAGS}
--    DEPS ${SCUDO_DEPS}
--    OBJECT_LIBS ${SCUDO_OBJECT_LIBS}
--    LINK_FLAGS ${SCUDO_LINK_FLAGS}
--    LINK_LIBS ${SCUDO_LINK_LIBS}
--    PARENT_TARGET scudo_standalone)
--endif()
-+# if(COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED)
-+#   add_compiler_rt_runtime(clang_rt.scudo_standalone
-+#     SHARED
-+#     ARCHS ${SCUDO_STANDALONE_SUPPORTED_ARCH}
-+#     SOURCES ${SCUDO_SOURCES} ${SCUDO_SOURCES_C_WRAPPERS} ${SCUDO_SOURCES_CXX_WRAPPERS}
-+#     ADDITIONAL_HEADERS ${SCUDO_HEADERS}
-+#     CFLAGS ${SCUDO_CFLAGS}
-+#     DEPS ${SCUDO_DEPS}
-+#     OBJECT_LIBS ${SCUDO_OBJECT_LIBS}
-+#     LINK_FLAGS ${SCUDO_LINK_FLAGS}
-+#     LINK_LIBS ${SCUDO_LINK_LIBS}
-+#     PARENT_TARGET scudo_standalone)
-+# endif()
+-  if(COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED)
+-    add_compiler_rt_runtime(clang_rt.scudo_standalone
+-      SHARED
+-      ARCHS ${SCUDO_STANDALONE_SUPPORTED_ARCH}
+-      SOURCES ${SCUDO_SOURCES} ${SCUDO_SOURCES_C_WRAPPERS} ${SCUDO_SOURCES_CXX_WRAPPERS}
+-      ADDITIONAL_HEADERS ${SCUDO_HEADERS}
+-      CFLAGS ${SCUDO_CFLAGS}
+-      DEPS ${SCUDO_DEPS}
+-      OBJECT_LIBS ${SCUDO_OBJECT_LIBS}
+-      LINK_FLAGS ${SCUDO_LINK_FLAGS}
+-      LINK_LIBS ${SCUDO_LINK_LIBS}
+-      PARENT_TARGET scudo_standalone)
+-  endif()
++  # if(COMPILER_RT_SCUDO_STANDALONE_BUILD_SHARED)
++  #   add_compiler_rt_runtime(clang_rt.scudo_standalone
++  #     SHARED
++  #     ARCHS ${SCUDO_STANDALONE_SUPPORTED_ARCH}
++  #     SOURCES ${SCUDO_SOURCES} ${SCUDO_SOURCES_C_WRAPPERS} ${SCUDO_SOURCES_CXX_WRAPPERS}
++  #     ADDITIONAL_HEADERS ${SCUDO_HEADERS}
++  #     CFLAGS ${SCUDO_CFLAGS}
++  #     DEPS ${SCUDO_DEPS}
++  #     OBJECT_LIBS ${SCUDO_OBJECT_LIBS}
++  #     LINK_FLAGS ${SCUDO_LINK_FLAGS}
++  #     LINK_LIBS ${SCUDO_LINK_LIBS}
++  #     PARENT_TARGET scudo_standalone)
++  # endif()
  
- if(COMPILER_RT_INCLUDE_TESTS)
-   add_subdirectory(tests)
+   add_subdirectory(benchmarks)
+   if(COMPILER_RT_INCLUDE_TESTS)
 diff --git a/compiler-rt/lib/ubsan/CMakeLists.txt b/compiler-rt/lib/ubsan/CMakeLists.txt
-index 5d45a53d02db..3de1500dcf77 100644
+index 3f1e12ed9ac6..33c371c5131b 100644
 --- a/compiler-rt/lib/ubsan/CMakeLists.txt
 +++ b/compiler-rt/lib/ubsan/CMakeLists.txt
-@@ -104,19 +104,19 @@ if(APPLE)
+@@ -103,19 +103,19 @@ if(APPLE)
      add_weak_symbols("ubsan" WEAK_SYMBOL_LINK_FLAGS)
      add_weak_symbols("sanitizer_common" WEAK_SYMBOL_LINK_FLAGS)
  
@@ -223,7 +223,7 @@ index 5d45a53d02db..3de1500dcf77 100644
  
      if (NOT APPLE)
        add_compiler_rt_runtime(clang_rt.ubsan
-@@ -225,23 +225,23 @@ else()
+@@ -245,23 +245,23 @@ else()
            APPEND PROPERTY
            OBJECT_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/clang_rt.ubsan_standalone-dynamic-${arch}.vers)
  

--- a/nix/cuda.nix
+++ b/nix/cuda.nix
@@ -7,9 +7,8 @@ with pkgs;
 pkgs.stdenvNoCC.mkDerivation {
   name = "cudatoolkit";
   src = fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/local_installers/cuda_12.6.0_560.28.03_linux.run";
-    hash = "sha256-MasEOU5psU3YZW4rRMKHfbGg6Jjf+KdUakxihDgQG5Q=";
-
+    url = "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run";
+    sha256 = "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb";
   };
   patches = [
     # patch host_defines.h to work with libc++


### PR DESCRIPTION
# Rationale for this change
The NVIDIA drivers required to run the CUDA toolkit 12.6 cannot be installed on Kubernetes clusters successfully. The version that can be installed is 550, which corresponds to [CUDA toolkit 12.4](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html). This PR downgrades the CUDA toolkit.

# What changes are included in this PR?
- Downgrade CUDA toolkit to 12.4.1 to work with Kubernetes pods.

# Are these changes tested?
Currently testing on latest