### PR TITLE
feat: add verification step of sumcheck (PROOF-913)

### DIFF
--- a/sxt/proof/sumcheck/BUILD
+++ b/sxt/proof/sumcheck/BUILD
@@ -37,3 +37,25 @@ sxt_cc_component(
         "//sxt/base/container:span",
     ],
 )
+
+sxt_cc_component(
+    name = "verification",
+    impl_deps = [
+        ":polynomial_utility",
+        ":transcript_utility",
+        "//sxt/base/error:assert",
+        "//sxt/base/log:log",
+        "//sxt/scalar25/operation:overload",
+        "//sxt/scalar25/type:element",
+        "//sxt/proof/transcript:transcript_utility",
+    ],
+    test_deps = [
+        ":transcript_utility",
+        "//sxt/base/test:unit_test",
+        "//sxt/scalar25/type:element",
+        "//sxt/scalar25/type:literal",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+    ],
+)

--- a/sxt/proof/sumcheck/BUILD
+++ b/sxt/proof/sumcheck/BUILD
@@ -45,9 +45,9 @@ sxt_cc_component(
         ":transcript_utility",
         "//sxt/base/error:assert",
         "//sxt/base/log:log",
+        "//sxt/proof/transcript:transcript_utility",
         "//sxt/scalar25/operation:overload",
         "//sxt/scalar25/type:element",
-        "//sxt/proof/transcript:transcript_utility",
     ],
     test_deps = [
         ":transcript_utility",

--- a/sxt/proof/sumcheck/polynomial_utility.cc
+++ b/sxt/proof/sumcheck/polynomial_utility.cc
@@ -34,7 +34,7 @@ void sum_polynomial_01(s25t::element& e, basct::cspan<s25t::element> polynomial)
     return;
   }
   e = polynomial[0];
-  for (unsigned i = 1; i < polynomial.size(); ++i) {
+  for (unsigned i = 0; i < polynomial.size(); ++i) {
     s25o::add(e, e, polynomial[i]);
   }
 }

