### PR TITLE
feat: add functions for doing basic sumcheck operations on transcripts (PROOF-913)

### DIFF
--- a/sxt/proof/sumcheck/BUILD
+++ b/sxt/proof/sumcheck/BUILD
@@ -1,0 +1,19 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "transcript_utility",
+    impl_deps = [
+        "//sxt/scalar25/type:element",
+        "//sxt/proof/transcript:transcript_utility",
+    ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/proof/transcript",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)

--- a/sxt/proof/sumcheck/transcript_utility.cc
+++ b/sxt/proof/sumcheck/transcript_utility.cc
@@ -1,0 +1,41 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/transcript_utility.h"
+
+#include "sxt/proof/transcript/transcript_utility.h"
+#include "sxt/scalar25/type/element.h"
+
+namespace sxt::prfsk {
+//--------------------------------------------------------------------------------------------------
+// init_transcript
+//--------------------------------------------------------------------------------------------------
+void init_transcript(prft::transcript& transcript, unsigned num_variables,
+                     unsigned round_degree) noexcept {
+  prft::set_domain(transcript, "sumcheck proof v1");
+  prft::append_value(transcript, "n", num_variables);
+  prft::append_value(transcript, "k", round_degree);
+}
+
+//--------------------------------------------------------------------------------------------------
+// round_challenge
+//--------------------------------------------------------------------------------------------------
+void round_challenge(s25t::element& r, prft::transcript& transcript,
+                     basct::cspan<s25t::element> polynomial) noexcept {
+  prft::append_values(transcript, "P", polynomial);
+  prft::challenge_value(r, transcript, "R");
+}
+} // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/transcript_utility.h
+++ b/sxt/proof/sumcheck/transcript_utility.h
@@ -1,0 +1,40 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "sxt/base/container/span.h"
+
+namespace sxt::prft {
+class transcript;
+}
+namespace sxt::s25t {
+class element;
+}
+
+namespace sxt::prfsk {
+//--------------------------------------------------------------------------------------------------
+// init_transcript
+//--------------------------------------------------------------------------------------------------
+void init_transcript(prft::transcript& transcript, unsigned num_variables,
+                     unsigned round_degree) noexcept;
+
+//--------------------------------------------------------------------------------------------------
+// round_challenge
+//--------------------------------------------------------------------------------------------------
+void round_challenge(s25t::element& r, prft::transcript& transcript,
+                     basct::cspan<s25t::element> polynomial) noexcept;
+} // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/transcript_utility.t.cc
+++ b/sxt/proof/sumcheck/transcript_utility.t.cc
@@ -1,0 +1,44 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/transcript_utility.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/proof/transcript/transcript.h"
+#include "sxt/scalar25/type/literal.h"
+
+using namespace sxt;
+using namespace sxt::prfsk;
+using s25t::operator""_s25;
+
+TEST_CASE("we can perform basic operations on a transcript") {
+  prft::transcript transcript{"abc"};
+  std::vector<s25t::element> p = {0x123_s25};
+  s25t::element r, rp;
+
+  SECTION("we don't draw the same challenge from a transcript") {
+    round_challenge(r, transcript, p);
+    round_challenge(rp, transcript, p);
+    REQUIRE(r != rp);
+
+    prft::transcript transcript_p{"abc"};
+    p[0] = 0x456_s25;
+    round_challenge(rp, transcript_p, p);
+    REQUIRE(r != rp);
+  }
+}

--- a/sxt/proof/sumcheck/transcript_utility.t.cc
+++ b/sxt/proof/sumcheck/transcript_utility.t.cc
@@ -41,4 +41,15 @@ TEST_CASE("we can perform basic operations on a transcript") {
     round_challenge(rp, transcript_p, p);
     REQUIRE(r != rp);
   }
+
+  SECTION("init_transcript produces different results based on parameters") {
+    init_transcript(transcript, 1, 2);
+    round_challenge(r, transcript, p);
+
+    prft::transcript transcript_p{"abc"};
+    init_transcript(transcript_p, 2, 1);
+    round_challenge(rp, transcript_p, p);
+
+    REQUIRE(r != rp);
+  }
 }


### PR DESCRIPTION
# Rationale for this change

Add functions for doing basic sumcheck operations on transcripts.

# What changes are included in this PR?

Adds a new component transcript_utility.

# Are these changes tested?

Yes.
