### PR TITLE
feat: add cache for sumcheck values (PROOF-913)

### DIFF
--- a/sxt/proof/sumcheck/BUILD
+++ b/sxt/proof/sumcheck/BUILD
@@ -9,6 +9,29 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "device_cache",
+    impl_deps = [
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:state",
+        "//sxt/base/device:stream",
+        "//sxt/memory/resource:device_resource",
+    ],
+    test_deps = [
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/device:stream",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/scalar25/type:literal",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/device:device_map",
+        "//sxt/memory/management:managed_array",
+        "//sxt/scalar25/type:element",
+    ],
+)
+
+sxt_cc_component(
     name = "workspace",
     with_test = False,
 )

--- a/sxt/proof/sumcheck/device_cache.cc
+++ b/sxt/proof/sumcheck/device_cache.cc
@@ -1,0 +1,70 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/device_cache.h"
+
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/state.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/memory/resource/device_resource.h"
+
+namespace sxt::prfsk {
+//--------------------------------------------------------------------------------------------------
+// make_device_copy
+//--------------------------------------------------------------------------------------------------
+static std::unique_ptr<device_cache_data>
+make_device_copy(basct::cspan<std::pair<s25t::element, unsigned>> product_table,
+                 basct::cspan<unsigned> product_terms, basdv::stream& stream) noexcept {
+  device_cache_data res{
+      .product_table{product_table.size(), memr::get_device_resource()},
+      .product_terms{product_terms.size(), memr::get_device_resource()},
+  };
+  basdv::async_copy_host_to_device(res.product_table, product_table, stream);
+  basdv::async_copy_host_to_device(res.product_terms, product_terms, stream);
+  return std::make_unique<device_cache_data>(std::move(res));
+}
+
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+device_cache::device_cache(basct::cspan<std::pair<s25t::element, unsigned>> product_table,
+                           basct::cspan<unsigned> product_terms) noexcept
+    : product_table_{product_table}, product_terms_{product_terms} {}
+
+//--------------------------------------------------------------------------------------------------
+// lookup
+//--------------------------------------------------------------------------------------------------
+void device_cache::lookup(basct::cspan<std::pair<s25t::element, unsigned>>& product_table,
+                          basct::cspan<unsigned>& product_terms, basdv::stream& stream) noexcept {
+  auto& ptr = data_[basdv::get_device()];
+  if (ptr == nullptr) {
+    ptr = make_device_copy(product_table_, product_terms_, stream);
+  }
+  product_table = ptr->product_table;
+  product_terms = ptr->product_terms;
+}
+
+//--------------------------------------------------------------------------------------------------
+// clear
+//--------------------------------------------------------------------------------------------------
+std::unique_ptr<device_cache_data> device_cache::clear() noexcept {
+  auto res{std::move(data_[basdv::get_device()])};
+  for (auto& ptr : data_) {
+    ptr.reset();
+  }
+  return res;
+}
+} // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/device_cache.h
+++ b/sxt/proof/sumcheck/device_cache.h
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/device/device_map.h"
+#include "sxt/memory/management/managed_array.h"
+#include "sxt/scalar25/type/element.h"
+
+namespace sxt::basdv {
+class stream;
+}
+
+namespace sxt::prfsk {
+//--------------------------------------------------------------------------------------------------
+// device_cache_data
+//--------------------------------------------------------------------------------------------------
+struct device_cache_data {
+  memmg::managed_array<std::pair<s25t::element, unsigned>> product_table;
+  memmg::managed_array<unsigned> product_terms;
+};
+
+//--------------------------------------------------------------------------------------------------
+// device_cache
+//--------------------------------------------------------------------------------------------------
+class device_cache {
+public:
+  device_cache(basct::cspan<std::pair<s25t::element, unsigned>> product_table,
+               basct::cspan<unsigned> product_terms) noexcept;
+
+  void lookup(basct::cspan<std::pair<s25t::element, unsigned>>& product_table,
+              basct::cspan<unsigned>& product_terms, basdv::stream& stream) noexcept;
+
+  std::unique_ptr<device_cache_data> clear() noexcept;
+
+private:
+  basct::cspan<std::pair<s25t::element, unsigned>> product_table_;
+  basct::cspan<unsigned> product_terms_;
+  basdv::device_map<std::unique_ptr<device_cache_data>> data_;
+};
+} // namespace sxt::prfsk

--- a/sxt/proof/sumcheck/device_cache.t.cc
+++ b/sxt/proof/sumcheck/device_cache.t.cc
@@ -66,7 +66,11 @@ TEST_CASE("we can cache device values that don't change as a proof is computed")
     std::vector<unsigned> product_terms_p(product_terms.size());
     basdv::async_copy_device_to_host(product_terms_p, product_terms_dev, stream);
 
+    auto data = cache.clear();
+    basdv::async_copy_device_to_host(product_table_p, data->product_table, stream);
+    basdv::async_copy_device_to_host(product_terms_p, data->product_terms, stream);
     basdv::synchronize_stream(stream);
-    cache.clear();
+    REQUIRE(product_table_p == product_table);
+    REQUIRE(product_terms_p == product_terms);
   }
 }

--- a/sxt/proof/sumcheck/device_cache.t.cc
+++ b/sxt/proof/sumcheck/device_cache.t.cc
@@ -1,0 +1,72 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/proof/sumcheck/device_cache.h"
+
+#include <vector>
+
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/scalar25/type/literal.h"
+
+using namespace sxt;
+using namespace sxt::prfsk;
+using s25t::operator""_s25;
+
+TEST_CASE("we can cache device values that don't change as a proof is computed") {
+  std::vector<std::pair<s25t::element, unsigned>> product_table;
+  std::vector<unsigned> product_terms;
+
+  basdv::stream stream;
+
+  basct::cspan<std::pair<s25t::element, unsigned>> product_table_dev;
+  basct::cspan<unsigned> product_terms_dev;
+
+  SECTION("we can access values from device memory") {
+    product_table = {{0x123_s25, 0}};
+    product_terms = {0};
+    device_cache cache{product_table, product_terms};
+    cache.lookup(product_table_dev, product_terms_dev, stream);
+
+    std::vector<std::pair<s25t::element, unsigned>> product_table_p(product_table.size());
+    basdv::async_copy_device_to_host(product_table_p, product_table_dev, stream);
+
+    std::vector<unsigned> product_terms_p(product_terms.size());
+    basdv::async_copy_device_to_host(product_terms_p, product_terms_dev, stream);
+
+    basdv::synchronize_stream(stream);
+    REQUIRE(product_table_p == product_table);
+    REQUIRE(product_terms_p == product_terms);
+  }
+
+  SECTION("we can clear the device cache") {
+    product_table = {{0x123_s25, 0}};
+    product_terms = {0};
+    device_cache cache{product_table, product_terms};
+    cache.lookup(product_table_dev, product_terms_dev, stream);
+
+    std::vector<std::pair<s25t::element, unsigned>> product_table_p(product_table.size());
+    basdv::async_copy_device_to_host(product_table_p, product_table_dev, stream);
+
+    std::vector<unsigned> product_terms_p(product_terms.size());
+    basdv::async_copy_device_to_host(product_terms_p, product_terms_dev, stream);
+
+    basdv::synchronize_stream(stream);
+    cache.clear();
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a device cache for sumcheck values reused between rounds.

This will be used to support a chunked version of sumcheck.

# What changes are included in this PR?

* Adds a component device_cache to manage sumcheck values cached on a device.

# Are these changes tested?

Yes
