### PR TITLE
docs: Fix incorrect closing tags in badge links

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,27 +26,22 @@
   <a href="https://github.com/spaceandtimelabs/blitzar/blob/main/LICENSE">
     <img alt="License" src="https://img.shields.io/badge/License-Apache_2.0-blue.svg">
     </a>
-  </a>
 
   <a href="https://en.cppreference.com/w/cpp/20">
     <img alt="C++ Logo" src="https://img.shields.io/badge/C%2B%2B-20-blue?style=flat&logo=c%2B%2B">
     </a>
-  </a>
 
   <a href="https://www.linux.org/">
     <img alt="OS" src="https://img.shields.io/badge/OS-Linux-blue?logo=linux">
     </a>
-  </a>
 
   <a href="https://www.linux.org/">
     <img alt="CPU" src="https://img.shields.io/badge/CPU-x86-red">
     </a>
-  </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
     <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
     </a>
-  </a>
 
   <p align="center">
     Space and Time C++ library for accelerating cryptographic zero-knowledge proofs algorithms on the CPU and GPU.


### PR DESCRIPTION
# **Rationale for this change**

The extra `</a>` tags were creating an incorrect HTML structure, causing potential issues in rendering. This fix ensures that each anchor (`<a>`) tag correctly wraps its respective image (`<img>`) tag, improving the HTML structure and ensuring proper functionality.

# **What changes are included in this PR?**

Removed the extra `</a>` closing tags from each badge link section to restore correct HTML structure.

# **Are these changes tested?**

This change does not directly require tests since it involves fixing HTML structure, but it ensures that the page renders correctly without breaking any functionality.