### PR TITLE
build: downgrade CUDA toolkit (PROOF-916)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.4.1-green?style=flat&logo=nvidia">
     </a>
   </a>
 
@@ -182,7 +182,7 @@ See the [example](./example) folder for some examples.
 Prerequisites:
 * `x86_64` Linux instance.
 * Nix with flake support (check out [The Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer))
-* Nvidia GPU capable of running CUDA 12.6 code.
+* Nvidia GPU capable of running CUDA 12.4.1 code.
 
 From your terminal, run the following command in the root of the source directory to set
 up a build environment. 

--- a/nix/cuda.nix
+++ b/nix/cuda.nix
@@ -7,9 +7,8 @@ with pkgs;
 pkgs.stdenvNoCC.mkDerivation {
   name = "cudatoolkit";
   src = fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/12.6.0/local_installers/cuda_12.6.0_560.28.03_linux.run";
-    hash = "sha256-MasEOU5psU3YZW4rRMKHfbGg6Jjf+KdUakxihDgQG5Q=";
-
+    url = "https://developer.download.nvidia.com/compute/cuda/12.4.1/local_installers/cuda_12.4.1_550.54.15_linux.run";
+    sha256 = "367d2299b3a4588ab487a6d27276ca5d9ead6e394904f18bccb9e12433b9c4fb";
   };
   patches = [
     # patch host_defines.h to work with libc++

--- a/sxt/algorithm/block/BUILD
+++ b/sxt/algorithm/block/BUILD
@@ -10,8 +10,8 @@ sxt_cc_component(
         "//sxt/memory/resource:managed_device_resource",
     ],
     deps = [
+        "//sxt/base/device:cub",
         "//sxt/base/device:synchronization",
         "//sxt/base/macro:cuda_callable",
-        "@local_cuda//:cub",
     ],
 )

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -16,6 +16,26 @@
  */
 #pragma once
 
+/*
+ * This is a workaround to define _VSTD before including cub/cub.cuh.
+ * It should be removed when we can upgrade to a newer version of CUDA.
+ *
+ * We need to define _VSTD in order to use the clang version defined in 
+ * clang.nix and the CUDA toolkit version defined in cuda.nix.
+ * 
+ * _VSTD was deprecated and removed from the LLVM truck.
+ * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
+ * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
+ * 
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
+ * cluster currently cannot install a driver above 550. 
+ * 
+ * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ */
+#include <__config>
+#define _VSTD std::_LIBCPP_ABI_NAMESPACE
+_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+
 #include "cub/cub.cuh"
 #include "sxt/base/macro/cuda_callable.h"
 

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -34,9 +34,7 @@
  * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
  */
 #include <__config>
-
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 
 #include "cub/cub.cuh"
 #include "sxt/base/macro/cuda_callable.h"

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -16,28 +16,7 @@
  */
 #pragma once
 
-/*
- * This is a workaround to define _VSTD before including cub/cub.cuh.
- * It should be removed when we can upgrade to a newer version of CUDA.
- *
- * We need to define _VSTD in order to use the clang version defined in
- * clang.nix and the CUDA toolkit version defined in cuda.nix.
- *
- * _VSTD was deprecated and removed from the LLVM truck.
- * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
- * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- *
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
- * cluster currently cannot install a driver above 550.
- *
- * See CUDA toolkit and driver support:
- * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
- */
-#include <__config>
-
-#define _VSTD std::_LIBCPP_ABI_NAMESPACE
-
-#include "cub/cub.cuh"
+#include "sxt/base/device/cub.h"
 #include "sxt/base/macro/cuda_callable.h"
 
 namespace sxt::algbk {

--- a/sxt/algorithm/block/runlength_count.h
+++ b/sxt/algorithm/block/runlength_count.h
@@ -34,67 +34,68 @@
  * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
  */
 #include <__config>
+
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
 
 #include "cub/cub.cuh"
 #include "sxt/base/macro/cuda_callable.h"
 
-    namespace sxt::algbk {
-  //--------------------------------------------------------------------------------------------------
-  // runlength_count
-  //--------------------------------------------------------------------------------------------------
-  /**
-   * This is adapted from block_histogram_sort in CUB. See
-   *   https://github.com/NVIDIA/cccl/blob/a51b1f8c75f8e577eeccc74b45f1ff16a2727265/cub/cub/block/specializations/block_histogram_sort.cuh
-   */
-  template <class T, class CounterT, unsigned NumThreads, unsigned NumBins> class runlength_count {
-    using Discontinuity = cub::BlockDiscontinuity<T, NumThreads>;
+namespace sxt::algbk {
+//--------------------------------------------------------------------------------------------------
+// runlength_count
+//--------------------------------------------------------------------------------------------------
+/**
+ * This is adapted from block_histogram_sort in CUB. See
+ *   https://github.com/NVIDIA/cccl/blob/a51b1f8c75f8e577eeccc74b45f1ff16a2727265/cub/cub/block/specializations/block_histogram_sort.cuh
+ */
+template <class T, class CounterT, unsigned NumThreads, unsigned NumBins> class runlength_count {
+  using Discontinuity = cub::BlockDiscontinuity<T, NumThreads>;
 
-  public:
-    struct temp_storage {
-      typename Discontinuity::TempStorage discontinuity;
-      CounterT run_begin[NumBins];
-      CounterT run_end[NumBins];
-    };
-
-    CUDA_CALLABLE explicit runlength_count(temp_storage& storage) noexcept
-        : storage_{storage}, discontinuity_{storage.discontinuity} {}
-
-    /**
-     * If items holds sorted items across threads in a block, count and return a
-     * pointer to a table of the items' run lengths.
-     */
-    template <unsigned ItemsPerThread>
-    CUDA_CALLABLE CounterT* count(T (&items)[ItemsPerThread]) noexcept {
-      auto thread_id = threadIdx.x;
-      for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
-        storage_.run_begin[i] = NumThreads * ItemsPerThread;
-        storage_.run_end[i] = NumThreads * ItemsPerThread;
-      }
-      int flags[ItemsPerThread];
-      auto flag_op = [&storage = storage_](T a, T b, int b_index) noexcept {
-        if (a != b) {
-          storage.run_begin[b] = static_cast<CounterT>(b_index);
-          storage.run_end[a] = static_cast<CounterT>(b_index);
-          return true;
-        } else {
-          return false;
-        }
-      };
-      __syncthreads();
-      discontinuity_.FlagHeads(flags, items, flag_op);
-      if (thread_id == 0) {
-        storage_.run_begin[items[0]] = 0;
-      }
-      __syncthreads();
-      for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
-        storage_.run_end[i] -= storage_.run_begin[i];
-      }
-      return storage_.run_end;
-    }
-
-  private:
-    temp_storage& storage_;
-    Discontinuity discontinuity_;
+public:
+  struct temp_storage {
+    typename Discontinuity::TempStorage discontinuity;
+    CounterT run_begin[NumBins];
+    CounterT run_end[NumBins];
   };
+
+  CUDA_CALLABLE explicit runlength_count(temp_storage& storage) noexcept
+      : storage_{storage}, discontinuity_{storage.discontinuity} {}
+
+  /**
+   * If items holds sorted items across threads in a block, count and return a
+   * pointer to a table of the items' run lengths.
+   */
+  template <unsigned ItemsPerThread>
+  CUDA_CALLABLE CounterT* count(T (&items)[ItemsPerThread]) noexcept {
+    auto thread_id = threadIdx.x;
+    for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
+      storage_.run_begin[i] = NumThreads * ItemsPerThread;
+      storage_.run_end[i] = NumThreads * ItemsPerThread;
+    }
+    int flags[ItemsPerThread];
+    auto flag_op = [&storage = storage_](T a, T b, int b_index) noexcept {
+      if (a != b) {
+        storage.run_begin[b] = static_cast<CounterT>(b_index);
+        storage.run_end[a] = static_cast<CounterT>(b_index);
+        return true;
+      } else {
+        return false;
+      }
+    };
+    __syncthreads();
+    discontinuity_.FlagHeads(flags, items, flag_op);
+    if (thread_id == 0) {
+      storage_.run_begin[items[0]] = 0;
+    }
+    __syncthreads();
+    for (unsigned i = thread_id; i < NumBins; i += NumThreads) {
+      storage_.run_end[i] -= storage_.run_begin[i];
+    }
+    return storage_.run_end;
+  }
+
+private:
+  temp_storage& storage_;
+  Discontinuity discontinuity_;
+};
 } // namespace sxt::algbk

