### PR TITLE
chore: fix spelling errors in `backend.cc`, `reduce.t.cc`, and `exponent_aggregates_computation.cc`

### DIFF
--- a/cbindings/backend.cc
+++ b/cbindings/backend.cc
@@ -75,7 +75,7 @@ static void try_get_environ_backend(int& backend) noexcept {
     return;
   }
   std::string s{val};
-  basl::info("override default backend with environmental varaible BLITZAR_BACKEND={}", s);
+  basl::info("override default backend with environmental variable BLITZAR_BACKEND={}", s);
   for (auto& c : s) {
     c = std::tolower(c);
   }

--- a/sxt/multiexp/pippenger/exponent_aggregates_computation.cc
+++ b/sxt/multiexp/pippenger/exponent_aggregates_computation.cc
@@ -32,9 +32,9 @@
 
 namespace sxt::mtxpi {
 //--------------------------------------------------------------------------------------------------
-// aggegate_term
+// aggregate_term
 //--------------------------------------------------------------------------------------------------
-static void aggegate_term(exponent_aggregates& aggregates, basct::cspan<uint8_t> term,
+static void aggregate_term(exponent_aggregates& aggregates, basct::cspan<uint8_t> term,
                           size_t output_index, size_t term_index) noexcept {
   basbt::or_equal(aggregates.term_or_all[term_index], term);
   basbt::or_equal(aggregates.output_or_all[output_index], term);
@@ -50,7 +50,7 @@ static void aggregate_unsigned_terms(exponent_aggregates& aggregates, size_t out
   auto element_nbytes = sequence.element_nbytes;
   for (size_t term_index = 0; term_index < sequence.n; ++term_index) {
     basct::cspan<uint8_t> term{sequence.data + term_index * element_nbytes, element_nbytes};
-    aggegate_term(aggregates, term, output_index, term_index);
+    aggregate_term(aggregates, term, output_index, term_index);
   }
 }
 
@@ -66,9 +66,9 @@ static void aggregate_signed_terms(exponent_aggregates& aggregates, size_t outpu
     auto abs_x = basn::abs_to_unsigned(x);
     basct::cspan<uint8_t> term{reinterpret_cast<uint8_t*>(&abs_x), NumBytes};
     if (x >= 0) {
-      aggegate_term(aggregates, term, output_index, term_index);
+      aggregate_term(aggregates, term, output_index, term_index);
     } else {
-      aggegate_term(aggregates, term, output_index + 1, term_index);
+      aggregate_term(aggregates, term, output_index + 1, term_index);
     }
   }
 }

--- a/sxt/scalar25/operation/reduce.t.cc
+++ b/sxt/scalar25/operation/reduce.t.cc
@@ -76,7 +76,7 @@ TEST_CASE("we correctly reduces arrays with 64 bytes") {
     element s = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ec_s25;
     element expected_s = s;
     uint8_t s_data[64] = {};
-    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the begginning of s_data
+    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the beginning of s_data
     reduce64(s, s_data);
     REQUIRE(s == expected_s);
   }
@@ -84,7 +84,7 @@ TEST_CASE("we correctly reduces arrays with 64 bytes") {
   SECTION("we correctly reduce A when A = L (L = the field order)") {
     element s = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed_s25;
     uint8_t s_data[64] = {};
-    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the begginning of s_data
+    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the beginning of s_data
     reduce64(s, s_data);
     REQUIRE(s == 0x0_s25);
   }
@@ -92,7 +92,7 @@ TEST_CASE("we correctly reduces arrays with 64 bytes") {
   SECTION("we correctly reduce A when A = L + 103 (L = the field order)") {
     element s = 0x1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d454_s25;
     uint8_t s_data[64] = {};
-    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the begginning of s_data
+    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the beginning of s_data
     reduce64(s, s_data);
     REQUIRE(s == 0x67_s25);
   }
@@ -100,7 +100,7 @@ TEST_CASE("we correctly reduces arrays with 64 bytes") {
   SECTION("we correctly reduce A when A is the biggest 256bits integer") {
     element s = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_s25;
     uint8_t s_data[64] = {};
-    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the begginning of s_data
+    std::memcpy(s_data, s.data(), 32); // we copy the 32 bytes to the beginning of s_data
     reduce64(s, s_data);
     REQUIRE(s == 0xffffffffffffffffffffffffffffffec6ef5bf4737dcf70d6ec31748d98951c_s25);
   }
@@ -108,7 +108,7 @@ TEST_CASE("we correctly reduces arrays with 64 bytes") {
   SECTION("we correctly reduce A when A is the biggest 512bits integer") {
     element s = 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff_s25;
     uint8_t s_data[64] = {};
-    std::memcpy(s_data, s.data(), 32);      // we copy the 32 bytes to the begginning of s_data
+    std::memcpy(s_data, s.data(), 32);      // we copy the 32 bytes to the beginning of s_data
     std::memcpy(s_data + 32, s.data(), 32); // we copy the 32 bytes to the end of s_data
     reduce64(s, s_data);
     REQUIRE(s == 0x399411b7c309a3dceec73d217f5be65d00e1ba768859347a40611e3449c0f00_s25);


### PR DESCRIPTION
1. **`backend.cc`**:
   - Fixed "varaible" → "variable" in a log message.

2. **`exponent_aggregates_computation.cc`**:
   - Corrected multiple instances of "aggegate_term" → "aggregate_term" in function definitions and calls.

3. **`reduce.t.cc`**:
   - Fixed "begginning" → "beginning" in multiple comments describing memory operations.

### Are These Changes Tested?
These updates only correct spelling errors in comments and function names. No functional changes were made, so existing tests should continue to pass without modifications.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Enhancement

### Checklist
- [x] Self-reviewed the changes.
- [ ] Opened or linked an existing issue if applicable.

### Impact
**Impact**: Low. These changes are limited to spelling corrections in comments and function names, with no effect on functionality.
