### PR TITLE
ci: the runner should be specified in the workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   release:
     name: Build Publish Library - Linux-x86_64
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check code
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
   
   test-cpp:
     name: C++ code
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -42,7 +42,7 @@ jobs:
           #
           # test-cpp-compute-sanitizer:
           #   name: C++ code with compute sanitizer
-          #   runs-on: self-hosted
+          #   runs-on: public-blitzar-T4-gpu-vm
           #   timeout-minutes: 600
           #   steps:
           #     - name: Checkout Code
@@ -63,7 +63,7 @@ jobs:
          
   test-cpp-opt:
     name: C++ code with optimizations
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -74,7 +74,7 @@ jobs:
   
   test-cpp-asan:
     name: C++ code with address sanitizer
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -85,7 +85,7 @@ jobs:
 
   test-rust:
     name: Rust Sys Crate
-    runs-on: self-hosted
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     steps:
       - name: Checkout Code


### PR DESCRIPTION
# Rationale for this change
The CI will sometimes fail if the `proofs-dev-muti-gpu-becnhmarks-w3` VM is on. It shows up as shared with the repository because it is in the same runner group as the the VM we want to use - `public-blitzar-T4-gpu-vm`. Since `proofs-dev-muti-gpu-becnhmarks-w3` is shared with the repository, there is no way to my knowledge or permissions level to remove it. This PR makes explicit in the workflow that we want to use `public-blitzar-T4-gpu-vm` as the runner.

# What changes are included in this PR?
- The workflow now is explicitly told to run on the `public-blitzar-T4-gpu-vm` self-hosted runner.

# Are these changes tested?
Yes