--- a/sxt/base/device/BUILD
+++ b/sxt/base/device/BUILD
@@ -15,6 +15,14 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "cub",
+    with_test = False,
+    deps = [
+        "@local_cuda//:cub",
+    ],
+)
+
+sxt_cc_component(
     name = "pointer_attributes",
     with_test = False,
     deps = [

--- a/sxt/base/device/cub.cc
+++ b/sxt/base/device/cub.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/base/device/cub.h"

--- a/sxt/base/device/cub.h
+++ b/sxt/base/device/cub.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+/*
+ * This is a workaround to define _VSTD before including cub/cub.cuh.
+ * It should be removed when we can upgrade to a newer version of CUDA.
+ *
+ * We need to define _VSTD in order to use the clang version defined in
+ * clang.nix and the CUDA toolkit version defined in cuda.nix.
+ *
+ * _VSTD was deprecated and removed from the LLVM truck.
+ * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
+ * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
+ *
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
+ * cluster currently cannot install a driver above 550.
+ *
+ * See CUDA toolkit and driver support:
+ * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ */
+#include <__config>
+
+#define _VSTD std::_LIBCPP_ABI_NAMESPACE
+
+#include "cub/cub.cuh"

--- a/sxt/multiexp/base/BUILD
+++ b/sxt/multiexp/base/BUILD
@@ -46,8 +46,8 @@ sxt_cc_component(
 sxt_cc_component(
     name = "scalar_array",
     impl_deps = [
-        "@local_cuda//:cub",
         "//sxt/base/container:span_utility",
+        "//sxt/base/device:cub",
         "//sxt/base/device:memory_utility",
         "//sxt/base/device:stream",
         "//sxt/base/error:assert",

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -18,6 +18,26 @@
 
 #include <vector>
 
+/*
+ * This is a workaround to define _VSTD before including cub/cub.cuh.
+ * It should be removed when we can upgrade to a newer version of CUDA.
+ *
+ * We need to define _VSTD in order to use the clang version defined in 
+ * clang.nix and the CUDA toolkit version defined in cuda.nix.
+ * 
+ * _VSTD was deprecated and removed from the LLVM truck.
+ * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
+ * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
+ * 
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
+ * cluster currently cannot install a driver above 550. 
+ * 
+ * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ */
+#include <__config>
+#define _VSTD std::_LIBCPP_ABI_NAMESPACE
+_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+
 #include "cub/cub.cuh"
 #include "sxt/base/container/span_utility.h"
 #include "sxt/base/device/memory_utility.h"

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -22,17 +22,18 @@
  * This is a workaround to define _VSTD before including cub/cub.cuh.
  * It should be removed when we can upgrade to a newer version of CUDA.
  *
- * We need to define _VSTD in order to use the clang version defined in 
+ * We need to define _VSTD in order to use the clang version defined in
  * clang.nix and the CUDA toolkit version defined in cuda.nix.
- * 
+ *
  * _VSTD was deprecated and removed from the LLVM truck.
  * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
  * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- * 
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
- * cluster currently cannot install a driver above 550. 
- * 
- * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ *
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
+ * cluster currently cannot install a driver above 550.
+ *
+ * See CUDA toolkit and driver support:
+ * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
@@ -50,100 +51,100 @@ _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/memory/resource/async_device_resource.h"
 
-namespace sxt::mtxb {
-//--------------------------------------------------------------------------------------------------
-// scalar_blob
-//--------------------------------------------------------------------------------------------------
-namespace {
-template <unsigned NumBytes> struct scalar_blob {
-  uint8_t data[NumBytes];
-};
-} // namespace
+    namespace sxt::mtxb {
+  //--------------------------------------------------------------------------------------------------
+  // scalar_blob
+  //--------------------------------------------------------------------------------------------------
+  namespace {
+  template <unsigned NumBytes> struct scalar_blob {
+    uint8_t data[NumBytes];
+  };
+  } // namespace
 
-//--------------------------------------------------------------------------------------------------
-// transpose_kernel
-//--------------------------------------------------------------------------------------------------
-template <unsigned NumBytes>
-static __global__ void transpose_kernel(uint8_t* __restrict__ dst,
-                                        const scalar_blob<NumBytes>* __restrict__ src,
-                                        unsigned n) noexcept {
-  using Scalar = scalar_blob<NumBytes>;
+  //--------------------------------------------------------------------------------------------------
+  // transpose_kernel
+  //--------------------------------------------------------------------------------------------------
+  template <unsigned NumBytes>
+  static __global__ void transpose_kernel(uint8_t* __restrict__ dst,
+                                          const scalar_blob<NumBytes>* __restrict__ src,
+                                          unsigned n) noexcept {
+    using Scalar = scalar_blob<NumBytes>;
 
-  auto byte_index = threadIdx.x;
-  auto tile_index = blockIdx.x;
-  auto output_index = blockIdx.y;
-  auto num_tiles = gridDim.x;
-  auto n_per_tile = basn::divide_up(basn::divide_up(n, NumBytes), num_tiles) * NumBytes;
+    auto byte_index = threadIdx.x;
+    auto tile_index = blockIdx.x;
+    auto output_index = blockIdx.y;
+    auto num_tiles = gridDim.x;
+    auto n_per_tile = basn::divide_up(basn::divide_up(n, NumBytes), num_tiles) * NumBytes;
 
-  auto first = tile_index * n_per_tile;
-  auto m = min(n_per_tile, n - first);
+    auto first = tile_index * n_per_tile;
+    auto m = min(n_per_tile, n - first);
 
-  // adjust pointers
-  src += first;
-  src += output_index * n;
-  dst += byte_index * n + first;
-  dst += output_index * NumBytes * n;
+    // adjust pointers
+    src += first;
+    src += output_index * n;
+    dst += byte_index * n + first;
+    dst += output_index * NumBytes * n;
 
-  // set up algorithm
-  using BlockExchange = cub::BlockExchange<uint8_t, NumBytes, NumBytes>;
-  __shared__ typename BlockExchange::TempStorage temp_storage;
+    // set up algorithm
+    using BlockExchange = cub::BlockExchange<uint8_t, NumBytes, NumBytes>;
+    __shared__ typename BlockExchange::TempStorage temp_storage;
 
-  // transpose
-  Scalar s;
-  unsigned out_first = 0;
-  for (unsigned i = byte_index; i < n_per_tile; i += NumBytes) {
-    if (i < m) {
-      s = src[i];
-    }
-    BlockExchange(temp_storage).StripedToBlocked(s.data);
-    __syncthreads();
-    for (unsigned j = 0; j < NumBytes; ++j) {
-      auto out_index = out_first + j;
-      if (out_index < m) {
-        dst[out_index] = s.data[j];
+    // transpose
+    Scalar s;
+    unsigned out_first = 0;
+    for (unsigned i = byte_index; i < n_per_tile; i += NumBytes) {
+      if (i < m) {
+        s = src[i];
       }
+      BlockExchange(temp_storage).StripedToBlocked(s.data);
+      __syncthreads();
+      for (unsigned j = 0; j < NumBytes; ++j) {
+        auto out_index = out_first + j;
+        if (out_index < m) {
+          dst[out_index] = s.data[j];
+        }
+      }
+      out_first += NumBytes;
+      __syncthreads();
     }
-    out_first += NumBytes;
-    __syncthreads();
   }
-}
 
-//--------------------------------------------------------------------------------------------------
-// transpose_scalars_to_device
-//--------------------------------------------------------------------------------------------------
-xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
-                                           basct::cspan<const uint8_t*> scalars,
-                                           unsigned element_num_bytes, unsigned n) noexcept {
-  auto num_outputs = static_cast<unsigned>(scalars.size());
-  if (n == 0 || num_outputs == 0) {
-    co_return;
-  }
-  SXT_DEBUG_ASSERT(
-      // clang-format off
+  //--------------------------------------------------------------------------------------------------
+  // transpose_scalars_to_device
+  //--------------------------------------------------------------------------------------------------
+  xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
+                                             basct::cspan<const uint8_t*> scalars,
+                                             unsigned element_num_bytes, unsigned n) noexcept {
+    auto num_outputs = static_cast<unsigned>(scalars.size());
+    if (n == 0 || num_outputs == 0) {
+      co_return;
+    }
+    SXT_DEBUG_ASSERT(
+        // clang-format off
       array.size() == num_outputs * element_num_bytes * n &&
       basdv::is_active_device_pointer(array.data()) &&
       basdv::is_host_pointer(scalars[0])
-      // clang-format on
-  );
-  basdv::stream stream;
-  memr::async_device_resource resource{stream};
-  memmg::managed_array<uint8_t> array_p{array.size(), &resource};
-  auto num_bytes_per_output = element_num_bytes * n;
-  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
-    basdv::async_copy_host_to_device(
-        basct::subspan(array_p, output_index * num_bytes_per_output, num_bytes_per_output),
-        basct::cspan<uint8_t>{scalars[output_index], num_bytes_per_output}, stream);
+        // clang-format on
+    );
+    basdv::stream stream;
+    memr::async_device_resource resource{stream};
+    memmg::managed_array<uint8_t> array_p{array.size(), &resource};
+    auto num_bytes_per_output = element_num_bytes * n;
+    for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+      basdv::async_copy_host_to_device(
+          basct::subspan(array_p, output_index * num_bytes_per_output, num_bytes_per_output),
+          basct::cspan<uint8_t>{scalars[output_index], num_bytes_per_output}, stream);
+    }
+    auto num_tiles = std::min(basn::divide_up(n, num_outputs * element_num_bytes), 64u);
+    auto num_bytes_log2 = basn::ceil_log2(element_num_bytes);
+    basn::constexpr_switch<6>(
+        num_bytes_log2,
+        [&]<unsigned LogNumBytes>(std::integral_constant<unsigned, LogNumBytes>) noexcept {
+          constexpr auto NumBytes = 1u << LogNumBytes;
+          SXT_DEBUG_ASSERT(NumBytes == element_num_bytes);
+          transpose_kernel<NumBytes><<<dim3(num_tiles, num_outputs, 1), NumBytes, 0, stream>>>(
+              array.data(), reinterpret_cast<scalar_blob<NumBytes>*>(array_p.data()), n);
+        });
+    co_await xendv::await_stream(std::move(stream));
   }
-  auto num_tiles = std::min(basn::divide_up(n, num_outputs * element_num_bytes), 64u);
-  auto num_bytes_log2 = basn::ceil_log2(element_num_bytes);
-  basn::constexpr_switch<6>(
-      num_bytes_log2,
-      [&]<unsigned LogNumBytes>(std::integral_constant<unsigned, LogNumBytes>) noexcept {
-        constexpr auto NumBytes = 1u << LogNumBytes;
-        SXT_DEBUG_ASSERT(NumBytes == element_num_bytes);
-        transpose_kernel<NumBytes><<<dim3(num_tiles, num_outputs, 1), NumBytes, 0, stream>>>(
-            array.data(), reinterpret_cast<scalar_blob<NumBytes>*>(array_p.data()), n);
-      });
-  co_await xendv::await_stream(std::move(stream));
-}
 } // namespace sxt::mtxb

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -18,28 +18,8 @@
 
 #include <vector>
 
-/*
- * This is a workaround to define _VSTD before including cub/cub.cuh.
- * It should be removed when we can upgrade to a newer version of CUDA.
- *
- * We need to define _VSTD in order to use the clang version defined in
- * clang.nix and the CUDA toolkit version defined in cuda.nix.
- *
- * _VSTD was deprecated and removed from the LLVM truck.
- * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
- * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- *
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
- * cluster currently cannot install a driver above 550.
- *
- * See CUDA toolkit and driver support:
- * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
- */
-#include <__config>
-#define _VSTD std::_LIBCPP_ABI_NAMESPACE
-
-#include "cub/cub.cuh"
 #include "sxt/base/container/span_utility.h"
+#include "sxt/base/device/cub.h"
 #include "sxt/base/device/memory_utility.h"
 #include "sxt/base/device/stream.h"
 #include "sxt/base/num/ceil_log2.h"

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -50,100 +50,100 @@
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/memory/resource/async_device_resource.h"
 
-    namespace sxt::mtxb {
-  //--------------------------------------------------------------------------------------------------
-  // scalar_blob
-  //--------------------------------------------------------------------------------------------------
-  namespace {
-  template <unsigned NumBytes> struct scalar_blob {
-    uint8_t data[NumBytes];
-  };
-  } // namespace
+namespace sxt::mtxb {
+//--------------------------------------------------------------------------------------------------
+// scalar_blob
+//--------------------------------------------------------------------------------------------------
+namespace {
+template <unsigned NumBytes> struct scalar_blob {
+  uint8_t data[NumBytes];
+};
+} // namespace
 
-  //--------------------------------------------------------------------------------------------------
-  // transpose_kernel
-  //--------------------------------------------------------------------------------------------------
-  template <unsigned NumBytes>
-  static __global__ void transpose_kernel(uint8_t* __restrict__ dst,
-                                          const scalar_blob<NumBytes>* __restrict__ src,
-                                          unsigned n) noexcept {
-    using Scalar = scalar_blob<NumBytes>;
+//--------------------------------------------------------------------------------------------------
+// transpose_kernel
+//--------------------------------------------------------------------------------------------------
+template <unsigned NumBytes>
+static __global__ void transpose_kernel(uint8_t* __restrict__ dst,
+                                        const scalar_blob<NumBytes>* __restrict__ src,
+                                        unsigned n) noexcept {
+  using Scalar = scalar_blob<NumBytes>;
 
-    auto byte_index = threadIdx.x;
-    auto tile_index = blockIdx.x;
-    auto output_index = blockIdx.y;
-    auto num_tiles = gridDim.x;
-    auto n_per_tile = basn::divide_up(basn::divide_up(n, NumBytes), num_tiles) * NumBytes;
+  auto byte_index = threadIdx.x;
+  auto tile_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+  auto num_tiles = gridDim.x;
+  auto n_per_tile = basn::divide_up(basn::divide_up(n, NumBytes), num_tiles) * NumBytes;
 
-    auto first = tile_index * n_per_tile;
-    auto m = min(n_per_tile, n - first);
+  auto first = tile_index * n_per_tile;
+  auto m = min(n_per_tile, n - first);
 
-    // adjust pointers
-    src += first;
-    src += output_index * n;
-    dst += byte_index * n + first;
-    dst += output_index * NumBytes * n;
+  // adjust pointers
+  src += first;
+  src += output_index * n;
+  dst += byte_index * n + first;
+  dst += output_index * NumBytes * n;
 
-    // set up algorithm
-    using BlockExchange = cub::BlockExchange<uint8_t, NumBytes, NumBytes>;
-    __shared__ typename BlockExchange::TempStorage temp_storage;
+  // set up algorithm
+  using BlockExchange = cub::BlockExchange<uint8_t, NumBytes, NumBytes>;
+  __shared__ typename BlockExchange::TempStorage temp_storage;
 
-    // transpose
-    Scalar s;
-    unsigned out_first = 0;
-    for (unsigned i = byte_index; i < n_per_tile; i += NumBytes) {
-      if (i < m) {
-        s = src[i];
-      }
-      BlockExchange(temp_storage).StripedToBlocked(s.data);
-      __syncthreads();
-      for (unsigned j = 0; j < NumBytes; ++j) {
-        auto out_index = out_first + j;
-        if (out_index < m) {
-          dst[out_index] = s.data[j];
-        }
-      }
-      out_first += NumBytes;
-      __syncthreads();
+  // transpose
+  Scalar s;
+  unsigned out_first = 0;
+  for (unsigned i = byte_index; i < n_per_tile; i += NumBytes) {
+    if (i < m) {
+      s = src[i];
     }
+    BlockExchange(temp_storage).StripedToBlocked(s.data);
+    __syncthreads();
+    for (unsigned j = 0; j < NumBytes; ++j) {
+      auto out_index = out_first + j;
+      if (out_index < m) {
+        dst[out_index] = s.data[j];
+      }
+    }
+    out_first += NumBytes;
+    __syncthreads();
   }
+}
 
-  //--------------------------------------------------------------------------------------------------
-  // transpose_scalars_to_device
-  //--------------------------------------------------------------------------------------------------
-  xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
-                                             basct::cspan<const uint8_t*> scalars,
-                                             unsigned element_num_bytes, unsigned n) noexcept {
-    auto num_outputs = static_cast<unsigned>(scalars.size());
-    if (n == 0 || num_outputs == 0) {
-      co_return;
-    }
-    SXT_DEBUG_ASSERT(
-        // clang-format off
+//--------------------------------------------------------------------------------------------------
+// transpose_scalars_to_device
+//--------------------------------------------------------------------------------------------------
+xena::future<> transpose_scalars_to_device(basct::span<uint8_t> array,
+                                           basct::cspan<const uint8_t*> scalars,
+                                           unsigned element_num_bytes, unsigned n) noexcept {
+  auto num_outputs = static_cast<unsigned>(scalars.size());
+  if (n == 0 || num_outputs == 0) {
+    co_return;
+  }
+  SXT_DEBUG_ASSERT(
+      // clang-format off
       array.size() == num_outputs * element_num_bytes * n &&
       basdv::is_active_device_pointer(array.data()) &&
       basdv::is_host_pointer(scalars[0])
-        // clang-format on
-    );
-    basdv::stream stream;
-    memr::async_device_resource resource{stream};
-    memmg::managed_array<uint8_t> array_p{array.size(), &resource};
-    auto num_bytes_per_output = element_num_bytes * n;
-    for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
-      basdv::async_copy_host_to_device(
-          basct::subspan(array_p, output_index * num_bytes_per_output, num_bytes_per_output),
-          basct::cspan<uint8_t>{scalars[output_index], num_bytes_per_output}, stream);
-    }
-    auto num_tiles = std::min(basn::divide_up(n, num_outputs * element_num_bytes), 64u);
-    auto num_bytes_log2 = basn::ceil_log2(element_num_bytes);
-    basn::constexpr_switch<6>(
-        num_bytes_log2,
-        [&]<unsigned LogNumBytes>(std::integral_constant<unsigned, LogNumBytes>) noexcept {
-          constexpr auto NumBytes = 1u << LogNumBytes;
-          SXT_DEBUG_ASSERT(NumBytes == element_num_bytes);
-          transpose_kernel<NumBytes><<<dim3(num_tiles, num_outputs, 1), NumBytes, 0, stream>>>(
-              array.data(), reinterpret_cast<scalar_blob<NumBytes>*>(array_p.data()), n);
-        });
-    co_await xendv::await_stream(std::move(stream));
+      // clang-format on
+  );
+  basdv::stream stream;
+  memr::async_device_resource resource{stream};
+  memmg::managed_array<uint8_t> array_p{array.size(), &resource};
+  auto num_bytes_per_output = element_num_bytes * n;
+  for (size_t output_index = 0; output_index < num_outputs; ++output_index) {
+    basdv::async_copy_host_to_device(
+        basct::subspan(array_p, output_index * num_bytes_per_output, num_bytes_per_output),
+        basct::cspan<uint8_t>{scalars[output_index], num_bytes_per_output}, stream);
   }
+  auto num_tiles = std::min(basn::divide_up(n, num_outputs * element_num_bytes), 64u);
+  auto num_bytes_log2 = basn::ceil_log2(element_num_bytes);
+  basn::constexpr_switch<6>(
+      num_bytes_log2,
+      [&]<unsigned LogNumBytes>(std::integral_constant<unsigned, LogNumBytes>) noexcept {
+        constexpr auto NumBytes = 1u << LogNumBytes;
+        SXT_DEBUG_ASSERT(NumBytes == element_num_bytes);
+        transpose_kernel<NumBytes><<<dim3(num_tiles, num_outputs, 1), NumBytes, 0, stream>>>(
+            array.data(), reinterpret_cast<scalar_blob<NumBytes>*>(array_p.data()), n);
+      });
+  co_await xendv::await_stream(std::move(stream));
+}
 } // namespace sxt::mtxb

--- a/sxt/multiexp/base/scalar_array.cc
+++ b/sxt/multiexp/base/scalar_array.cc
@@ -37,7 +37,6 @@
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 
 #include "cub/cub.cuh"
 #include "sxt/base/container/span_utility.h"

--- a/sxt/multiexp/bucket_method2/BUILD
+++ b/sxt/multiexp/bucket_method2/BUILD
@@ -93,8 +93,8 @@ sxt_cc_component(
     deps = [
         ":constants",
         "//sxt/algorithm/block:runlength_count",
+        "//sxt/base/device:cub",
         "//sxt/base/device:stream",
-        "@local_cuda//:cub",
     ],
 )
 

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -16,28 +16,8 @@
  */
 #include "sxt/multiexp/bucket_method2/multiproduct_table.h"
 
-/*
- * This is a workaround to define _VSTD before including cub/cub.cuh.
- * It should be removed when we can upgrade to a newer version of CUDA.
- *
- * We need to define _VSTD in order to use the clang version defined in
- * clang.nix and the CUDA toolkit version defined in cuda.nix.
- *
- * _VSTD was deprecated and removed from the LLVM truck.
- * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
- * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- *
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
- * cluster currently cannot install a driver above 550.
- *
- * See CUDA toolkit and driver support:
- * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
- */
-#include <__config>
-#define _VSTD std::_LIBCPP_ABI_NAMESPACE
-
-#include "cub/cub.cuh"
 #include "sxt/algorithm/iteration/for_each.h"
+#include "sxt/base/device/cub.h"
 #include "sxt/base/device/memory_utility.h"
 #include "sxt/base/device/stream.h"
 #include "sxt/base/log/log.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -35,7 +35,6 @@
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 
 #include "cub/cub.cuh"
 #include "sxt/algorithm/iteration/for_each.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -16,6 +16,26 @@
  */
 #include "sxt/multiexp/bucket_method2/multiproduct_table.h"
 
+/*
+ * This is a workaround to define _VSTD before including cub/cub.cuh.
+ * It should be removed when we can upgrade to a newer version of CUDA.
+ *
+ * We need to define _VSTD in order to use the clang version defined in 
+ * clang.nix and the CUDA toolkit version defined in cuda.nix.
+ * 
+ * _VSTD was deprecated and removed from the LLVM truck.
+ * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
+ * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
+ * 
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
+ * cluster currently cannot install a driver above 550. 
+ * 
+ * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ */
+#include <__config>
+#define _VSTD std::_LIBCPP_ABI_NAMESPACE
+_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+
 #include "cub/cub.cuh"
 #include "sxt/algorithm/iteration/for_each.h"
 #include "sxt/base/device/memory_utility.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -20,17 +20,18 @@
  * This is a workaround to define _VSTD before including cub/cub.cuh.
  * It should be removed when we can upgrade to a newer version of CUDA.
  *
- * We need to define _VSTD in order to use the clang version defined in 
+ * We need to define _VSTD in order to use the clang version defined in
  * clang.nix and the CUDA toolkit version defined in cuda.nix.
- * 
+ *
  * _VSTD was deprecated and removed from the LLVM truck.
  * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
  * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- * 
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
- * cluster currently cannot install a driver above 550. 
- * 
- * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ *
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
+ * cluster currently cannot install a driver above 550.
+ *
+ * See CUDA toolkit and driver support:
+ * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
@@ -50,56 +51,55 @@ _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 #include "sxt/multiexp/base/scalar_array.h"
 #include "sxt/multiexp/bucket_method2/multiproduct_table_kernel.h"
 
-namespace sxt::mtxbk2 {
-//--------------------------------------------------------------------------------------------------
-// make_multiproduct_table
-//--------------------------------------------------------------------------------------------------
-xena::future<> make_multiproduct_table(basct::span<uint16_t> bucket_prefix_counts,
-                                       basct::span<uint16_t> indexes,
-                                       basct::cspan<const uint8_t*> scalars,
-                                       unsigned element_num_bytes, unsigned bit_width,
-                                       unsigned n) noexcept {
-  auto num_outputs = scalars.size();
-  auto num_buckets_per_digit = (1u << bit_width) - 1u;
-  auto num_digits = basn::divide_up(element_num_bytes * 8u, bit_width);
-  auto num_buckets_per_output = num_buckets_per_digit * num_digits;
-  auto num_buckets_total = num_buckets_per_output * num_outputs;
-  SXT_DEBUG_ASSERT(bucket_prefix_counts.size() == num_buckets_total &&
-                   indexes.size() == num_outputs * num_digits * n &&
-                   basdv::is_active_device_pointer(bucket_prefix_counts.data()) &&
-                   basdv::is_active_device_pointer(indexes.data()));
+    namespace sxt::mtxbk2 {
+  //--------------------------------------------------------------------------------------------------
+  // make_multiproduct_table
+  //--------------------------------------------------------------------------------------------------
+  xena::future<> make_multiproduct_table(
+      basct::span<uint16_t> bucket_prefix_counts, basct::span<uint16_t> indexes,
+      basct::cspan<const uint8_t*> scalars, unsigned element_num_bytes, unsigned bit_width,
+      unsigned n) noexcept {
+    auto num_outputs = scalars.size();
+    auto num_buckets_per_digit = (1u << bit_width) - 1u;
+    auto num_digits = basn::divide_up(element_num_bytes * 8u, bit_width);
+    auto num_buckets_per_output = num_buckets_per_digit * num_digits;
+    auto num_buckets_total = num_buckets_per_output * num_outputs;
+    SXT_DEBUG_ASSERT(bucket_prefix_counts.size() == num_buckets_total &&
+                     indexes.size() == num_outputs * num_digits * n &&
+                     basdv::is_active_device_pointer(bucket_prefix_counts.data()) &&
+                     basdv::is_active_device_pointer(indexes.data()));
 
-  // transpose scalars
-  basl::info("copying scalars to device");
-  memmg::managed_array<uint8_t> bytes{num_outputs * n * element_num_bytes,
-                                      memr::get_device_resource()};
-  co_await mtxb::transpose_scalars_to_device(bytes, scalars, element_num_bytes, n);
+    // transpose scalars
+    basl::info("copying scalars to device");
+    memmg::managed_array<uint8_t> bytes{num_outputs * n * element_num_bytes,
+                                        memr::get_device_resource()};
+    co_await mtxb::transpose_scalars_to_device(bytes, scalars, element_num_bytes, n);
 
-  // compute buckets
-  basl::info("computing multiproduct decomposition");
-  SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
-  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "limit length for now");
-  basdv::stream stream;
-  fit_multiproduct_table_kernel(
-      [&]<unsigned NumThreads, unsigned ItemsPerThread>(
-          std::integral_constant<unsigned, NumThreads>,
-          std::integral_constant<unsigned, ItemsPerThread>) noexcept {
-        multiproduct_table_kernel<NumThreads, ItemsPerThread, 8>
-            <<<dim3(num_digits, num_outputs, 1), NumThreads, 0, stream>>>(
-                bucket_prefix_counts.data(), indexes.data(), bytes.data(), n);
-      },
-      n);
+    // compute buckets
+    basl::info("computing multiproduct decomposition");
+    SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
+    SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "limit length for now");
+    basdv::stream stream;
+    fit_multiproduct_table_kernel(
+        [&]<unsigned NumThreads, unsigned ItemsPerThread>(
+            std::integral_constant<unsigned, NumThreads>,
+            std::integral_constant<unsigned, ItemsPerThread>) noexcept {
+          multiproduct_table_kernel<NumThreads, ItemsPerThread, 8>
+              <<<dim3(num_digits, num_outputs, 1), NumThreads, 0, stream>>>(
+                  bucket_prefix_counts.data(), indexes.data(), bytes.data(), n);
+        },
+        n);
 
-  // prefix sum
-  auto f = [bucket_prefix_counts = bucket_prefix_counts.data(),
-            num_buckets_per_digit = num_buckets_per_digit] __host__
-           __device__(unsigned /*num_digits_total*/, unsigned index) noexcept {
-             auto counts = bucket_prefix_counts + index * num_buckets_per_digit;
-             for (unsigned i = 1; i < num_buckets_per_digit; ++i) {
-               counts[i] += counts[i - 1u];
-             }
-           };
-  algi::launch_for_each_kernel(stream, f, num_digits * num_outputs);
-  co_await xendv::await_stream(stream);
-}
+    // prefix sum
+    auto f = [bucket_prefix_counts = bucket_prefix_counts.data(),
+              num_buckets_per_digit = num_buckets_per_digit] __host__
+             __device__(unsigned /*num_digits_total*/, unsigned index) noexcept {
+               auto counts = bucket_prefix_counts + index * num_buckets_per_digit;
+               for (unsigned i = 1; i < num_buckets_per_digit; ++i) {
+                 counts[i] += counts[i - 1u];
+               }
+             };
+    algi::launch_for_each_kernel(stream, f, num_digits * num_outputs);
+    co_await xendv::await_stream(stream);
+  }
 } // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table.cc
+++ b/sxt/multiexp/bucket_method2/multiproduct_table.cc
@@ -50,55 +50,56 @@
 #include "sxt/multiexp/base/scalar_array.h"
 #include "sxt/multiexp/bucket_method2/multiproduct_table_kernel.h"
 
-    namespace sxt::mtxbk2 {
-  //--------------------------------------------------------------------------------------------------
-  // make_multiproduct_table
-  //--------------------------------------------------------------------------------------------------
-  xena::future<> make_multiproduct_table(
-      basct::span<uint16_t> bucket_prefix_counts, basct::span<uint16_t> indexes,
-      basct::cspan<const uint8_t*> scalars, unsigned element_num_bytes, unsigned bit_width,
-      unsigned n) noexcept {
-    auto num_outputs = scalars.size();
-    auto num_buckets_per_digit = (1u << bit_width) - 1u;
-    auto num_digits = basn::divide_up(element_num_bytes * 8u, bit_width);
-    auto num_buckets_per_output = num_buckets_per_digit * num_digits;
-    auto num_buckets_total = num_buckets_per_output * num_outputs;
-    SXT_DEBUG_ASSERT(bucket_prefix_counts.size() == num_buckets_total &&
-                     indexes.size() == num_outputs * num_digits * n &&
-                     basdv::is_active_device_pointer(bucket_prefix_counts.data()) &&
-                     basdv::is_active_device_pointer(indexes.data()));
+namespace sxt::mtxbk2 {
+//--------------------------------------------------------------------------------------------------
+// make_multiproduct_table
+//--------------------------------------------------------------------------------------------------
+xena::future<> make_multiproduct_table(basct::span<uint16_t> bucket_prefix_counts,
+                                       basct::span<uint16_t> indexes,
+                                       basct::cspan<const uint8_t*> scalars,
+                                       unsigned element_num_bytes, unsigned bit_width,
+                                       unsigned n) noexcept {
+  auto num_outputs = scalars.size();
+  auto num_buckets_per_digit = (1u << bit_width) - 1u;
+  auto num_digits = basn::divide_up(element_num_bytes * 8u, bit_width);
+  auto num_buckets_per_output = num_buckets_per_digit * num_digits;
+  auto num_buckets_total = num_buckets_per_output * num_outputs;
+  SXT_DEBUG_ASSERT(bucket_prefix_counts.size() == num_buckets_total &&
+                   indexes.size() == num_outputs * num_digits * n &&
+                   basdv::is_active_device_pointer(bucket_prefix_counts.data()) &&
+                   basdv::is_active_device_pointer(indexes.data()));
 
-    // transpose scalars
-    basl::info("copying scalars to device");
-    memmg::managed_array<uint8_t> bytes{num_outputs * n * element_num_bytes,
-                                        memr::get_device_resource()};
-    co_await mtxb::transpose_scalars_to_device(bytes, scalars, element_num_bytes, n);
+  // transpose scalars
+  basl::info("copying scalars to device");
+  memmg::managed_array<uint8_t> bytes{num_outputs * n * element_num_bytes,
+                                      memr::get_device_resource()};
+  co_await mtxb::transpose_scalars_to_device(bytes, scalars, element_num_bytes, n);
 
-    // compute buckets
-    basl::info("computing multiproduct decomposition");
-    SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
-    SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "limit length for now");
-    basdv::stream stream;
-    fit_multiproduct_table_kernel(
-        [&]<unsigned NumThreads, unsigned ItemsPerThread>(
-            std::integral_constant<unsigned, NumThreads>,
-            std::integral_constant<unsigned, ItemsPerThread>) noexcept {
-          multiproduct_table_kernel<NumThreads, ItemsPerThread, 8>
-              <<<dim3(num_digits, num_outputs, 1), NumThreads, 0, stream>>>(
-                  bucket_prefix_counts.data(), indexes.data(), bytes.data(), n);
-        },
-        n);
+  // compute buckets
+  basl::info("computing multiproduct decomposition");
+  SXT_RELEASE_ASSERT(bit_width == 8u, "only support bit_width == 8u for now");
+  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v, "limit length for now");
+  basdv::stream stream;
+  fit_multiproduct_table_kernel(
+      [&]<unsigned NumThreads, unsigned ItemsPerThread>(
+          std::integral_constant<unsigned, NumThreads>,
+          std::integral_constant<unsigned, ItemsPerThread>) noexcept {
+        multiproduct_table_kernel<NumThreads, ItemsPerThread, 8>
+            <<<dim3(num_digits, num_outputs, 1), NumThreads, 0, stream>>>(
+                bucket_prefix_counts.data(), indexes.data(), bytes.data(), n);
+      },
+      n);
 
-    // prefix sum
-    auto f = [bucket_prefix_counts = bucket_prefix_counts.data(),
-              num_buckets_per_digit = num_buckets_per_digit] __host__
-             __device__(unsigned /*num_digits_total*/, unsigned index) noexcept {
-               auto counts = bucket_prefix_counts + index * num_buckets_per_digit;
-               for (unsigned i = 1; i < num_buckets_per_digit; ++i) {
-                 counts[i] += counts[i - 1u];
-               }
-             };
-    algi::launch_for_each_kernel(stream, f, num_digits * num_outputs);
-    co_await xendv::await_stream(stream);
-  }
+  // prefix sum
+  auto f = [bucket_prefix_counts = bucket_prefix_counts.data(),
+            num_buckets_per_digit = num_buckets_per_digit] __host__
+           __device__(unsigned /*num_digits_total*/, unsigned index) noexcept {
+             auto counts = bucket_prefix_counts + index * num_buckets_per_digit;
+             for (unsigned i = 1; i < num_buckets_per_digit; ++i) {
+               counts[i] += counts[i - 1u];
+             }
+           };
+  algi::launch_for_each_kernel(stream, f, num_digits * num_outputs);
+  co_await xendv::await_stream(stream);
+}
 } // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -18,6 +18,26 @@
 
 #include <utility>
 
+/*
+ * This is a workaround to define _VSTD before including cub/cub.cuh.
+ * It should be removed when we can upgrade to a newer version of CUDA.
+ *
+ * We need to define _VSTD in order to use the clang version defined in 
+ * clang.nix and the CUDA toolkit version defined in cuda.nix.
+ * 
+ * _VSTD was deprecated and removed from the LLVM truck.
+ * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
+ * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
+ * 
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
+ * cluster currently cannot install a driver above 550. 
+ * 
+ * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ */
+#include <__config>
+#define _VSTD std::_LIBCPP_ABI_NAMESPACE
+_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
+
 #include "cub/cub.cuh"
 #include "sxt/algorithm/block/runlength_count.h"
 #include "sxt/base/device/stream.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -18,28 +18,8 @@
 
 #include <utility>
 
-/*
- * This is a workaround to define _VSTD before including cub/cub.cuh.
- * It should be removed when we can upgrade to a newer version of CUDA.
- *
- * We need to define _VSTD in order to use the clang version defined in
- * clang.nix and the CUDA toolkit version defined in cuda.nix.
- *
- * _VSTD was deprecated and removed from the LLVM truck.
- * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
- * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- *
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
- * cluster currently cannot install a driver above 550.
- *
- * See CUDA toolkit and driver support:
- * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
- */
-#include <__config>
-#define _VSTD std::_LIBCPP_ABI_NAMESPACE
-
-#include "cub/cub.cuh"
 #include "sxt/algorithm/block/runlength_count.h"
+#include "sxt/base/device/cub.h"
 #include "sxt/base/device/stream.h"
 #include "sxt/base/num/constexpr_switch.h"
 #include "sxt/base/num/divide_up.h"

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -45,81 +45,81 @@
 #include "sxt/base/num/divide_up.h"
 #include "sxt/multiexp/bucket_method2/constants.h"
 
-    namespace sxt::mtxbk2 {
-  //--------------------------------------------------------------------------------------------------
-  // multiproduct_table_kernel
-  //--------------------------------------------------------------------------------------------------
-  template <uint16_t NumThreads, uint16_t ItemsPerThread, unsigned BitWidth>
-  __global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
-                                            uint16_t* __restrict__ indexes,
-                                            const uint8_t* __restrict__ bytes, unsigned n) {
-    uint16_t thread_index = threadIdx.x;
-    auto digit_index = blockIdx.x;
-    auto output_index = blockIdx.y;
-    auto num_digits = gridDim.x;
-    auto num_buckets_per_digit = (1u << BitWidth) - 1u;
+namespace sxt::mtxbk2 {
+//--------------------------------------------------------------------------------------------------
+// multiproduct_table_kernel
+//--------------------------------------------------------------------------------------------------
+template <uint16_t NumThreads, uint16_t ItemsPerThread, unsigned BitWidth>
+__global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
+                                          uint16_t* __restrict__ indexes,
+                                          const uint8_t* __restrict__ bytes, unsigned n) {
+  uint16_t thread_index = threadIdx.x;
+  auto digit_index = blockIdx.x;
+  auto output_index = blockIdx.y;
+  auto num_digits = gridDim.x;
+  auto num_buckets_per_digit = (1u << BitWidth) - 1u;
 
-    // algorithms and shared memory
-    using RadixSort = cub::BlockRadixSort<uint8_t, NumThreads, ItemsPerThread, uint16_t>;
-    using RunlengthCount = algbk::runlength_count<uint8_t, uint16_t, NumThreads, (1u << BitWidth)>;
-    __shared__ union {
-      RadixSort::TempStorage sort;
-      RunlengthCount::temp_storage count;
-    } temp_storage;
+  // algorithms and shared memory
+  using RadixSort = cub::BlockRadixSort<uint8_t, NumThreads, ItemsPerThread, uint16_t>;
+  using RunlengthCount = algbk::runlength_count<uint8_t, uint16_t, NumThreads, (1u << BitWidth)>;
+  __shared__ union {
+    RadixSort::TempStorage sort;
+    RunlengthCount::temp_storage count;
+  } temp_storage;
 
-    // adjust pointers
-    bucket_counts += digit_index * num_buckets_per_digit;
-    bucket_counts += output_index * num_digits * num_buckets_per_digit;
-    indexes += digit_index * n;
-    indexes += output_index * num_digits * n;
-    bytes += digit_index * n;
-    bytes += output_index * num_digits * n;
+  // adjust pointers
+  bucket_counts += digit_index * num_buckets_per_digit;
+  bucket_counts += output_index * num_digits * num_buckets_per_digit;
+  indexes += digit_index * n;
+  indexes += output_index * num_digits * n;
+  bytes += digit_index * n;
+  bytes += output_index * num_digits * n;
 
-    // load bytes
-    uint8_t keys[ItemsPerThread];
-    uint16_t values[ItemsPerThread];
-    for (uint16_t i = 0; i < ItemsPerThread; ++i) {
-      auto index = thread_index + i * NumThreads;
-      if (index < n) {
-        keys[i] = bytes[index];
-        values[i] = index;
-      } else {
-        keys[i] = 0;
-        values[i] = 0;
-      }
-    }
-
-    // sort
-    RadixSort(temp_storage.sort).Sort(keys, values);
-    __syncthreads();
-
-    // count
-    auto counts = RunlengthCount(temp_storage.count).count(keys);
-    __syncthreads();
-
-    // write counts
-    for (unsigned i = thread_index; i < num_buckets_per_digit; i += NumThreads) {
-      bucket_counts[i] = counts[i + 1];
-    }
-
-    // write indexes
-    auto zero_count = counts[0];
-    for (unsigned i = 0; i < ItemsPerThread; ++i) {
-      auto index = i + thread_index * ItemsPerThread;
-      if (index >= zero_count) {
-        indexes[index - zero_count] = values[i];
-      }
+  // load bytes
+  uint8_t keys[ItemsPerThread];
+  uint16_t values[ItemsPerThread];
+  for (uint16_t i = 0; i < ItemsPerThread; ++i) {
+    auto index = thread_index + i * NumThreads;
+    if (index < n) {
+      keys[i] = bytes[index];
+      values[i] = index;
+    } else {
+      keys[i] = 0;
+      values[i] = 0;
     }
   }
 
-  //--------------------------------------------------------------------------------------------------
-  // fit_multiproduct_table_kernel
-  //--------------------------------------------------------------------------------------------------
-  template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
-    SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
-    basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
-        basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
-          return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});
-        });
+  // sort
+  RadixSort(temp_storage.sort).Sort(keys, values);
+  __syncthreads();
+
+  // count
+  auto counts = RunlengthCount(temp_storage.count).count(keys);
+  __syncthreads();
+
+  // write counts
+  for (unsigned i = thread_index; i < num_buckets_per_digit; i += NumThreads) {
+    bucket_counts[i] = counts[i + 1];
   }
+
+  // write indexes
+  auto zero_count = counts[0];
+  for (unsigned i = 0; i < ItemsPerThread; ++i) {
+    auto index = i + thread_index * ItemsPerThread;
+    if (index >= zero_count) {
+      indexes[index - zero_count] = values[i];
+    }
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// fit_multiproduct_table_kernel
+//--------------------------------------------------------------------------------------------------
+template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
+  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
+  basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
+      basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
+        return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});
+      });
+}
 } // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -22,17 +22,18 @@
  * This is a workaround to define _VSTD before including cub/cub.cuh.
  * It should be removed when we can upgrade to a newer version of CUDA.
  *
