### PR TITLE
feat: support constructing arrays from iterators (PROOF-913)

### DIFF
--- a/sxt/memory/management/managed_array.h
+++ b/sxt/memory/management/managed_array.h
@@ -17,7 +17,9 @@
 #pragma once
 
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
+#include <iterator>
 #include <type_traits>
 #include <utility>
 
@@ -133,6 +135,18 @@ public:
       : data_{reinterpret_cast<void*>(alloc.allocate(values.size() * sizeof(T))), values.size(),
               values.size() * sizeof(T), alloc} {
     std::copy(values.begin(), values.end(), this->data());
+  }
+
+  template <std::forward_iterator Iter>
+    requires requires(Iter it) {
+      { *it } -> std::convertible_to<T>;
+    }
+  managed_array(Iter first, Iter last, allocator_type alloc = {}) noexcept
+      : data_{reinterpret_cast<void*>(
+                  alloc.allocate(static_cast<size_t>(std::distance(first, last)) * sizeof(T))),
+              static_cast<size_t>(std::distance(first, last)),
+              static_cast<size_t>(std::distance(first, last) * sizeof(T)), alloc} {
+    std::copy(first, last, this->data());
   }
 
   managed_array(const managed_array& other) noexcept = default;

--- a/sxt/memory/management/managed_array.t.cc
+++ b/sxt/memory/management/managed_array.t.cc
@@ -16,6 +16,8 @@
  */
 #include "sxt/memory/management/managed_array.h"
 
+#include <vector>
+
 #include "sxt/base/test/allocator_aware.h"
 #include "sxt/base/test/unit_test.h"
 
@@ -30,6 +32,12 @@ TEST_CASE("managed_array is an allocator-aware container manages an array of "
     REQUIRE(arr[0] == 1);
     REQUIRE(arr[1] == 2);
     REQUIRE(arr[2] == 3);
+  }
+
+  SECTION("we can construct a managed array from iterators") {
+    std::vector<int> v = {1, 2, 3};
+    memmg::managed_array<double> arr{v.begin(), v.end()};
+    REQUIRE(arr == memmg::managed_array<double>{1, 2, 3});
   }
 
   SECTION("we can move-assign a managed array to a void array") {


### PR DESCRIPTION
# Rationale for this change

Add a constructor to support creating a managed_array from two iterators. This is a convenience constructor and matches what's available in other standard containers such as std::vector.

# What changes are included in this PR?

* Adds new constructor to managed_array that takes two iterators.

# Are these changes tested?

Yes
