### PR TITLE
feat: add pinned buffer pool (PROOF-923)

### DIFF
--- a/sxt/base/device/BUILD
+++ b/sxt/base/device/BUILD
@@ -16,13 +16,14 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "pinned_buffer",
-    deps = [
-    ],
     impl_deps = [
-      ":pinned_buffer_pool",
+        ":pinned_buffer_pool",
     ],
     test_deps = [
-      "//sxt/base/test:unit_test",
+        ":pinned_buffer_pool",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
     ],
 )
 
@@ -35,14 +36,14 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "pinned_buffer_pool",
-    deps = [
-    ],
     impl_deps = [
-      ":pinned_buffer_handle",
-      "//sxt/base/error:panic",
+        ":pinned_buffer_handle",
+        "//sxt/base/error:panic",
     ],
     test_deps = [
-      "//sxt/base/test:unit_test",
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
     ],
 )
 

--- a/sxt/base/device/BUILD
+++ b/sxt/base/device/BUILD
@@ -15,6 +15,38 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "pinned_buffer",
+    deps = [
+    ],
+    impl_deps = [
+      ":pinned_buffer_pool",
+    ],
+    test_deps = [
+      "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
+    name = "pinned_buffer_handle",
+    with_test = False,
+    deps = [
+    ],
+)
+
+sxt_cc_component(
+    name = "pinned_buffer_pool",
+    deps = [
+    ],
+    impl_deps = [
+      ":pinned_buffer_handle",
+      "//sxt/base/error:panic",
+    ],
+    test_deps = [
+      "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "pointer_attributes",
     with_test = False,
     deps = [

--- a/sxt/base/device/pinned_buffer.cc
+++ b/sxt/base/device/pinned_buffer.cc
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/device/pinned_buffer.h"
 
 #include "sxt/base/device/pinned_buffer_pool.h"
@@ -6,8 +22,7 @@ namespace sxt::basdv {
 //--------------------------------------------------------------------------------------------------
 // consructor
 //--------------------------------------------------------------------------------------------------
-pinned_buffer::pinned_buffer() noexcept
-    : handle_{get_pinned_buffer_pool()->aquire_handle()} {}
+pinned_buffer::pinned_buffer() noexcept : handle_{get_pinned_buffer_pool()->aquire_handle()} {}
 
 pinned_buffer::pinned_buffer(pinned_buffer&& ptr) noexcept : handle_{ptr.handle_} {
   ptr.handle_ = nullptr;
@@ -37,7 +52,5 @@ pinned_buffer& pinned_buffer::operator=(pinned_buffer&& ptr) noexcept {
 //--------------------------------------------------------------------------------------------------
 // size
 //--------------------------------------------------------------------------------------------------
-size_t pinned_buffer::size() noexcept {
-  return pinned_buffer_size;
-}
+size_t pinned_buffer::size() noexcept { return pinned_buffer_size; }
 } // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer.cc
+++ b/sxt/base/device/pinned_buffer.cc
@@ -1,0 +1,43 @@
+#include "sxt/base/device/pinned_buffer.h"
+
+#include "sxt/base/device/pinned_buffer_pool.h"
+
+namespace sxt::basdv {
+//--------------------------------------------------------------------------------------------------
+// consructor
+//--------------------------------------------------------------------------------------------------
+pinned_buffer::pinned_buffer() noexcept
+    : handle_{get_pinned_buffer_pool()->aquire_handle()} {}
+
+pinned_buffer::pinned_buffer(pinned_buffer&& ptr) noexcept : handle_{ptr.handle_} {
+  ptr.handle_ = nullptr;
+}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+pinned_buffer::~pinned_buffer() noexcept {
+  if (handle_ != nullptr) {
+    get_pinned_buffer_pool()->release_handle(handle_);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// operator=
+//--------------------------------------------------------------------------------------------------
+pinned_buffer& pinned_buffer::operator=(pinned_buffer&& ptr) noexcept {
+  if (handle_ != nullptr) {
+    get_pinned_buffer_pool()->release_handle(handle_);
+  }
+  handle_ = ptr.handle_;
+  ptr.handle_ = nullptr;
+  return *this;
+}
+
+//--------------------------------------------------------------------------------------------------
+// size
+//--------------------------------------------------------------------------------------------------
+size_t pinned_buffer::size() noexcept {
+  return pinned_buffer_size;
+}
+} // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer.h
+++ b/sxt/base/device/pinned_buffer.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "sxt/base/device/pinned_buffer_handle.h"
+
+namespace sxt::basdv {
+//--------------------------------------------------------------------------------------------------
+// pinned_buffer
+//--------------------------------------------------------------------------------------------------
+class pinned_buffer {
+ public:
+   pinned_buffer() noexcept;
+   pinned_buffer(pinned_buffer&& ptr) noexcept;
+   pinned_buffer(const pinned_buffer&) noexcept = delete;
+
+   ~pinned_buffer() noexcept;
+
+   pinned_buffer& operator=(pinned_buffer&& ptr) noexcept;
+   pinned_buffer& operator=(const pinned_buffer& ptr) noexcept = delete;
+
+   static size_t size() noexcept;
+
+   void* data() noexcept {
+     return handle_->ptr;
+   }
+
+   const void* data() const noexcept {
+     return handle_->ptr;
+   }
+
+   operator void*() noexcept {
+     return handle_->ptr;
+   }
+
+   operator const void*() const noexcept {
+     return handle_->ptr;
+   }
+ private:
+   pinned_buffer_handle* handle_;
+};
+} // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer.h
+++ b/sxt/base/device/pinned_buffer.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/base/device/pinned_buffer_handle.h"
@@ -7,34 +23,27 @@ namespace sxt::basdv {
 // pinned_buffer
 //--------------------------------------------------------------------------------------------------
 class pinned_buffer {
- public:
-   pinned_buffer() noexcept;
-   pinned_buffer(pinned_buffer&& ptr) noexcept;
-   pinned_buffer(const pinned_buffer&) noexcept = delete;
+public:
+  pinned_buffer() noexcept;
+  pinned_buffer(pinned_buffer&& ptr) noexcept;
+  pinned_buffer(const pinned_buffer&) noexcept = delete;
 
-   ~pinned_buffer() noexcept;
+  ~pinned_buffer() noexcept;
 
-   pinned_buffer& operator=(pinned_buffer&& ptr) noexcept;
-   pinned_buffer& operator=(const pinned_buffer& ptr) noexcept = delete;
+  pinned_buffer& operator=(pinned_buffer&& ptr) noexcept;
+  pinned_buffer& operator=(const pinned_buffer& ptr) noexcept = delete;
 
-   static size_t size() noexcept;
+  static size_t size() noexcept;
 
-   void* data() noexcept {
-     return handle_->ptr;
-   }
+  void* data() noexcept { return handle_->ptr; }
 
-   const void* data() const noexcept {
-     return handle_->ptr;
-   }
+  const void* data() const noexcept { return handle_->ptr; }
 
-   operator void*() noexcept {
-     return handle_->ptr;
-   }
+  operator void*() noexcept { return handle_->ptr; }
 
-   operator const void*() const noexcept {
-     return handle_->ptr;
-   }
- private:
-   pinned_buffer_handle* handle_;
+  operator const void*() const noexcept { return handle_->ptr; }
+
+private:
+  pinned_buffer_handle* handle_;
 };
 } // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer.t.cc
+++ b/sxt/base/device/pinned_buffer.t.cc
@@ -1,0 +1,7 @@
+#include "sxt/base/device/pinned_buffer.h"
+
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::basdv;
+
+TEST_CASE("todo") {}

--- a/sxt/base/device/pinned_buffer.t.cc
+++ b/sxt/base/device/pinned_buffer.t.cc
@@ -1,7 +1,55 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/device/pinned_buffer.h"
 
+#include "sxt/base/device/pinned_buffer_pool.h"
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 using namespace sxt::basdv;
 
-TEST_CASE("todo") {}
+TEST_CASE("we can manage pinned buffers") {
+  auto num_buffers = 5u;
+  auto pool = get_pinned_buffer_pool(num_buffers);
+
+  SECTION("we can aquire and release a pinned buffer") {
+    {
+      pinned_buffer buf;
+      REQUIRE(pool->size() == num_buffers - 1);
+      *reinterpret_cast<char*>(buf.data()) = 1u;
+      *(reinterpret_cast<char*>(buf.data()) + buf.size() - 1) = 2u;
+    }
+    REQUIRE(pool->size() == num_buffers);
+  }
+
+  SECTION("we can move construct a buffer") {
+    pinned_buffer buf1;
+    auto ptr = buf1.data();
+    pinned_buffer buf{std::move(buf1)};
+    REQUIRE(buf.data() == ptr);
+    REQUIRE(pool->size() == num_buffers - 1);
+  }
+
+  SECTION("we can move-assign a buffer") {
+    pinned_buffer buf1;
+    auto ptr = buf1.data();
+    pinned_buffer buf;
+    buf = std::move(buf1);
+    REQUIRE(buf.data() == ptr);
+    REQUIRE(pool->size() == num_buffers - 1);
+  }
+}

--- a/sxt/base/device/pinned_buffer_handle.cc
+++ b/sxt/base/device/pinned_buffer_handle.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/device/pinned_buffer_handle.h"

--- a/sxt/base/device/pinned_buffer_handle.cc
+++ b/sxt/base/device/pinned_buffer_handle.cc
@@ -1,0 +1,1 @@
+#include "sxt/base/device/pinned_buffer_handle.h"

--- a/sxt/base/device/pinned_buffer_handle.h
+++ b/sxt/base/device/pinned_buffer_handle.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace sxt::basdv {
+//--------------------------------------------------------------------------------------------------
+// pinned_buffer_handle 
+//--------------------------------------------------------------------------------------------------
+struct pinned_buffer_handle {
+  void* ptr = nullptr;
+  pinned_buffer_handle* next = nullptr;
+};
+} // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer_handle.h
+++ b/sxt/base/device/pinned_buffer_handle.h
@@ -1,8 +1,24 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 namespace sxt::basdv {
 //--------------------------------------------------------------------------------------------------
-// pinned_buffer_handle 
+// pinned_buffer_handle
 //--------------------------------------------------------------------------------------------------
 struct pinned_buffer_handle {
   void* ptr = nullptr;

--- a/sxt/base/device/pinned_buffer_pool.cc
+++ b/sxt/base/device/pinned_buffer_pool.cc
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/device/pinned_buffer_pool.h"
 
 #include <cuda_runtime.h>
@@ -9,7 +25,7 @@
 
 namespace sxt::basdv {
 //--------------------------------------------------------------------------------------------------
-// new_handle 
+// new_handle
 //--------------------------------------------------------------------------------------------------
 static pinned_buffer_handle* new_handle() noexcept {
   auto res = new pinned_buffer_handle{};
@@ -24,7 +40,7 @@ static pinned_buffer_handle* new_handle() noexcept {
 // constructor
 //--------------------------------------------------------------------------------------------------
 pinned_buffer_pool::pinned_buffer_pool(size_t initial_size) noexcept {
-  for (size_t i=0; i<initial_size; ++i) {
+  for (size_t i = 0; i < initial_size; ++i) {
     auto h = new_handle();
     this->release_handle(h);
   }
@@ -61,7 +77,7 @@ pinned_buffer_handle* pinned_buffer_pool::aquire_handle() noexcept {
 //--------------------------------------------------------------------------------------------------
 // release_handle
 //--------------------------------------------------------------------------------------------------
-void pinned_buffer_pool::release_handle(pinned_buffer_handle* handle) noexcept { 
+void pinned_buffer_pool::release_handle(pinned_buffer_handle* handle) noexcept {
   assert(handle->next == nullptr);
   handle->next = head_;
   head_ = handle;

--- a/sxt/base/device/pinned_buffer_pool.cc
+++ b/sxt/base/device/pinned_buffer_pool.cc
@@ -1,0 +1,94 @@
+#include "sxt/base/device/pinned_buffer_pool.h"
+
+#include <cuda_runtime.h>
+
+#include <cassert>
+
+#include "sxt/base/device/pinned_buffer_handle.h"
+#include "sxt/base/error/panic.h"
+
+namespace sxt::basdv {
+//--------------------------------------------------------------------------------------------------
+// new_handle 
+//--------------------------------------------------------------------------------------------------
+static pinned_buffer_handle* new_handle() noexcept {
+  auto res = new pinned_buffer_handle{};
+  auto rcode = cudaMallocHost(&res->ptr, pinned_buffer_size);
+  if (rcode != cudaSuccess) {
+    baser::panic("cudaMallocHost failed: {}", cudaGetErrorString(rcode));
+  }
+  return res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+pinned_buffer_pool::pinned_buffer_pool(size_t initial_size) noexcept {
+  for (size_t i=0; i<initial_size; ++i) {
+    auto h = new_handle();
+    this->release_handle(h);
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// destructor
+//--------------------------------------------------------------------------------------------------
+pinned_buffer_pool::~pinned_buffer_pool() noexcept {
+  while (head_ != nullptr) {
+    auto rcode = cudaFreeHost(head_->ptr);
+    if (rcode != cudaSuccess) {
+      baser::panic("cudaFreeHost failed: {}", cudaGetErrorString(rcode));
+    }
+    auto next = head_->next;
+    delete head_;
+    head_ = next;
+  }
+}
+
+//--------------------------------------------------------------------------------------------------
+// aquire_handle
+//--------------------------------------------------------------------------------------------------
+pinned_buffer_handle* pinned_buffer_pool::aquire_handle() noexcept {
+  if (head_ == nullptr) {
+    head_ = new_handle();
+  }
+  auto res = head_;
+  head_ = res->next;
+  res->next = nullptr;
+  return res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// release_handle
+//--------------------------------------------------------------------------------------------------
+void pinned_buffer_pool::release_handle(pinned_buffer_handle* handle) noexcept { 
+  assert(handle->next == nullptr);
+  handle->next = head_;
+  head_ = handle;
+}
+
+//--------------------------------------------------------------------------------------------------
+// num_buffers
+//--------------------------------------------------------------------------------------------------
+size_t pinned_buffer_pool::num_buffers() const noexcept {
+  size_t res = 0;
+  auto h = head_;
+  while (h != nullptr) {
+    ++res;
+    h = h->next;
+  }
+  return res;
+}
+
+//--------------------------------------------------------------------------------------------------
+// get_pinned_buffer_pool
+//--------------------------------------------------------------------------------------------------
+/**
+ * Access the thread_local pinned pool.
+ */
+pinned_buffer_pool* get_pinned_buffer_pool(size_t initial_size) noexcept {
+  // Allocate a thread local pool that's available for the duration of the process.
+  static thread_local auto pool = new pinned_buffer_pool{initial_size};
+  return pool;
+}
+} // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer_pool.cc
+++ b/sxt/base/device/pinned_buffer_pool.cc
@@ -68,9 +68,9 @@ void pinned_buffer_pool::release_handle(pinned_buffer_handle* handle) noexcept {
 }
 
 //--------------------------------------------------------------------------------------------------
-// num_buffers
+// size
 //--------------------------------------------------------------------------------------------------
-size_t pinned_buffer_pool::num_buffers() const noexcept {
+size_t pinned_buffer_pool::size() const noexcept {
   size_t res = 0;
   auto h = head_;
   while (h != nullptr) {

--- a/sxt/base/device/pinned_buffer_pool.h
+++ b/sxt/base/device/pinned_buffer_pool.h
@@ -24,7 +24,7 @@ class pinned_buffer_pool {
 
   void release_handle(pinned_buffer_handle* handle) noexcept;
 
-  size_t num_buffers() const noexcept;
+  size_t size() const noexcept;
 
 private:
   pinned_buffer_handle* head_ = nullptr;

--- a/sxt/base/device/pinned_buffer_pool.h
+++ b/sxt/base/device/pinned_buffer_pool.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+
+namespace sxt::basdv {
+struct pinned_buffer_handle;
+
+constexpr unsigned pinned_buffer_size = 1024u * 1024u * 2u; // 2 megabytes
+
+//--------------------------------------------------------------------------------------------------
+// pinned_buffer_pool
+//--------------------------------------------------------------------------------------------------
+class pinned_buffer_pool {
+ public:
+  explicit pinned_buffer_pool(size_t initial_size) noexcept;
+
+  ~pinned_buffer_pool() noexcept;
+
+  pinned_buffer_pool(const pinned_buffer_pool&) = delete;
+  pinned_buffer_pool(pinned_buffer_pool&&) = delete;
+  pinned_buffer_pool& operator=(const pinned_buffer_pool&) = delete;
+
+  pinned_buffer_handle* aquire_handle() noexcept;
+
+  void release_handle(pinned_buffer_handle* handle) noexcept;
+
+  size_t num_buffers() const noexcept;
+
+private:
+  pinned_buffer_handle* head_ = nullptr;
+};
+
+//--------------------------------------------------------------------------------------------------
+// get_pinned_buffer_pool
+//--------------------------------------------------------------------------------------------------
+/**
+ * Access the thread_local pinned pool.
+ */
+pinned_buffer_pool* get_pinned_buffer_pool(size_t initial_size = 16) noexcept;
+} // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer_pool.h
+++ b/sxt/base/device/pinned_buffer_pool.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <cstddef>
@@ -11,7 +27,7 @@ constexpr unsigned pinned_buffer_size = 1024u * 1024u * 2u; // 2 megabytes
 // pinned_buffer_pool
 //--------------------------------------------------------------------------------------------------
 class pinned_buffer_pool {
- public:
+public:
   explicit pinned_buffer_pool(size_t initial_size) noexcept;
 
   ~pinned_buffer_pool() noexcept;

--- a/sxt/base/device/pinned_buffer_pool.t.cc
+++ b/sxt/base/device/pinned_buffer_pool.t.cc
@@ -1,0 +1,11 @@
+#include "sxt/base/device/pinned_buffer_pool.h"
+
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+using namespace sxt::basdv;
+
+TEST_CASE("we can pool pinned buffers") {
+  size_t num_buffers = 3u;
+  pinned_buffer_pool pool{num_buffers};
+  REQUIRE(pool.num_buffers() == num_buffers);
+}

--- a/sxt/base/device/pinned_buffer_pool.t.cc
+++ b/sxt/base/device/pinned_buffer_pool.t.cc
@@ -1,6 +1,23 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/base/device/pinned_buffer_pool.h"
 
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 using namespace sxt::basdv;
 

--- a/sxt/base/device/pinned_buffer_pool.t.cc
+++ b/sxt/base/device/pinned_buffer_pool.t.cc
@@ -7,5 +7,19 @@ using namespace sxt::basdv;
 TEST_CASE("we can pool pinned buffers") {
   size_t num_buffers = 3u;
   pinned_buffer_pool pool{num_buffers};
-  REQUIRE(pool.num_buffers() == num_buffers);
+  REQUIRE(pool.size() == num_buffers);
+
+  SECTION("we can aquire and release buffers") {
+    auto h = pool.aquire_handle();
+    REQUIRE(pool.size() == num_buffers - 1);
+    pool.release_handle(h);
+    REQUIRE(pool.size() == num_buffers);
+  }
+
+  SECTION("we can aquire a handle from an empty pool") {
+    pinned_buffer_pool empty_pool{0};
+    auto h = empty_pool.aquire_handle();
+    empty_pool.release_handle(h);
+    REQUIRE(empty_pool.size() == 1);
+  }
 }


### PR DESCRIPTION
# Rationale for this change

Benchmarking shows that allocating pinned memory can be expensive. This PR adds a pool so that pinned allocations can be minimized.

I'll follow up with memory utility functions to make used of the pooled buffers and benchmarking for memory operations.

# What changes are included in this PR?

<!--
There is no need to duplicate the description in the ticket here but it is sometimes worth providing a summary of the individual changes in this PR.
-->Adds a pinned buffer pool and a pinned buffer class to easily manage the acquisition and release of pooled buffers.

# Are these changes tested?

<!--
We typically require tests for all PRs in order to:
1. Prevent the code from being accidentally broken by subsequent changes
2. Serve as another way to document the expected behavior of the code

If tests are not included in your PR, please explain why (for example, are they covered by existing tests)?
-->Yes.