- * We need to define _VSTD in order to use the clang version defined in 
+ * We need to define _VSTD in order to use the clang version defined in
  * clang.nix and the CUDA toolkit version defined in cuda.nix.
- * 
+ *
  * _VSTD was deprecated and removed from the LLVM truck.
  * NVIDIA: https://github.com/NVIDIA/cccl/pull/1331
  * LLVM: https://github.com/llvm/llvm-project/commit/683bc94e1637bd9bacc978f5dc3c79cfc8ff94b9
- * 
- * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes 
- * cluster currently cannot install a driver above 550. 
- * 
- * See CUDA toolkit and driver support: https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
+ *
+ * We cannot currently use any CUDA toolkit above 12.4.1 because the Kubernetes
+ * cluster currently cannot install a driver above 550.
+ *
+ * See CUDA toolkit and driver support:
+ * https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
@@ -45,81 +46,81 @@ _LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 #include "sxt/base/num/divide_up.h"
 #include "sxt/multiexp/bucket_method2/constants.h"
 
-namespace sxt::mtxbk2 {
-//--------------------------------------------------------------------------------------------------
-// multiproduct_table_kernel
-//--------------------------------------------------------------------------------------------------
-template <uint16_t NumThreads, uint16_t ItemsPerThread, unsigned BitWidth>
-__global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
-                                          uint16_t* __restrict__ indexes,
-                                          const uint8_t* __restrict__ bytes, unsigned n) {
-  uint16_t thread_index = threadIdx.x;
-  auto digit_index = blockIdx.x;
-  auto output_index = blockIdx.y;
-  auto num_digits = gridDim.x;
-  auto num_buckets_per_digit = (1u << BitWidth) - 1u;
+    namespace sxt::mtxbk2 {
+  //--------------------------------------------------------------------------------------------------
+  // multiproduct_table_kernel
+  //--------------------------------------------------------------------------------------------------
+  template <uint16_t NumThreads, uint16_t ItemsPerThread, unsigned BitWidth>
+  __global__ void multiproduct_table_kernel(uint16_t* __restrict__ bucket_counts,
+                                            uint16_t* __restrict__ indexes,
+                                            const uint8_t* __restrict__ bytes, unsigned n) {
+    uint16_t thread_index = threadIdx.x;
+    auto digit_index = blockIdx.x;
+    auto output_index = blockIdx.y;
+    auto num_digits = gridDim.x;
+    auto num_buckets_per_digit = (1u << BitWidth) - 1u;
 
-  // algorithms and shared memory
-  using RadixSort = cub::BlockRadixSort<uint8_t, NumThreads, ItemsPerThread, uint16_t>;
-  using RunlengthCount = algbk::runlength_count<uint8_t, uint16_t, NumThreads, (1u << BitWidth)>;
-  __shared__ union {
-    RadixSort::TempStorage sort;
-    RunlengthCount::temp_storage count;
-  } temp_storage;
+    // algorithms and shared memory
+    using RadixSort = cub::BlockRadixSort<uint8_t, NumThreads, ItemsPerThread, uint16_t>;
+    using RunlengthCount = algbk::runlength_count<uint8_t, uint16_t, NumThreads, (1u << BitWidth)>;
+    __shared__ union {
+      RadixSort::TempStorage sort;
+      RunlengthCount::temp_storage count;
+    } temp_storage;
 
-  // adjust pointers
-  bucket_counts += digit_index * num_buckets_per_digit;
-  bucket_counts += output_index * num_digits * num_buckets_per_digit;
-  indexes += digit_index * n;
-  indexes += output_index * num_digits * n;
-  bytes += digit_index * n;
-  bytes += output_index * num_digits * n;
+    // adjust pointers
+    bucket_counts += digit_index * num_buckets_per_digit;
+    bucket_counts += output_index * num_digits * num_buckets_per_digit;
+    indexes += digit_index * n;
+    indexes += output_index * num_digits * n;
+    bytes += digit_index * n;
+    bytes += output_index * num_digits * n;
 
-  // load bytes
-  uint8_t keys[ItemsPerThread];
-  uint16_t values[ItemsPerThread];
-  for (uint16_t i = 0; i < ItemsPerThread; ++i) {
-    auto index = thread_index + i * NumThreads;
-    if (index < n) {
-      keys[i] = bytes[index];
-      values[i] = index;
-    } else {
-      keys[i] = 0;
-      values[i] = 0;
+    // load bytes
+    uint8_t keys[ItemsPerThread];
+    uint16_t values[ItemsPerThread];
+    for (uint16_t i = 0; i < ItemsPerThread; ++i) {
+      auto index = thread_index + i * NumThreads;
+      if (index < n) {
+        keys[i] = bytes[index];
+        values[i] = index;
+      } else {
+        keys[i] = 0;
+        values[i] = 0;
+      }
+    }
+
+    // sort
+    RadixSort(temp_storage.sort).Sort(keys, values);
+    __syncthreads();
+
+    // count
+    auto counts = RunlengthCount(temp_storage.count).count(keys);
+    __syncthreads();
+
+    // write counts
+    for (unsigned i = thread_index; i < num_buckets_per_digit; i += NumThreads) {
+      bucket_counts[i] = counts[i + 1];
+    }
+
+    // write indexes
+    auto zero_count = counts[0];
+    for (unsigned i = 0; i < ItemsPerThread; ++i) {
+      auto index = i + thread_index * ItemsPerThread;
+      if (index >= zero_count) {
+        indexes[index - zero_count] = values[i];
+      }
     }
   }
 
-  // sort
-  RadixSort(temp_storage.sort).Sort(keys, values);
-  __syncthreads();
-
-  // count
-  auto counts = RunlengthCount(temp_storage.count).count(keys);
-  __syncthreads();
-
-  // write counts
-  for (unsigned i = thread_index; i < num_buckets_per_digit; i += NumThreads) {
-    bucket_counts[i] = counts[i + 1];
+  //--------------------------------------------------------------------------------------------------
+  // fit_multiproduct_table_kernel
+  //--------------------------------------------------------------------------------------------------
+  template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
+    SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
+    basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
+        basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
+          return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});
+        });
   }
