### PR TITLE
feat: support serialization of multiexponentiation handles (PROOF-920)

### DIFF
--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -168,6 +168,7 @@ sxt_cc_component(
     ],
     test_deps = [
         ":backend",
+        "//sxt/base/test:temp_file",
         "//sxt/base/test:unit_test",
         "//sxt/curve21/operation:add",
         "//sxt/curve21/operation:double",

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -586,6 +586,12 @@ struct sxt_multiexp_handle* sxt_multiexp_handle_new_from_file(unsigned curve_id,
                                                               const char* filename);
 
 /**
+ * Write to file
+ */
+void sxt_multiexp_handle_write_to_file(const struct sxt_multiexp_handle* handle,
+                                       const char* filename);
+
+/**
  * Free resources for a multiexponentiation handle
  */
 void sxt_multiexp_handle_free(struct sxt_multiexp_handle* handle);

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -579,14 +579,19 @@ struct sxt_multiexp_handle* sxt_multiexp_handle_new(unsigned curve_id, const voi
                                                     unsigned n);
 
 /**
- * Use a serialized file to create a handle for computing multiexponentiations using a fixed 
+ * Use a serialized file to create a handle for computing multiexponentiations using a fixed
  * sequence of generators.
+ *
+ * Reading the handle from a file can be significantly faster than calling
+ * sxt_multiexp_handle_new.
  */
 struct sxt_multiexp_handle* sxt_multiexp_handle_new_from_file(unsigned curve_id,
                                                               const char* filename);
 
 /**
- * Write to file
+ * Write a multiexponentiation handle to file.
+ *
+ * Use this function in combination with sxt_multiexp_handle_new_from_file.
  */
 void sxt_multiexp_handle_write_to_file(const struct sxt_multiexp_handle* handle,
                                        const char* filename);

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -579,6 +579,13 @@ struct sxt_multiexp_handle* sxt_multiexp_handle_new(unsigned curve_id, const voi
                                                     unsigned n);
 
 /**
+ * Use a serialized file to create a handle for computing multiexponentiations using a fixed 
+ * sequence of generators.
+ */
+struct sxt_multiexp_handle* sxt_multiexp_handle_new_from_file(unsigned curve_id,
+                                                              const char* filename);
+
+/**
  * Free resources for a multiexponentiation handle
  */
 void sxt_multiexp_handle_free(struct sxt_multiexp_handle* handle);

--- a/cbindings/fixed_pedersen.cc
+++ b/cbindings/fixed_pedersen.cc
@@ -49,6 +49,16 @@ struct sxt_multiexp_handle* sxt_multiexp_handle_new_from_file(unsigned curve_id,
 }
 
 //--------------------------------------------------------------------------------------------------
+// sxt_multiexp_handle_write_to_file
+//--------------------------------------------------------------------------------------------------
+void sxt_multiexp_handle_write_to_file(const struct sxt_multiexp_handle* handle,
+                                       const char* filename) {
+  auto backend = cbn::get_backend();
+  auto h = reinterpret_cast<const cbnb::multiexp_handle*>(handle);
+  backend->write_partition_table_accessor(h->curve_id, *h->partition_table_accessor, filename);
+}
+
+//--------------------------------------------------------------------------------------------------
 // sxt_multiexp_handle_free
 //--------------------------------------------------------------------------------------------------
 void sxt_multiexp_handle_free(struct sxt_multiexp_handle* handle) {

--- a/cbindings/fixed_pedersen.cc
+++ b/cbindings/fixed_pedersen.cc
@@ -37,6 +37,18 @@ struct sxt_multiexp_handle* sxt_multiexp_handle_new(unsigned curve_id, const voi
 }
 
 //--------------------------------------------------------------------------------------------------
+// sxt_multiexp_handle_new_from_file
+//--------------------------------------------------------------------------------------------------
+struct sxt_multiexp_handle* sxt_multiexp_handle_new_from_file(unsigned curve_id,
+                                                              const char* filename) {
+  auto res = std::make_unique<cbnb::multiexp_handle>();
+  res->curve_id = static_cast<cbnb::curve_id_t>(curve_id);
+  auto backend = cbn::get_backend();
+  res->partition_table_accessor = backend->read_partition_table_accessor(res->curve_id, filename);
+  return reinterpret_cast<sxt_multiexp_handle*>(res.release());
+}
+
+//--------------------------------------------------------------------------------------------------
 // sxt_multiexp_handle_free
 //--------------------------------------------------------------------------------------------------
 void sxt_multiexp_handle_free(struct sxt_multiexp_handle* handle) {

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -5,6 +5,9 @@ load(
 
 sxt_cc_component(
     name = "computational_backend",
+    impl_deps = [
+        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor",
+    ],
     with_test = False,
     deps = [
         ":computational_backend_utility",
@@ -14,9 +17,6 @@ sxt_cc_component(
         "//sxt/multiexp/base:exponent_sequence",
         "//sxt/multiexp/pippenger2:partition_table_accessor_base",
         "//sxt/ristretto/type:compressed_element",
-    ],
-    impl_deps = [
-        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor",
     ],
 )
 

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -7,6 +7,7 @@ sxt_cc_component(
     name = "computational_backend",
     with_test = False,
     deps = [
+        ":computational_backend_utility",
         "//sxt/base/container:span",
         "//sxt/cbindings/base:curve_id",
         "//sxt/curve21/type:element_p3",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -15,6 +15,9 @@ sxt_cc_component(
         "//sxt/multiexp/pippenger2:partition_table_accessor_base",
         "//sxt/ristretto/type:compressed_element",
     ],
+    impl_deps = [
+        "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor",
+    ],
 )
 
 sxt_cc_component(

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -14,8 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #include "sxt/cbindings/backend/computational_backend.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
+#include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 
 namespace sxt::cbnbck {
 //--------------------------------------------------------------------------------------------------
@@ -24,8 +26,12 @@ namespace sxt::cbnbck {
 std::unique_ptr<mtxpp2::partition_table_accessor_base>
 computational_backend::read_partition_table_accessor(cbnb::curve_id_t curve_id,
                                                      const char* filename) const noexcept {
-  (void)curve_id;
-  (void)filename;
+  std::unique_ptr<mtxpp2::partition_table_accessor_base> res;
+  cbnb::switch_curve_type(
+      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
+        res = std::make_unique<mtxpp2::in_memory_partition_table_accessor<U>>(filename);
+      });
+  return res;
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "computational_backend.h"
 #include "sxt/cbindings/backend/computational_backend.h"
 
 #include "sxt/cbindings/base/curve_id_utility.h"

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -15,3 +15,25 @@
  * limitations under the License.
  */
 #include "sxt/cbindings/backend/computational_backend.h"
+#include "sxt/cbindings/base/curve_id_utility.h"
+
+namespace sxt::cbnbck {
+//--------------------------------------------------------------------------------------------------
+// read_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+std::unique_ptr<mtxpp2::partition_table_accessor_base>
+computational_backend::read_partition_table_accessor(cbnb::curve_id_t curve_id,
+                                                     const char* filename) const noexcept {
+  (void)curve_id;
+  (void)filename;
+}
+
+//--------------------------------------------------------------------------------------------------
+// write_partition_table_accessor
+//--------------------------------------------------------------------------------------------------
+void computational_backend::write_partition_table_accessor(cbnb::curve_id_t curve_id,
+                                                           const char* filename) const noexcept {
+  (void)curve_id;
+  (void)filename;
+}
+} // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -15,8 +15,9 @@
  * limitations under the License.
  */
 
-#include "sxt/cbindings/backend/computational_backend.h"
 #include "computational_backend.h"
+#include "sxt/cbindings/backend/computational_backend.h"
+
 #include "sxt/cbindings/base/curve_id_utility.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -16,6 +16,7 @@
  */
 
 #include "sxt/cbindings/backend/computational_backend.h"
+#include "computational_backend.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
 
@@ -37,9 +38,12 @@ computational_backend::read_partition_table_accessor(cbnb::curve_id_t curve_id,
 //--------------------------------------------------------------------------------------------------
 // write_partition_table_accessor
 //--------------------------------------------------------------------------------------------------
-void computational_backend::write_partition_table_accessor(cbnb::curve_id_t curve_id,
-                                                           const char* filename) const noexcept {
-  (void)curve_id;
-  (void)filename;
+void computational_backend::write_partition_table_accessor(
+    cbnb::curve_id_t curve_id, const mtxpp2::partition_table_accessor_base& accessor,
+    const char* filename) const noexcept {
+  cbnb::switch_curve_type(
+      curve_id, [&]<class U, class T>(std::type_identity<U>, std::type_identity<T>) noexcept {
+        static_cast<const mtxpp2::partition_table_accessor<U>&>(accessor).write_to_file(filename);
+      });
 }
 } // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -108,6 +108,7 @@ public:
   make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                 unsigned n) const noexcept = 0;
 
+
   virtual void fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id,
                                          const mtxpp2::partition_table_accessor_base& accessor,
                                          unsigned element_num_bytes, unsigned num_outputs,
@@ -123,5 +124,11 @@ public:
                                          const unsigned* output_bit_table,
                                          const unsigned* output_lengths, unsigned num_outputs,
                                          const uint8_t* scalars) const noexcept = 0;
+
+  std::unique_ptr<mtxpp2::partition_table_accessor_base>
+  read_partition_table_accessor(cbnb::curve_id_t curve_id, const char* filename) const noexcept;
+
+  void write_partition_table_accessor(cbnb::curve_id_t curve_id,
+                                      const char* filename) const noexcept;
 };
 } // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -129,6 +129,7 @@ public:
   read_partition_table_accessor(cbnb::curve_id_t curve_id, const char* filename) const noexcept;
 
   void write_partition_table_accessor(cbnb::curve_id_t curve_id,
+                                      const mtxpp2::partition_table_accessor_base& accessor,
                                       const char* filename) const noexcept;
 };
 } // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -108,7 +108,6 @@ public:
   make_partition_table_accessor(cbnb::curve_id_t curve_id, const void* generators,
                                 unsigned n) const noexcept = 0;
 
-
   virtual void fixed_multiexponentiation(void* res, cbnb::curve_id_t curve_id,
                                          const mtxpp2::partition_table_accessor_base& accessor,
                                          unsigned element_num_bytes, unsigned num_outputs,


### PR DESCRIPTION
# Rationale for this change

Add API functions to read and write multiexponentiation handles to disk.

With these functions, it can be significantly cheaper to create handles.

# What changes are included in this PR?

* Add sxt_multiexp_handle_new_from_file and sxt_multiexp_handle_write_to_file to blitzar_api.h.

# Are these changes tested?

Yes.