### PR TITLE
fix: the grumpkin curve ID in the blitzar_api should be unique

### DIFF
--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -28,7 +28,7 @@ extern "C" {
 #define SXT_CURVE_RISTRETTO255 0
 #define SXT_CURVE_BLS_381 1
 #define SXT_CURVE_BN_254 2
-#define SXT_CURVE_GRUMPKIN 2
+#define SXT_CURVE_GRUMPKIN 3
 
 /** config struct to hold the chosen backend */
 struct sxt_config {


### PR DESCRIPTION
# Rationale for this change
There is a typo in the `blitzar_api` related to the `SXT_CURVE_GRUMPKIN` curve ID. It was the same as the `SXT_CURVE_BN_254` curve ID. This has not been a problem because `blitzar-rs` does not support grumkin yet.

# What changes are included in this PR?
- The `SXT_CURVE_GRUMPKIN` curve ID value is updated to be unique.

# Are these changes tested?
No, there are only tests for `SXT_CURVE_RISTRETTO255` curve elements. Future work should include tests for the other supported curves, including grumpkin,