-
-  // write indexes
-  auto zero_count = counts[0];
-  for (unsigned i = 0; i < ItemsPerThread; ++i) {
-    auto index = i + thread_index * ItemsPerThread;
-    if (index >= zero_count) {
-      indexes[index - zero_count] = values[i];
-    }
-  }
-}
-
-//--------------------------------------------------------------------------------------------------
-// fit_multiproduct_table_kernel
-//--------------------------------------------------------------------------------------------------
-template <class F> void fit_multiproduct_table_kernel(F f, unsigned n) noexcept {
-  SXT_RELEASE_ASSERT(n <= max_multiexponentiation_length_v);
-  basn::constexpr_switch<1, max_multiexponentiation_length_v / 128u + 1u>(
-      basn::divide_up(n, 128u), [&]<unsigned K>(std::integral_constant<unsigned, K>) noexcept {
-        return f(std::integral_constant<unsigned, 128>{}, std::integral_constant<unsigned, K>{});
-      });
-}
 } // namespace sxt::mtxbk2

--- a/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
+++ b/sxt/multiexp/bucket_method2/multiproduct_table_kernel.h
@@ -37,7 +37,6 @@
  */
 #include <__config>
 #define _VSTD std::_LIBCPP_ABI_NAMESPACE
-_LIBCPP_BEGIN_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD
 
 #include "cub/cub.cuh"
 #include "sxt/algorithm/block/runlength_count.h"