--- a/sxt/proof/sumcheck/polynomial_utility.t.cc
+++ b/sxt/proof/sumcheck/polynomial_utility.t.cc
@@ -40,13 +40,13 @@ TEST_CASE("we perform basic operations on polynomials") {
   SECTION("we can compute the 0-1 sum of a constant polynomial") {
     p = {0x123_s25};
     sum_polynomial_01(e, p);
-    REQUIRE(e == 0x123_s25);
+    REQUIRE(e == 0x246_s25);
   }
 
   SECTION("we can compute the 0-1 sum of a 1 degree polynomial") {
     p = {0x123_s25, 0x456_s25};
     sum_polynomial_01(e, p);
-    REQUIRE(e == 0x123_s25 + 0x456_s25);
+    REQUIRE(e == 0x246_s25 + 0x456_s25);
   }
 
   SECTION("we can evaluate the zero polynomial") {

--- a/sxt/proof/sumcheck/verification.cc
+++ b/sxt/proof/sumcheck/verification.cc
@@ -1,0 +1,78 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/verification.h"
+
+#include "sxt/base/error/assert.h"
+#include "sxt/base/log/log.h"
+#include "sxt/proof/sumcheck/polynomial_utility.h"
+#include "sxt/proof/sumcheck/transcript_utility.h"
+#include "sxt/proof/transcript/transcript_utility.h"
+#include "sxt/scalar25/type/element.h"
+
+namespace sxt::prfsk {
+//--------------------------------------------------------------------------------------------------
+// verify_sumcheck_no_evaluation
+//--------------------------------------------------------------------------------------------------
+bool verify_sumcheck_no_evaluation(s25t::element& expected_sum,
+                                   basct::span<s25t::element> evaluation_point,
+                                   prft::transcript& transcript,
+                                   basct::cspan<s25t::element> round_polynomials,
+                                   unsigned round_degree) noexcept {
+  auto num_variables = evaluation_point.size();
+  SXT_RELEASE_ASSERT(
+      // clang-format off
+      num_variables > 0 && round_degree > 0
+      // clang-format on
+  );
+
+  basl::info("verifying sumcheck of {} variables and round degree {}", num_variables, round_degree);
+
+  // check dimensions
+  if (auto expected_count = (round_degree + 1u) * num_variables;
+      round_polynomials.size() != expected_count) {
+    basl::info("sumcheck verification failed: expected {} scalars for round_polynomials but got {}",
+               expected_count, round_polynomials.size());
+    return false;
+  }
+
+  init_transcript(transcript, num_variables, round_degree);
+
+  // go through sumcheck rounds
+  for (unsigned round_index = 0; round_index < num_variables; ++round_index) {
+    auto polynomial =
+        round_polynomials.subspan((round_degree + 1u) * round_index, round_degree + 1u);
+
+    // check sum
+    s25t::element sum;
+    sum_polynomial_01(sum, polynomial);
+    if (expected_sum != sum) {
+      basl::info("sumcheck verification failed on round {}", round_index + 1);
+      return false;
+    }
+
+    // draw a random scalar
+    s25t::element r;
+    round_challenge(r, transcript, polynomial);
+    evaluation_point[round_index] = r;
+
+    // evaluate at random point
+    evaluate_polynomial(expected_sum, polynomial, r);
+  }
+
+  return true;
+}
+} // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/verification.h
+++ b/sxt/proof/sumcheck/verification.h
@@ -17,32 +17,21 @@
 #pragma once
 
 #include "sxt/base/container/span.h"
-#include "sxt/base/macro/cuda_callable.h"
 
+namespace sxt::prft {
+class transcript;
+}
 namespace sxt::s25t {
 class element;
 }
 
 namespace sxt::prfsk {
 //--------------------------------------------------------------------------------------------------
-// sum_polynomial_01
+// verify_sumcheck_no_evaluation
 //--------------------------------------------------------------------------------------------------
-// Given a polynomial
-//    f_a(X) = a[0] + a[1] * X + a[2] * X^2 + ...
-// compute the sum
-//    f_a(0) + f_a(1)
-void sum_polynomial_01(s25t::element& e, basct::cspan<s25t::element> polynomial) noexcept;
-
-//--------------------------------------------------------------------------------------------------
-// evaluate_polynomial
-//--------------------------------------------------------------------------------------------------
-void evaluate_polynomial(s25t::element& e, basct::cspan<s25t::element> polynomial,
-                         const s25t::element& x) noexcept;
-
-//--------------------------------------------------------------------------------------------------
-// expand_products
-//--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void expand_products(basct::span<s25t::element> p, const s25t::element* mles, unsigned n,
-                     unsigned step, basct::cspan<unsigned> terms) noexcept;
+bool verify_sumcheck_no_evaluation(s25t::element& expected_sum,
+                                   basct::span<s25t::element> evaluation_point,
+                                   prft::transcript& transcript,
+                                   basct::cspan<s25t::element> round_polynomials,
+                                   unsigned round_degree) noexcept;
 } // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/verification.t.cc
+++ b/sxt/proof/sumcheck/verification.t.cc
@@ -1,0 +1,127 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/verification.h"
+
+#include <vector>
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/proof/sumcheck/transcript_utility.h"
+#include "sxt/proof/transcript/transcript.h"
+#include "sxt/scalar25/operation/overload.h"
+#include "sxt/scalar25/type/element.h"
+#include "sxt/scalar25/type/literal.h"
+
+using namespace sxt;
+using namespace sxt::prfsk;
+using sxt::s25t::operator""_s25;
+
+TEST_CASE("we can verify a sumcheck proof up to the polynomial evaluation") {
+  s25t::element expected_sum = 0x0_s25;
+  std::vector<s25t::element> evaluation_point = {0x0_s25};
+  prft::transcript transcript{"abc"};
+  std::vector<s25t::element> round_polynomials = {0x0_s25, 0x0_s25};
+
+  SECTION("verification fails if dimensions don't match") {
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 2);
+    REQUIRE(!res);
+  }
+
+  SECTION("we can verify a single round") {
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 1);
+    REQUIRE(res);
+    REQUIRE(evaluation_point[0] != 0x0_s25);
+  }
+
+  SECTION("verification fails if the round polynomial doesn't match the sum") {
+    round_polynomials[1] = 0x1_s25;
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 1);
+    REQUIRE(!res);
+  }
+
+  SECTION("we can verify a sum with two rounds") {
+    // Use the MLE:
+    //    3(1-x1)(1-x2) + 5(1-x1)x2 -7x1(1-x2) -1x1x2
+    round_polynomials.resize(4);
+
+    // round 1
+    round_polynomials[0] = 0x3_s25 + 0x5_s25;
+    round_polynomials[1] = -0x3_s25 - 0x7_s25 - 0x5_s25 - 0x1_s25;
+
+    // draw scalar
+    s25t::element r;
+    {
+      prft::transcript transcript_p{"abc"};
+      init_transcript(transcript_p, 2, 1);
+      round_challenge(r, transcript_p, basct::span<s25t::element>{round_polynomials}.subspan(0, 2));
+    }
+
+    // round 2
+    round_polynomials[2] = 0x3_s25 * (0x1_s25 - r) - 0x7_s25 * r;
+    round_polynomials[3] =
+        -0x3_s25 * (0x1_s25 - r) + 0x5_s25 * (0x1_s25 - r) + 0x7_s25 * r - 0x1_s25 * r;
+
+    // prove
+    evaluation_point.resize(2);
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 1);
+    REQUIRE(evaluation_point[0] == r);
+    REQUIRE(res);
+  }
+
+  SECTION("sumcheck verification fails if the random scalar used is wrong") {
+    // Use the MLE:
+    //    3(1-x1)(1-x2) + 5(1-x1)x2 -7x1(1-x2) -1x1x2
+    round_polynomials.resize(4);
+
+    // round 1
+    round_polynomials[0] = 0x3_s25 + 0x5_s25;
+    round_polynomials[1] = -0x3_s25 - 0x7_s25 - 0x5_s25 - 0x1_s25;
+
+    // draw scalar
+    s25t::element r = 0x112233_s25;
+
+    // round 2
+    round_polynomials[2] = 0x3_s25 * (0x1_s25 - r) - 0x7_s25 * r;
+    round_polynomials[3] =
+        -0x3_s25 * (0x1_s25 - r) + 0x5_s25 * (0x1_s25 - r) + 0x7_s25 * r - 0x1_s25 * r;
+
+    // prove
+    evaluation_point.resize(2);
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 1);
+    REQUIRE(!res);
+  }
+
+  SECTION("we can verify a polynomial of degree 2 with one round") {
+    // Use the MLEs:
+    //    f(x1) = 3(1-x1) -7x1
+    //    g(x1) = -2 (1 - x1) + 4 x1
+    round_polynomials = {
+        0x3_s25 * -0x2_s25,
+        (-0x3_s25 - 0x7_s25) * -0x2_s25 + 0x3_s25 * (0x2_s25 + 0x4_s25),
+        (-0x3_s25 - 0x7_s25) * (0x2_s25 + 0x4_s25),
+    };
+    expected_sum = 0x3_s25 * -0x2_s25 - 0x7_s25 * 0x4_s25;
+    auto res = sxt::prfsk::verify_sumcheck_no_evaluation(expected_sum, evaluation_point, transcript,
+                                                         round_polynomials, 2);
+    REQUIRE(res);
+    REQUIRE(evaluation_point[0] != 0x0_s25);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Adds the verification step of sumcheck.

# What changes are included in this PR?

* Adds a component verification for verifying sumcheck
* Makes a fix to polynomial_utility to correctly compute 0-1 sum.

# Are these changes tested?

Yes
