### PR TITLE
feat: improvements to serialization (PROOF-927)

### DIFF
--- a/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
+++ b/sxt/multiexp/pippenger2/in_memory_partition_table_accessor_utility.h
@@ -61,11 +61,14 @@ std::unique_ptr<partition_table_accessor<U>> make_in_memory_partition_table_acce
 // make_in_memory_partition_table_accessor
 //--------------------------------------------------------------------------------------------------
 template <class U, class T>
-  requires(!std::same_as<U, T>)
 std::unique_ptr<partition_table_accessor<U>> make_in_memory_partition_table_accessor(
     basct::cspan<T> generators, basm::alloc_t alloc = memr::get_pinned_resource(),
     unsigned window_width = get_default_window_width()) noexcept {
-  return make_in_memory_partition_table_accessor_impl<U, T>(generators, alloc, window_width);
+  if constexpr (!std::is_same_v<U, T>) {
+    return make_in_memory_partition_table_accessor_impl<U, T>(generators, alloc, window_width);
+  } else {
+    return make_in_memory_partition_table_accessor_impl<T, T>(generators, alloc, window_width);
+  }
 }
 
 template <class T>

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
@@ -53,6 +53,18 @@ template <bascrv::element T, class U> struct variable_length_multiexponentiation
 };
 
 //--------------------------------------------------------------------------------------------------
+// write_meta_info
+//--------------------------------------------------------------------------------------------------
+template <bascrv::element T, class U>
+void write_meta_info(std::string_view filename, size_t num_outputs) noexcept {
+  std::string s;
+  s.append(std::format("element type: {}\n", typeid(T).name()));
+  s.append(std::format("accessor type: {}\n", typeid(U).name()));
+  s.append(std::format("num_outputs: {}\n", typeid(U).name()));
+  bassy::write_file<char>(filename, s);
+}
+
+//--------------------------------------------------------------------------------------------------
 // write_multiexponentiation
 //--------------------------------------------------------------------------------------------------
 template <bascrv::element T, class U>
@@ -66,6 +78,7 @@ void write_multiexponentiation(std::string_view dir, const partition_table_acces
 
   bassy::write_file(std::format("{}/output_bit_table.bin", dir), output_bit_table);
   bassy::write_file(std::format("{}/scalars.bin", dir), scalars);
+  write_meta_info<T, U>(std::format("{}/meta.txt", dir), output_bit_table.size());
 
   std::vector<U> generators(n);
   accessor.copy_generators(generators);
@@ -88,6 +101,7 @@ void write_multiexponentiation(std::string_view dir, const partition_table_acces
   bassy::write_file(std::format("{}/output_bit_table.bin", dir), output_bit_table);
   bassy::write_file(std::format("{}/output_lengths.bin", dir), output_lengths);
   bassy::write_file(std::format("{}/scalars.bin", dir), scalars);
+  write_meta_info<T, U>(std::format("{}/meta.txt", dir), output_bit_table.size());
 
   std::vector<U> generators(n);
   accessor.copy_generators(generators);

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
@@ -60,7 +60,7 @@ void write_meta_info(std::string_view filename, size_t num_outputs) noexcept {
   std::string s;
   s.append(std::format("element type: {}\n", typeid(T).name()));
   s.append(std::format("accessor type: {}\n", typeid(U).name()));
-  s.append(std::format("num_outputs: {}\n", typeid(U).name()));
+  s.append(std::format("num_outputs: {}\n", num_outputs));
   bassy::write_file<char>(filename, s);
 }
 

--- a/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
+++ b/sxt/multiexp/pippenger2/multiexponentiation_serialization.h
@@ -115,7 +115,7 @@ void read_multiexponentiation(packed_multiexponentiation_descriptor<T, U>& descr
   bassy::read_file(generators, std::format("{}/generators.bin", dir));
   std::vector<T> generators_p{generators.begin(), generators.end()};
   descr.accessor =
-      make_in_memory_partition_table_accessor<U>(generators_p, basm::alloc_t{}, window_width[0]);
+      make_in_memory_partition_table_accessor<U, T>(generators_p, basm::alloc_t{}, window_width[0]);
 }
 
 template <bascrv::element T, class U>
@@ -133,6 +133,6 @@ void read_multiexponentiation(variable_length_multiexponentiation_descriptor<T, 
   bassy::read_file(generators, std::format("{}/generators.bin", dir));
   std::vector<T> generators_p{generators.begin(), generators.end()};
   descr.accessor =
-      make_in_memory_partition_table_accessor<U>(generators_p, basm::alloc_t{}, window_width[0]);
+      make_in_memory_partition_table_accessor<U, T>(generators_p, basm::alloc_t{}, window_width[0]);
 }
 } // namespace sxt::mtxpp2


### PR DESCRIPTION
# Rationale for this change

Make reading serialized multi-exponentiations easier and add metadata in plain text.

# What changes are included in this PR?

* Small refactoring of in memory data accessor utility
* Add a meta.txt file to a multi-exponentiation serialization.

# Are these changes tested?

Reuses existing tests.