### PR DESCRIPTION
# Rationale for this change
The NVIDIA drivers required to run the CUDA toolkit 12.6 cannot be installed on Kubernetes clusters successfully. The version that can be installed is 550, which corresponds to [CUDA toolkit 12.4](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html). This PR downgrades the CUDA toolkit.

Downgrading the CUDA toolkit with the version of clang we are using causes the following error:
```
In file included from external/local_cuda/cuda/include/cub/cub.cuh:62:
In file included from external/local_cuda/cuda/include/cub/device/device_adjacent_difference.cuh:42:
In file included from external/local_cuda/cuda/include/cub/device/dispatch/dispatch_adjacent_difference.cuh:40:
In file included from external/local_cuda/cuda/include/cub/agent/agent_adjacent_difference.cuh:46:
In file included from external/local_cuda/cuda/include/thrust/system/cuda/detail/core/util.h:42:
external/local_cuda/cuda/include/thrust/type_traits/is_contiguous_iterator.h:150:3: error: use of undeclared identifier '_VSTD'
  150 |   _VSTD::__wrap_iter<Iterator>
      |   ^
external/local_cuda/cuda/include/thrust/type_traits/is_contiguous_iterator.h:150:22: error: 'Iterator' does not refer to a value
  150 |   _VSTD::__wrap_iter<Iterator>
      |                      ^
external/local_cuda/cuda/include/thrust/type_traits/is_contiguous_iterator.h:148:20: note: declared here
  148 | template <typename Iterator>
      |                    ^
external/local_cuda/cuda/include/thrust/type_traits/is_contiguous_iterator.h:151:1: error: expected unqualified-id
  151 | > : true_type {};
      | ^
3 errors generated when compiling for sm_70.
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 54.200s, Critical Path: 10.23s
INFO: 2588 processes: 2032 internal, 556 local.
ERROR: Build did NOT complete successfully
```
This PR includes a temporary workaround for this error.

# What changes are included in this PR?
- Downgrade the CUDA toolkit to 12.4.1 to work with Kubernetes pods.
- Create a temporary workaround for `_VSTD` build error.

# Are these changes tested?
Yes