### PR TITLE
fix: fix chunked multi-exponentiation (PROOF-926)

### DIFF
--- a/sxt/multiexp/pippenger2/multiexponentiation.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation.h
@@ -175,7 +175,6 @@ multiexponentiate_impl(basct::span<T> res, const partition_table_accessor<U>& ac
   size_t chunk_index = 0;
   co_await xendv::concurrent_for_each(
       chunk_first, chunk_last, [&](const basit::index_range& rng) noexcept -> xena::future<> {
-        co_return;
         basl::info("computing {} multiproducts for generators [{}, {}] on device {}", num_products,
                    rng.a(), rng.b(), basdv::get_device());
         memmg::managed_array<T> partial_products_dev{num_products, memr::get_device_resource()};


### PR DESCRIPTION
# Rationale for this change

From a previous PR, I accidentally left in some code that I was using for testing that breaks chunked multi-exponentiations.

This PR undoes that change.

Fixes #241 

# What changes are included in this PR?

* Removes a co_return statement I used for testing.

# Are these changes tested?

Yes. I added additional test cases for the area of code that was missed.
