### PR TITLE
feat: support serializing packed multi-exponentiations (PROOF-927)

### DIFF
--- a/sxt/multiexp/pippenger2/BUILD
+++ b/sxt/multiexp/pippenger2/BUILD
@@ -271,6 +271,7 @@ sxt_cc_component(
         "//sxt/base/container:span",
         "//sxt/base/curve:element",
         "//sxt/base/error:assert",
+        "//sxt/base/num:divide_up",
         "//sxt/base/system:file_io",
     ],
 )

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
@@ -21,16 +21,27 @@
 #include <format>
 #include <fstream>
 #include <memory>
+#include <numeric>
 #include <vector>
 
 #include "sxt/base/container/span.h"
 #include "sxt/base/curve/element.h"
 #include "sxt/base/error/assert.h"
+#include "sxt/base/num/divide_up.h"
 #include "sxt/base/system/file_io.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h"
 #include "sxt/multiexp/pippenger2/partition_table_accessor.h"
 
 namespace sxt::mtxpp2 {
+//--------------------------------------------------------------------------------------------------
+// packed_multiexponentiation_descriptor
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T, class U> struct packed_multiexponentiation_descriptor {
+  std::unique_ptr<partition_table_accessor<U>> accessor;
+  std::vector<unsigned> output_bit_table;
+  std::vector<uint8_t> scalars;
+};
+
 //--------------------------------------------------------------------------------------------------
 // variable_length_multiexponentiation_descriptor
 //--------------------------------------------------------------------------------------------------
@@ -44,6 +55,29 @@ template <bascrv::element T, class U> struct variable_length_multiexponentiation
 //--------------------------------------------------------------------------------------------------
 // write_multiexponentiation
 //--------------------------------------------------------------------------------------------------
+template <bascrv::element T, class U>
+void write_multiexponentiation(std::string_view dir, const partition_table_accessor<U>& accessor,
+                               basct::cspan<unsigned> output_bit_table,
+                               basct::cspan<uint8_t> scalars) noexcept {
+  size_t num_products = std::accumulate(output_bit_table.begin(), output_bit_table.end(), 0ull);
+  auto num_output_bytes = basn::divide_up<size_t>(num_products, 8);
+  SXT_DEBUG_ASSERT(
+      scalars.size() % num_output_bytes == 0
+  );
+  auto n = scalars.size() / num_output_bytes;
+
+  bassy::write_file(std::format("{}/output_bit_table.bin", dir), output_bit_table);
+  bassy::write_file(std::format("{}/scalars.bin", dir), scalars);
+
+  std::vector<U> generators(n);
+  accessor.copy_generators(generators);
+  bassy::write_file<U>(std::format("{}/generators.bin", dir), generators);
+
+  uint64_t window_width = accessor.window_width();
+  bassy::write_file(std::format("{}/window_width.bin", dir),
+                    basct::cspan<uint64_t>{&window_width, 1});
+}
+
 template <bascrv::element T, class U>
 void write_multiexponentiation(std::string_view dir, const partition_table_accessor<U>& accessor,
                                basct::cspan<unsigned> output_bit_table,
@@ -69,6 +103,23 @@ void write_multiexponentiation(std::string_view dir, const partition_table_acces
 //--------------------------------------------------------------------------------------------------
 // read_multiexponentiation
 //--------------------------------------------------------------------------------------------------
+template <bascrv::element T, class U>
+void read_multiexponentiation(packed_multiexponentiation_descriptor<T, U>& descr,
+                              std::string_view dir) noexcept {
+  bassy::read_file(descr.output_bit_table, std::format("{}/output_bit_table.bin", dir));
+  bassy::read_file(descr.scalars, std::format("{}/scalars.bin", dir));
+
+  // accessor
+  std::vector<uint64_t> window_width;
+  bassy::read_file(window_width, std::format("{}/window_width.bin", dir));
+  SXT_RELEASE_ASSERT(window_width.size() == 1);
+  std::vector<U> generators;
+  bassy::read_file(generators, std::format("{}/generators.bin", dir));
+  std::vector<T> generators_p{generators.begin(), generators.end()};
+  descr.accessor =
+      make_in_memory_partition_table_accessor<U>(generators_p, basm::alloc_t{}, window_width[0]);
+}
+
 template <bascrv::element T, class U>
 void read_multiexponentiation(variable_length_multiexponentiation_descriptor<T, U>& descr,
                               std::string_view dir) noexcept {

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
@@ -61,9 +61,7 @@ void write_multiexponentiation(std::string_view dir, const partition_table_acces
                                basct::cspan<uint8_t> scalars) noexcept {
   size_t num_products = std::accumulate(output_bit_table.begin(), output_bit_table.end(), 0ull);
   auto num_output_bytes = basn::divide_up<size_t>(num_products, 8);
-  SXT_DEBUG_ASSERT(
-      scalars.size() % num_output_bytes == 0
-  );
+  SXT_DEBUG_ASSERT(scalars.size() % num_output_bytes == 0);
   auto n = scalars.size() / num_output_bytes;
 
   bassy::write_file(std::format("{}/output_bit_table.bin", dir), output_bit_table);

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.t.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.t.cc
@@ -49,7 +49,7 @@ TEST_CASE("we can serialize and deserialize a multiexponentiations") {
     REQUIRE(descr.accessor->window_width() == accessor->window_width());
   }
 
-  SECTION("we can serialize then deserialize a multiexponentiation") {
+  SECTION("we can serialize then deserialize a packed multiexponentiation") {
     write_multiexponentiation<E>(dir.name(), *accessor, output_bit_table, scalars);
 
     packed_multiexponentiation_descriptor<E, E> descr;

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.t.cc
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.t.cc
@@ -23,7 +23,7 @@
 using namespace sxt;
 using namespace sxt::mtxpp2;
 
-TEST_CASE("we can serialize and deserialize a variable length multiexponentiation") {
+TEST_CASE("we can serialize and deserialize a multiexponentiations") {
   using E = bascrv::element97;
 
   bastst::temp_directory dir;
@@ -32,15 +32,29 @@ TEST_CASE("we can serialize and deserialize a variable length multiexponentiatio
   auto accessor = make_in_memory_partition_table_accessor<E>(generators);
   std::vector<unsigned> output_bit_table = {1, 1};
   std::vector<unsigned> output_lengths = {1, 2};
-  std::vector<uint8_t> scalars = {3, 2, 1};
+  std::vector<uint8_t> scalars = {3, 0, 2, 1};
 
-  SECTION("we can serialize then deserialize") {
+  SECTION("we can serialize then deserialize a variable length multiexponentiation") {
     write_multiexponentiation<E>(dir.name(), *accessor, output_bit_table, output_lengths, scalars);
 
     variable_length_multiexponentiation_descriptor<E, E> descr;
     read_multiexponentiation(descr, dir.name());
     REQUIRE(descr.output_bit_table == output_bit_table);
     REQUIRE(descr.output_lengths == output_lengths);
+    REQUIRE(descr.scalars == scalars);
+    std::vector<E> generators_p(2);
+    descr.accessor->copy_generators(generators_p);
+    REQUIRE(generators[0] == generators_p[0]);
+    REQUIRE(generators[1] == generators_p[1]);
+    REQUIRE(descr.accessor->window_width() == accessor->window_width());
+  }
+
+  SECTION("we can serialize then deserialize a multiexponentiation") {
+    write_multiexponentiation<E>(dir.name(), *accessor, output_bit_table, scalars);
+
+    packed_multiexponentiation_descriptor<E, E> descr;
+    read_multiexponentiation(descr, dir.name());
+    REQUIRE(descr.output_bit_table == output_bit_table);
     REQUIRE(descr.scalars == scalars);
     std::vector<E> generators_p(2);
     descr.accessor->copy_generators(generators_p);


### PR DESCRIPTION
# Rationale for this change

Follow up to #237 . Adds serialization support for more multiexponentiation APIs.

# What changes are included in this PR?

* extends serialization for packed multi-exponentiations.

# Are these changes tested?

Yes
