### PR TITLE
feat: add c api for proving sumcheck (PROOF-913)

### DIFF
--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -224,6 +224,9 @@ sxt_cc_component(
     test_deps = [
         ":backend",
         "//sxt/base/test:unit_test",
+        "//sxt/proof/sumcheck:reference_transcript",
+        "//sxt/scalar25/type:element",
+        "//sxt/scalar25/type:literal",
     ],
     deps = [
         ":blitzar_api",

--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -225,6 +225,7 @@ sxt_cc_component(
         ":backend",
         "//sxt/base/test:unit_test",
         "//sxt/proof/sumcheck:reference_transcript",
+        "//sxt/scalar25/operation:overload",
         "//sxt/scalar25/type:element",
         "//sxt/scalar25/type:literal",
     ],

--- a/cbindings/BUILD
+++ b/cbindings/BUILD
@@ -17,6 +17,7 @@ cuda_library(
         ":get_one_commit",
         ":inner_product_proof",
         ":pedersen",
+        ":sumcheck",
     ],
     alwayslink = 1,
 )
@@ -208,6 +209,21 @@ sxt_cc_component(
         "//sxt/scalar25/random:element",
         "//sxt/scalar25/type:element",
         "//sxt/scalar25/type:literal",
+    ],
+    deps = [
+        ":blitzar_api",
+    ],
+    alwayslink = 1,
+)
+
+sxt_cc_component(
+    name = "sumcheck",
+    impl_deps = [
+        ":backend",
+    ],
+    test_deps = [
+        ":backend",
+        "//sxt/base/test:unit_test",
     ],
     deps = [
         ":blitzar_api",

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -30,6 +30,8 @@ extern "C" {
 #define SXT_CURVE_BN_254 2
 #define SXT_CURVE_GRUMPKIN 3
 
+#define SXT_FIELD_SCALAR255 0
+
 /** config struct to hold the chosen backend */
 struct sxt_config {
   int backend;
@@ -689,6 +691,22 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
                                         const unsigned* output_bit_table,
                                         const unsigned* output_lengths, unsigned num_outputs,
                                         const uint8_t* scalars);
+
+/**
+ * TODO: fill me in
+ */
+void sxt_prove_sumcheck(
+    void* polynomials,
+    void* evaluation_point,
+    unsigned field_id,
+    const void* transcript_callback,
+    void* transcript_context,
+    const void* mles,
+    const void* product_table,
+    const unsigned* product_terms,
+    unsigned num_outputs,
+    unsigned n);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -710,10 +710,8 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
  * TODO: fill me in
  */
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                        const sumcheck_descriptor* descriptor,
-                        void* transcript_callback,
-                        void* transcript_context
-                        );
+                        const sumcheck_descriptor* descriptor, void* transcript_callback,
+                        void* transcript_context);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -710,7 +710,10 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
  * TODO: fill me in
  */
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                        const sumcheck_descriptor* descriptor);
+                        const sumcheck_descriptor* descriptor,
+                        void* transcript_callback,
+                        void* transcript_context
+                        );
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -755,7 +755,7 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
  *  and will be invoked each sumcheck round to draw a random FIELD entry.
  *
  * output:
- * polynomials points to an (round_degree + 1) x (num_variables) matrix of type FIELD
+ * polynomials points to an (round_degree + 1) x (num_variables) column major matrix of type FIELD
  * and will be filled with the sumcheck round polynomials upon completion.
  *
  * evaluation_point points to a num_variables array of type FIELD and will contain

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -129,17 +129,53 @@ struct sxt_sequence_descriptor {
   int is_signed;
 };
 
-/** describe inputs to a sumcheck proof */
+/** Describe inputs to a sumcheck proof.
+ *
+ * The sumcheck proof is constructed using a polynomial of the form
+ *
+ * sum_i^num_products {mult_i x prod_j^product_length_i f_j(X1, ..., Xr)}
+ *
+ * where f_j(X1, ..., Xr) denotes a multilinear extension of r variables.
+ *
+ * Pointer types are dependent on the field type as specified
+ * by the field id.
+ *
+ * We will let FIELD denote the field type when describing fields.
+ */
 struct sumcheck_descriptor {
   // multilinear extensions referenced in a sumcheck proof
+  //
+  // mles should point to a n x num_mles column major matrix of
+  // type FIELD
   const void* mles;
 
+  // Describe each product of the sumcheck polynomial. product_table should
+  // point to an num_products array with entries of type
+  //
+  // struct {
+  //    FIELD multiplier
+  //    unsigned product_length
+  // }
   const void* product_table;
+
+  // MLE indices for the entries in product_table
   const unsigned* product_terms;
+
+  // The length of each MLE
   unsigned n;
+
+  // The number of distinct MLEs
   unsigned num_mles;
+
+  // The number of products in the sumcheck polynomial
   unsigned num_products;
+
+  /// The total number of total product terms in the sumcheck polynomial
+  // sum_i product_length_i
   unsigned num_product_terms;
+
+  // The degree of the round polynomial for sumcheck
+  // max_i product_length_i
   unsigned round_degree;
 };
 
@@ -707,7 +743,24 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
                                         const uint8_t* scalars);
 
 /**
- * TODO: fill me in
+ * Construct a sumcheck proof for a polynomial
+ *
+ * sum_i^num_products {mult_i x prod_j^product_length_i f_j(X1, ..., Xr)}
+ *
+ * input:
+ * field_id identifies the field of the sumcheck polynomial
+ * descriptor describes the sumcheck polynomial
+ * transcript_callback points to a function with signature
+ *      void (FIELD* r, void* context, FIELD* polynomial, unsigned polynomial_length)
+ *  and will be invoked each sumcheck round to draw a random FIELD entry.
+ *
+ * output:
+ * polynomials points to an (round_degree + 1) x (num_variables) matrix of type FIELD
+ * and will be filled with the sumcheck round polynomials upon completion.
+ *
+ * evaluation_point points to a num_variables array of type FIELD and will contain
+ * the evaluation point for sumcheck upon completion as set by the transcript_callback.
+ *
  */
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
                         const sumcheck_descriptor* descriptor, void* transcript_callback,

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -129,11 +129,11 @@ struct sxt_sequence_descriptor {
   int is_signed;
 };
 
-//--------------------------------------------------------------------------------------------------
-// sumcheck_descriptor
-//--------------------------------------------------------------------------------------------------
+/** describe inputs to a sumcheck proof */
 struct sumcheck_descriptor {
+  // multilinear extensions referenced in a sumcheck proof
   const void* mles;
+
   const void* product_table;
   const unsigned* product_terms;
   unsigned n;

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -129,6 +129,20 @@ struct sxt_sequence_descriptor {
   int is_signed;
 };
 
+//--------------------------------------------------------------------------------------------------
+// sumcheck_descriptor
+//--------------------------------------------------------------------------------------------------
+struct sumcheck_descriptor {
+  const void* mles;
+  const void* product_table;
+  const unsigned* product_terms;
+  unsigned n;
+  unsigned num_mles;
+  unsigned num_products;
+  unsigned num_product_terms;
+  unsigned round_degree;
+};
+
 /** resources for multiexponentiations with pre-specified generators */
 struct sxt_multiexp_handle;
 
@@ -695,17 +709,8 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
 /**
  * TODO: fill me in
  */
-void sxt_prove_sumcheck(
-    void* polynomials,
-    void* evaluation_point,
-    unsigned field_id,
-    const void* transcript_callback,
-    void* transcript_context,
-    const void* mles,
-    const void* product_table,
-    const unsigned* product_terms,
-    unsigned num_outputs,
-    unsigned n);
+void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                        const sumcheck_descriptor* descriptor);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -763,7 +763,7 @@ void sxt_fixed_vlen_multiexponentiation(void* res, const struct sxt_multiexp_han
  *
  */
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                        const sumcheck_descriptor* descriptor, void* transcript_callback,
+                        const struct sumcheck_descriptor* descriptor, void* transcript_callback,
                         void* transcript_context);
 
 #ifdef __cplusplus

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -8,6 +8,6 @@
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                        const sumcheck_descriptor* descriptor) {
-}
+                        const sumcheck_descriptor* descriptor, void* transcript_callback,
+                        void* transcript_context) {}
 #pragma clang diagnostic pop

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -14,8 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "cbindings/sumcheck.h"
 #include "cbindings/backend.h"
-#include "cbindings/fixed_pedersen.h"
 
 using namespace sxt;
 

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #include "cbindings/sumcheck.h"
+
 #include "cbindings/backend.h"
 
 using namespace sxt;

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -1,0 +1,22 @@
+#include "cbindings/fixed_pedersen.h"
+
+//--------------------------------------------------------------------------------------------------
+// sxt_prove_sumcheck
+//--------------------------------------------------------------------------------------------------
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+void sxt_prove_sumcheck(
+    void* polynomials,
+    void* evaluation_point,
+    unsigned field_id,
+    const void* transcript_callback,
+    void* transcript_context,
+    const void* mles,
+    const void* product_table,
+    const unsigned* product_terms,
+    unsigned num_outputs,
+    unsigned n) {
+}
+#pragma clang diagnostic pop

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -27,6 +27,8 @@ void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned fiel
                         const sumcheck_descriptor* descriptor, void* transcript_callback,
                         void* transcript_context) {
   auto backend = cbn::get_backend();
+  static_assert(sizeof(sumcheck_descriptor) == sizeof(cbnb::sumcheck_descriptor),
+                "sumcheck descriptors must be binary compatible");
   backend->prove_sumcheck(polynomials, evaluation_point, field_id,
                           *reinterpret_cast<const cbnb::sumcheck_descriptor*>(descriptor),
                           transcript_callback, transcript_context);

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -7,16 +7,7 @@
 #pragma clang diagnostic ignored "-Wunused-function"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
-void sxt_prove_sumcheck(
-    void* polynomials,
-    void* evaluation_point,
-    unsigned field_id,
-    const void* transcript_callback,
-    void* transcript_context,
-    const void* mles,
-    const void* product_table,
-    const unsigned* product_terms,
-    unsigned num_outputs,
-    unsigned n) {
+void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                        const sumcheck_descriptor* descriptor) {
 }
 #pragma clang diagnostic pop

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -1,6 +1,21 @@
-#include "cbindings/fixed_pedersen.h"
-
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "cbindings/backend.h"
+#include "cbindings/fixed_pedersen.h"
 
 using namespace sxt;
 

--- a/cbindings/sumcheck.cc
+++ b/cbindings/sumcheck.cc
@@ -1,13 +1,17 @@
 #include "cbindings/fixed_pedersen.h"
 
+#include "cbindings/backend.h"
+
+using namespace sxt;
+
 //--------------------------------------------------------------------------------------------------
 // sxt_prove_sumcheck
 //--------------------------------------------------------------------------------------------------
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-parameter"
 void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
                         const sumcheck_descriptor* descriptor, void* transcript_callback,
-                        void* transcript_context) {}
-#pragma clang diagnostic pop
+                        void* transcript_context) {
+  auto backend = cbn::get_backend();
+  backend->prove_sumcheck(polynomials, evaluation_point, field_id,
+                          *reinterpret_cast<const cbnb::sumcheck_descriptor*>(descriptor),
+                          transcript_callback, transcript_context);
+}

--- a/cbindings/sumcheck.h
+++ b/cbindings/sumcheck.h
@@ -17,4 +17,3 @@
 #pragma once
 
 #include "cbindings/blitzar_api.h"
-

--- a/cbindings/sumcheck.h
+++ b/cbindings/sumcheck.h
@@ -1,0 +1,20 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2024-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "cbindings/blitzar_api.h"
+

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -28,7 +28,7 @@
 using namespace sxt;
 using s25t::operator""_s25;
 
-TEST_CASE("todo") {
+TEST_CASE("we can create sumcheck proofs") {
   prft::transcript base_transcript{"abc"};
   prfsk::reference_transcript transcript{base_transcript};
 

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -21,6 +21,7 @@
 #include "cbindings/backend.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/proof/sumcheck/reference_transcript.h"
+#include "sxt/scalar25/operation/overload.h"
 #include "sxt/scalar25/type/element.h"
 #include "sxt/scalar25/type/literal.h"
 
@@ -58,23 +59,21 @@ TEST_CASE("todo") {
         *r, {polynomial, polynomial_len});
   };
 
-  SECTION("we can prove a sum with n=1 on GPU") {
+  SECTION("we can prove a sum with n=2 on GPU") {
     cbn::reset_backend_for_testing();
     const sxt_config config = {SXT_GPU_BACKEND, 0};
     REQUIRE(sxt_init(&config) == 0);
 
     sxt_prove_sumcheck(polynomials.data(), evaluation_point.data(), SXT_FIELD_SCALAR255,
                        &descriptor, reinterpret_cast<void*>(+f), &transcript);
+    REQUIRE(polynomials[0] == mles[0]);
+    REQUIRE(polynomials[1] == mles[1] - mles[0]);
+    {
+      prft::transcript base_transcript_p{"abc"};
+      prfsk::reference_transcript transcript_p{base_transcript_p};
+      s25t::element r;
+      transcript_p.round_challenge(r, polynomials);
+      REQUIRE(evaluation_point[0] == r);
+    }
   }
 }
-#if 0
-
-  SECTION("we can prove a sum with n=1") {
-    auto fut = prove_sum(polynomials, evaluation_point, transcript, drv, mles, product_table,
-                         product_terms, 1);
-    xens::get_scheduler().run();
-    REQUIRE(fut.ready());
-    REQUIRE(polynomials[0] == mles[0]);
-    REQUIRE(polynomials[1] == -mles[0]);
-  }
-#endif

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "cbindings/sumcheck.h"
 
 #include <vector>
@@ -7,6 +23,7 @@
 #include "sxt/proof/sumcheck/reference_transcript.h"
 #include "sxt/scalar25/type/element.h"
 #include "sxt/scalar25/type/literal.h"
+
 using namespace sxt;
 using s25t::operator""_s25;
 

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -1,0 +1,5 @@
+#include "cbindings/sumcheck.h"
+
+#include "sxt/base/test/unit_test.h"
+
+TEST_CASE("todo") {}

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -76,4 +76,22 @@ TEST_CASE("todo") {
       REQUIRE(evaluation_point[0] == r);
     }
   }
+
+  SECTION("we can prove a sum with n=2 on CPU") {
+    cbn::reset_backend_for_testing();
+    const sxt_config config = {SXT_CPU_BACKEND, 0};
+    REQUIRE(sxt_init(&config) == 0);
+
+    sxt_prove_sumcheck(polynomials.data(), evaluation_point.data(), SXT_FIELD_SCALAR255,
+                       &descriptor, reinterpret_cast<void*>(+f), &transcript);
+    REQUIRE(polynomials[0] == mles[0]);
+    REQUIRE(polynomials[1] == mles[1] - mles[0]);
+    {
+      prft::transcript base_transcript_p{"abc"};
+      prfsk::reference_transcript transcript_p{base_transcript_p};
+      s25t::element r;
+      transcript_p.round_challenge(r, polynomials);
+      REQUIRE(evaluation_point[0] == r);
+    }
+  }
 }

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -1,5 +1,43 @@
 #include "cbindings/sumcheck.h"
 
-#include "sxt/base/test/unit_test.h"
+#include <vector>
 
-TEST_CASE("todo") {}
+#include "sxt/base/test/unit_test.h"
+#include "sxt/proof/sumcheck/reference_transcript.h"
+#include "sxt/scalar25/type/element.h"
+#include "sxt/scalar25/type/literal.h"
+using namespace sxt;
+using s25t::operator""_s25;
+
+TEST_CASE("todo") {
+  prft::transcript base_transcript{"abc"};
+  prfsk::reference_transcript transcript{base_transcript};
+
+  std::vector<s25t::element> polynomials(2);
+  std::vector<s25t::element> evaluation_point(1);
+  std::vector<s25t::element> mles = {
+      0x8_s25,
+      0x3_s25,
+  };
+  std::vector<std::pair<s25t::element, unsigned>> product_table = {
+      {0x1_s25, 1},
+  };
+  std::vector<unsigned> product_terms = {0};
+
+  auto f = [](s25t::element* r, void* context, const s25t::element* polynomial,
+              unsigned polynomial_len) noexcept {
+    static_cast<prfsk::reference_transcript*>(context)->round_challenge(
+        *r, {polynomial, polynomial_len});
+  };
+}
+#if 0
+
+  SECTION("we can prove a sum with n=1") {
+    auto fut = prove_sum(polynomials, evaluation_point, transcript, drv, mles, product_table,
+                         product_terms, 1);
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    REQUIRE(polynomials[0] == mles[0]);
+    REQUIRE(polynomials[1] == -mles[0]);
+  }
+#endif

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -24,6 +24,16 @@ TEST_CASE("todo") {
       {0x1_s25, 1},
   };
   std::vector<unsigned> product_terms = {0};
+  sumcheck_descriptor descriptor{
+      .mles = mles.data(),
+      .product_table = product_table.data(),
+      .product_terms = product_terms.data(),
+      .n = 2,
+      .num_mles = 1,
+      .num_products = 1,
+      .num_product_terms = 1,
+      .round_degree = 1,
+  };
 
   auto f = [](s25t::element* r, void* context, const s25t::element* polynomial,
               unsigned polynomial_len) noexcept {
@@ -35,11 +45,9 @@ TEST_CASE("todo") {
     cbn::reset_backend_for_testing();
     const sxt_config config = {SXT_GPU_BACKEND, 0};
     REQUIRE(sxt_init(&config) == 0);
-#if 0
-void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                        const sumcheck_descriptor* descriptor, void* transcript_callback,
-                        void* transcript_context) {
-#endif
+
+    sxt_prove_sumcheck(polynomials.data(), evaluation_point.data(), SXT_FIELD_SCALAR255,
+                       &descriptor, reinterpret_cast<void*>(+f), &transcript);
   }
 }
 #if 0

--- a/cbindings/sumcheck.t.cc
+++ b/cbindings/sumcheck.t.cc
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "cbindings/backend.h"
 #include "sxt/base/test/unit_test.h"
 #include "sxt/proof/sumcheck/reference_transcript.h"
 #include "sxt/scalar25/type/element.h"
@@ -29,6 +30,17 @@ TEST_CASE("todo") {
     static_cast<prfsk::reference_transcript*>(context)->round_challenge(
         *r, {polynomial, polynomial_len});
   };
+
+  SECTION("we can prove a sum with n=1 on GPU") {
+    cbn::reset_backend_for_testing();
+    const sxt_config config = {SXT_GPU_BACKEND, 0};
+    REQUIRE(sxt_init(&config) == 0);
+#if 0
+void sxt_prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                        const sumcheck_descriptor* descriptor, void* transcript_callback,
+                        void* transcript_context) {
+#endif
+  }
 }
 #if 0
 

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -97,6 +97,8 @@ sxt_cc_component(
         "//sxt/proof/inner_product:proof_descriptor",
         "//sxt/proof/inner_product:proof_computation",
         "//sxt/proof/inner_product:gpu_driver",
+        "//sxt/proof/sumcheck:chunked_gpu_driver",
+        "//sxt/proof/sumcheck:proof_computation",
     ],
     with_test = False,
     deps = [

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -23,12 +23,10 @@ sxt_cc_component(
         ":computational_backend_utility",
         "//sxt/base/container:span",
         "//sxt/cbindings/base:curve_id_utility",
-        "//sxt/cbindings/base:field_id_utility",
         "//sxt/cbindings/base:sumcheck_descriptor",
         "//sxt/curve21/type:element_p3",
         "//sxt/multiexp/base:exponent_sequence",
         "//sxt/multiexp/pippenger2:partition_table_accessor_base",
-        "//sxt/proof/sumcheck:sumcheck_transcript",
         "//sxt/ristretto/type:compressed_element",
     ],
 )

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -24,6 +24,7 @@ sxt_cc_component(
         "//sxt/base/container:span",
         "//sxt/cbindings/base:curve_id_utility",
         "//sxt/cbindings/base:field_id_utility",
+        "//sxt/cbindings/base:sumcheck_descriptor",
         "//sxt/curve21/type:element_p3",
         "//sxt/multiexp/base:exponent_sequence",
         "//sxt/multiexp/pippenger2:partition_table_accessor_base",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -110,10 +110,13 @@ sxt_cc_component(
 sxt_cc_component(
     name = "cpu_backend",
     impl_deps = [
+        ":callback_sumcheck_transcript",
         ":computational_backend_utility",
         "//sxt/base/error:panic",
+        "//sxt/base/num:ceil_log2",
         "//sxt/base/num:round_up",
         "//sxt/cbindings/base:curve_id_utility",
+        "//sxt/cbindings/base:field_id_utility",
         "//sxt/proof/transcript:transcript",
         "//sxt/scalar25/type:element",
         "//sxt/curve_bng1/operation:add",
@@ -152,6 +155,8 @@ sxt_cc_component(
         "//sxt/proof/inner_product:proof_descriptor",
         "//sxt/proof/inner_product:proof_computation",
         "//sxt/proof/inner_product:cpu_driver",
+        "//sxt/proof/sumcheck:cpu_driver",
+        "//sxt/proof/sumcheck:proof_computation",
     ],
     with_test = False,
     deps = [

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -4,6 +4,16 @@ load(
 )
 
 sxt_cc_component(
+    name = "callback_sumcheck_transcript",
+    impl_deps = [
+    ],
+    with_test = False,
+    deps = [
+        "//sxt/proof/sumcheck:sumcheck_transcript",
+    ],
+)
+
+sxt_cc_component(
     name = "computational_backend",
     impl_deps = [
         "//sxt/multiexp/pippenger2:in_memory_partition_table_accessor",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -12,10 +12,12 @@ sxt_cc_component(
     deps = [
         ":computational_backend_utility",
         "//sxt/base/container:span",
-        "//sxt/cbindings/base:curve_id",
+        "//sxt/cbindings/base:curve_id_utility",
+        "//sxt/cbindings/base:field_id_utility",
         "//sxt/curve21/type:element_p3",
         "//sxt/multiexp/base:exponent_sequence",
         "//sxt/multiexp/pippenger2:partition_table_accessor_base",
+        "//sxt/proof/sumcheck:sumcheck_transcript",
         "//sxt/ristretto/type:compressed_element",
     ],
 )

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -50,6 +50,7 @@ sxt_cc_component(
     name = "gpu_backend",
     impl_deps = [
         ":computational_backend_utility",
+        ":callback_sumcheck_transcript",
         "//sxt/base/error:assert",
         "//sxt/base/system:directory_recorder",
         "//sxt/base/system:file_io",
@@ -57,6 +58,7 @@ sxt_cc_component(
         "//sxt/proof/transcript:transcript",
         "//sxt/scalar25/type:element",
         "//sxt/cbindings/base:curve_id_utility",
+        "//sxt/cbindings/base:field_id_utility",
         "//sxt/curve_bng1/operation:add",
         "//sxt/curve_bng1/operation:double",
         "//sxt/curve_bng1/operation:neg",

--- a/sxt/cbindings/backend/BUILD
+++ b/sxt/cbindings/backend/BUILD
@@ -54,6 +54,7 @@ sxt_cc_component(
         "//sxt/base/system:directory_recorder",
         "//sxt/base/system:file_io",
         "//sxt/base/num:divide_up",
+        "//sxt/base/num:ceil_log2",
         "//sxt/proof/transcript:transcript",
         "//sxt/scalar25/type:element",
         "//sxt/cbindings/base:curve_id_utility",

--- a/sxt/cbindings/backend/callback_sumcheck_transcript.cc
+++ b/sxt/cbindings/backend/callback_sumcheck_transcript.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/cbindings/backend/callback_sumcheck_transcript.h"

--- a/sxt/cbindings/backend/callback_sumcheck_transcript.cc
+++ b/sxt/cbindings/backend/callback_sumcheck_transcript.cc
@@ -1,0 +1,1 @@
+#include "sxt/cbindings/backend/callback_sumcheck_transcript.h"

--- a/sxt/cbindings/backend/callback_sumcheck_transcript.h
+++ b/sxt/cbindings/backend/callback_sumcheck_transcript.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/proof/sumcheck/sumcheck_transcript.h"

--- a/sxt/cbindings/backend/callback_sumcheck_transcript.h
+++ b/sxt/cbindings/backend/callback_sumcheck_transcript.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "sxt/proof/sumcheck/sumcheck_transcript.h"
+
+namespace sxt::cbnbck {
+//--------------------------------------------------------------------------------------------------
+// callback_sumcheck_transcript
+//--------------------------------------------------------------------------------------------------
+class callback_sumcheck_transcript final : public prfsk::sumcheck_transcript {
+public:
+  using callback_t = void (*)(s25t::element* r, void* context, const s25t::element* polynomial,
+                              unsigned round_degree);
+
+  callback_sumcheck_transcript(callback_t f, void* context) noexcept : f_{f}, context_{context} {}
+
+  void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
+
+  void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
+    f_(&r, context_, polynomial.data(), static_cast<unsigned>(polynomial.size()));
+  }
+
+private:
+  callback_t f_;
+  void* context_;
+};
+} // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/callback_sumcheck_transcript.h
+++ b/sxt/cbindings/backend/callback_sumcheck_transcript.h
@@ -9,7 +9,7 @@ namespace sxt::cbnbck {
 class callback_sumcheck_transcript final : public prfsk::sumcheck_transcript {
 public:
   using callback_t = void (*)(s25t::element* r, void* context, const s25t::element* polynomial,
-                              unsigned round_degree);
+                              unsigned polynomial_len);
 
   callback_sumcheck_transcript(callback_t f, void* context) noexcept : f_{f}, context_{context} {}
 

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -57,6 +57,13 @@ void computational_backend::prove_sumcheck(void* polynomials, void* evaluation_p
                                            void* transcript_context, const void* mles,
                                            const void* product_table, const unsigned* product_terms,
                                            unsigned num_outputs, unsigned n) noexcept {
+  cbnb::switch_field_type(
+      static_cast<cbnb::field_id_t>(field_id), [&]<class T>(std::type_identity<T>) noexcept {
+        sumcheck_transcript transcript{reinterpret_cast<sumcheck_transcript::callback_t>(
+                                           const_cast<void*>(transcript_callback)),
+                                       transcript_context};
+        (void)transcript;
+      });
 }
 #pragma clang diagnostic pop
 

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -18,9 +18,27 @@
 #include "sxt/cbindings/backend/computational_backend.h"
 
 #include "sxt/cbindings/base/curve_id_utility.h"
+#include "sxt/cbindings/base/field_id_utility.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
+#include "sxt/proof/sumcheck/sumcheck_transcript.h"
 
 namespace sxt::cbnbck {
+//--------------------------------------------------------------------------------------------------
+// sumcheck_transcript
+//--------------------------------------------------------------------------------------------------
+namespace {
+class sumcheck_transcript final : public prfsk::sumcheck_transcript {
+  public:
+    void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
+
+    void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
+      (void)r;
+      (void)polynomial;
+    }
+  private:
+};
+} // anonymous namespace
+
 //--------------------------------------------------------------------------------------------------
 // prove_sumcheck
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -18,55 +18,9 @@
 #include "sxt/cbindings/backend/computational_backend.h"
 
 #include "sxt/cbindings/base/curve_id_utility.h"
-#include "sxt/cbindings/base/field_id_utility.h"
 #include "sxt/multiexp/pippenger2/in_memory_partition_table_accessor.h"
-#include "sxt/proof/sumcheck/sumcheck_transcript.h"
 
 namespace sxt::cbnbck {
-//--------------------------------------------------------------------------------------------------
-// sumcheck_transcript
-//--------------------------------------------------------------------------------------------------
-namespace {
-class sumcheck_transcript final : public prfsk::sumcheck_transcript {
-public:
-  using callback_t = void (*)(s25t::element* r, void* context, const s25t::element* polynomial,
-                              unsigned round_degree);
-  sumcheck_transcript(callback_t f, void* context) noexcept : f_{f}, context_{context} {}
-
-  void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
-
-  void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
-    f_(&r, context_, polynomial.data(), static_cast<unsigned>(polynomial.size()));
-  }
-
-private:
-  callback_t f_;
-  void* context_;
-};
-} // anonymous namespace
-
-//--------------------------------------------------------------------------------------------------
-// prove_sumcheck
-//--------------------------------------------------------------------------------------------------
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-void computational_backend::prove_sumcheck(void* polynomials, void* evaluation_point,
-                                           unsigned field_id, const void* transcript_callback,
-                                           void* transcript_context, const void* mles,
-                                           const void* product_table, const unsigned* product_terms,
-                                           unsigned num_outputs, unsigned n) noexcept {
-  cbnb::switch_field_type(
-      static_cast<cbnb::field_id_t>(field_id), [&]<class T>(std::type_identity<T>) noexcept {
-        sumcheck_transcript transcript{reinterpret_cast<sumcheck_transcript::callback_t>(
-                                           const_cast<void*>(transcript_callback)),
-                                       transcript_context};
-        (void)transcript;
-      });
-}
-#pragma clang diagnostic pop
-
 //--------------------------------------------------------------------------------------------------
 // write_partition_table_accessor
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -22,6 +22,21 @@
 
 namespace sxt::cbnbck {
 //--------------------------------------------------------------------------------------------------
+// prove_sumcheck
+//--------------------------------------------------------------------------------------------------
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+void computational_backend::prove_sumcheck(void* polynomials, void* evaluation_point,
+                                           unsigned field_id, const void* transcript_callback,
+                                           void* transcript_context, const void* mles,
+                                           const void* product_table, const unsigned* product_terms,
+                                           unsigned num_outputs, unsigned n) noexcept {
+}
+#pragma clang diagnostic pop
+
+//--------------------------------------------------------------------------------------------------
 // write_partition_table_accessor
 //--------------------------------------------------------------------------------------------------
 void computational_backend::write_partition_table_accessor(

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -28,14 +28,22 @@ namespace sxt::cbnbck {
 //--------------------------------------------------------------------------------------------------
 namespace {
 class sumcheck_transcript final : public prfsk::sumcheck_transcript {
-  public:
-    void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
+public:
+  using callback_t = void (*)(s25t::element* r, void* context, const s25t::element* polynomial,
+                              unsigned round_degree);
+  sumcheck_transcript(callback_t f, void* context) noexcept : f_{f}, context_{context} {}
 
-    void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
-      (void)r;
-      (void)polynomial;
+  void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
+
+  void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
+    (void)r;
+    (void)polynomial;
+    (void)f_;
+    (void)context_;
     }
   private:
+    callback_t f_;
+    void* context_;
 };
 } // anonymous namespace
 

--- a/sxt/cbindings/backend/computational_backend.cc
+++ b/sxt/cbindings/backend/computational_backend.cc
@@ -36,14 +36,12 @@ public:
   void init(size_t /*num_variables*/, size_t /*round_degree*/) noexcept override {}
 
   void round_challenge(s25t::element& r, basct::cspan<s25t::element> polynomial) noexcept override {
-    (void)r;
-    (void)polynomial;
-    (void)f_;
-    (void)context_;
-    }
-  private:
-    callback_t f_;
-    void* context_;
+    f_(&r, context_, polynomial.data(), static_cast<unsigned>(polynomial.size()));
+  }
+
+private:
+  callback_t f_;
+  void* context_;
 };
 } // anonymous namespace
 

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -135,12 +135,5 @@ public:
   void write_partition_table_accessor(cbnb::curve_id_t curve_id,
                                       const mtxpp2::partition_table_accessor_base& accessor,
                                       const char* filename) const noexcept;
-
-private:
-  /* void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id, */
-  /*                     const void* transcript_callback, void* transcript_context, const void*
-   * mles, */
-  /*                     const void* product_table, const unsigned* product_terms, */
-  /*                     unsigned num_outputs, unsigned n) noexcept; */
 };
 } // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -79,11 +79,16 @@ public:
                               unsigned n) noexcept;
 
   virtual void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
-                         const cbnb::sumcheck_descriptor& descriptor) noexcept {
+                         const cbnb::sumcheck_descriptor& descriptor,
+                         void* transcript_callback,
+                         void* transcript_context
+                         ) noexcept {
     (void)polynomials;
     (void)evaluation_point;
     (void)field_id;
     (void)descriptor;
+    (void)transcript_callback;
+    (void)transcript_context;
   }
 
   virtual void compute_commitments(basct::span<rstt::compressed_element> commitments,

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -74,14 +74,7 @@ public:
 
   virtual void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
                               const cbnb::sumcheck_descriptor& descriptor,
-                              void* transcript_callback, void* transcript_context) noexcept {
-    (void)polynomials;
-    (void)evaluation_point;
-    (void)field_id;
-    (void)descriptor;
-    (void)transcript_callback;
-    (void)transcript_context;
-  }
+                              void* transcript_callback, void* transcript_context) noexcept = 0;
 
   virtual void compute_commitments(basct::span<rstt::compressed_element> commitments,
                                    basct::cspan<mtxb::exponent_sequence> value_sequences,

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -72,11 +72,9 @@ class computational_backend {
 public:
   virtual ~computational_backend() noexcept = default;
 
-  virtual void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
-                         const cbnb::sumcheck_descriptor& descriptor,
-                         void* transcript_callback,
-                         void* transcript_context
-                         ) noexcept {
+  virtual void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                              const cbnb::sumcheck_descriptor& descriptor,
+                              void* transcript_callback, void* transcript_context) noexcept {
     (void)polynomials;
     (void)evaluation_point;
     (void)field_id;

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -71,10 +71,11 @@ class computational_backend {
 public:
   virtual ~computational_backend() noexcept = default;
 
-  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                      const void* transcript_callback, void* transcript_context, const void* mles,
-                      const void* product_table, const unsigned* product_terms,
-                      unsigned num_outputs, unsigned n) noexcept;
+  virtual void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                              const void* transcript_callback, void* transcript_context,
+                              const void* mles, const void* product_table,
+                              const unsigned* product_terms, unsigned num_outputs,
+                              unsigned n) noexcept;
 
   virtual void compute_commitments(basct::span<rstt::compressed_element> commitments,
                                    basct::cspan<mtxb::exponent_sequence> value_sequences,

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -72,12 +72,6 @@ class computational_backend {
 public:
   virtual ~computational_backend() noexcept = default;
 
-  virtual void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                              const void* transcript_callback, void* transcript_context,
-                              const void* mles, const void* product_table,
-                              const unsigned* product_terms, unsigned num_outputs,
-                              unsigned n) noexcept;
-
   virtual void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
                          const cbnb::sumcheck_descriptor& descriptor,
                          void* transcript_callback,

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -135,5 +135,10 @@ public:
   void write_partition_table_accessor(cbnb::curve_id_t curve_id,
                                       const mtxpp2::partition_table_accessor_base& accessor,
                                       const char* filename) const noexcept;
+private:
+  /* void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id, */
+  /*                     const void* transcript_callback, void* transcript_context, const void* mles, */
+  /*                     const void* product_table, const unsigned* product_terms, */
+  /*                     unsigned num_outputs, unsigned n) noexcept; */
 };
 } // namespace sxt::cbnbck

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -142,9 +142,11 @@ public:
   void write_partition_table_accessor(cbnb::curve_id_t curve_id,
                                       const mtxpp2::partition_table_accessor_base& accessor,
                                       const char* filename) const noexcept;
+
 private:
   /* void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id, */
-  /*                     const void* transcript_callback, void* transcript_context, const void* mles, */
+  /*                     const void* transcript_callback, void* transcript_context, const void*
+   * mles, */
   /*                     const void* product_table, const unsigned* product_terms, */
   /*                     unsigned num_outputs, unsigned n) noexcept; */
 };

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -71,6 +71,11 @@ class computational_backend {
 public:
   virtual ~computational_backend() noexcept = default;
 
+  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                      const void* transcript_callback, void* transcript_context, const void* mles,
+                      const void* product_table, const unsigned* product_terms,
+                      unsigned num_outputs, unsigned n) noexcept;
+
   virtual void compute_commitments(basct::span<rstt::compressed_element> commitments,
                                    basct::cspan<mtxb::exponent_sequence> value_sequences,
                                    basct::cspan<c21t::element_p3> generators) const noexcept = 0;

--- a/sxt/cbindings/backend/computational_backend.h
+++ b/sxt/cbindings/backend/computational_backend.h
@@ -22,6 +22,7 @@
 
 #include "sxt/base/container/span.h"
 #include "sxt/cbindings/base/curve_id.h"
+#include "sxt/cbindings/base/sumcheck_descriptor.h"
 #include "sxt/multiexp/pippenger2/partition_table_accessor_base.h"
 
 namespace sxt::mtxb {
@@ -76,6 +77,14 @@ public:
                               const void* mles, const void* product_table,
                               const unsigned* product_terms, unsigned num_outputs,
                               unsigned n) noexcept;
+
+  virtual void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
+                         const cbnb::sumcheck_descriptor& descriptor) noexcept {
+    (void)polynomials;
+    (void)evaluation_point;
+    (void)field_id;
+    (void)descriptor;
+  }
 
   virtual void compute_commitments(basct::span<rstt::compressed_element> commitments,
                                    basct::cspan<mtxb::exponent_sequence> value_sequences,

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -22,9 +22,12 @@
 
 #include "sxt/base/error/assert.h"
 #include "sxt/base/error/panic.h"
+#include "sxt/base/num/ceil_log2.h"
 #include "sxt/base/num/divide_up.h"
+#include "sxt/cbindings/backend/callback_sumcheck_transcript.h"
 #include "sxt/cbindings/backend/computational_backend_utility.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
+#include "sxt/cbindings/base/field_id_utility.h"
 #include "sxt/curve21/operation/add.h"
 #include "sxt/curve21/operation/double.h"
 #include "sxt/curve21/operation/neg.h"
@@ -56,6 +59,8 @@
 #include "sxt/proof/inner_product/cpu_driver.h"
 #include "sxt/proof/inner_product/proof_computation.h"
 #include "sxt/proof/inner_product/proof_descriptor.h"
+#include "sxt/proof/sumcheck/cpu_driver.h"
+#include "sxt/proof/sumcheck/proof_computation.h"
 #include "sxt/proof/transcript/transcript.h"
 #include "sxt/ristretto/operation/compression.h"
 #include "sxt/ristretto/type/compressed_element.h"
@@ -63,6 +68,56 @@
 #include "sxt/seqcommit/generator/precomputed_generators.h"
 
 namespace sxt::cbnbck {
+//--------------------------------------------------------------------------------------------------
+// prove_sumcheck
+//--------------------------------------------------------------------------------------------------
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+void cpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                                 const cbnb::sumcheck_descriptor& descriptor,
+                                 void* transcript_callback, void* transcript_context) noexcept {
+  auto num_variables = static_cast<size_t>(std::max(basn::ceil_log2(descriptor.n), 1));
+  cbnb::switch_field_type(
+      static_cast<cbnb::field_id_t>(field_id), [&]<class T>(std::type_identity<T>) noexcept {
+        static_assert(std::same_as<T, s25t::element>, "only support curve-255 right now");
+        // transcript
+        callback_sumcheck_transcript transcript{
+            reinterpret_cast<callback_sumcheck_transcript::callback_t>(
+                const_cast<void*>(transcript_callback)),
+            transcript_context};
+
+        // prove
+        basct::span<s25t::element> polynomials_span{
+            static_cast<s25t::element*>(polynomials),
+            (descriptor.round_degree + 1u) * num_variables,
+        };
+        basct::span<s25t::element> evaluation_point_span{
+            static_cast<s25t::element*>(evaluation_point),
+            num_variables,
+        };
+        basct::cspan<s25t::element> mles_span{
+            static_cast<const s25t::element*>(descriptor.mles),
+            descriptor.n * descriptor.num_mles,
+        };
+        basct::cspan<std::pair<s25t::element, unsigned>> product_table_span{
+            static_cast<const std::pair<s25t::element, unsigned>*>(descriptor.product_table),
+            descriptor.num_products,
+        };
+        basct::cspan<unsigned> product_terms_span{
+            descriptor.product_terms,
+            descriptor.num_product_terms,
+        };
+        prfsk::cpu_driver drv;
+        auto fut =
+            prfsk::prove_sum(polynomials_span, evaluation_point_span, transcript, drv, mles_span,
+                             product_table_span, product_terms_span, descriptor.n);
+        SXT_RELEASE_ASSERT(fut.ready());
+      });
+}
+#pragma clang diagnostic pop
+
 //--------------------------------------------------------------------------------------------------
 // compute_commitments
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/cpu_backend.h
+++ b/sxt/cbindings/backend/cpu_backend.h
@@ -28,6 +28,10 @@ namespace sxt::cbnbck {
 //--------------------------------------------------------------------------------------------------
 class cpu_backend final : public computational_backend {
 public:
+  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                      const cbnb::sumcheck_descriptor& descriptor, void* transcript_callback,
+                      void* transcript_context) noexcept override;
+
   void compute_commitments(basct::span<rstt::compressed_element> commitments,
                            basct::cspan<mtxb::exponent_sequence> value_sequences,
                            basct::cspan<c21t::element_p3> generators) const noexcept override;

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -25,6 +25,7 @@
 #include "sxt/base/system/file_io.h"
 #include "sxt/cbindings/backend/computational_backend_utility.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
+#include "sxt/cbindings/base/field_id_utility.h"
 #include "sxt/curve21/operation/add.h"
 #include "sxt/curve21/operation/double.h"
 #include "sxt/curve21/operation/neg.h"

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -104,9 +104,9 @@ gpu_backend::gpu_backend() noexcept { pre_initialize_gpu(); }
 //--------------------------------------------------------------------------------------------------
 // prove_sumcheck
 //--------------------------------------------------------------------------------------------------
-void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
-                            const cbnb::sumcheck_descriptor& descriptor, void* transcript_callback,
-                            void* transcript_context) noexcept {
+void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                                 const cbnb::sumcheck_descriptor& descriptor,
+                                 void* transcript_callback, void* transcript_context) noexcept {
   auto num_variables = static_cast<size_t>(std::max(basn::ceil_log2(descriptor.n), 1));
   cbnb::switch_field_type(static_cast<cbnb::field_id_t>(field_id),
                           [&]<class T>(std::type_identity<T>) noexcept {

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -145,10 +145,9 @@ void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned 
                                 descriptor.num_product_terms,
                             };
                             prfsk::chunked_gpu_driver drv;
-                            (void)drv;
-                            /* auto fut = prfsk::prove_sum( */
-                            /*  */
-                            /* ); */
+                            auto fut = prfsk::prove_sum(
+                                polynomials_span, evaluation_point_span, transcript, drv, mles_span,
+                                product_table_span, product_terms_span, descriptor.n);
 #if 0
 xena::future<> prove_sum(basct::span<s25t::element> polynomials,
                          basct::span<s25t::element> evaluation_point,

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -61,6 +61,8 @@
 #include "sxt/proof/inner_product/gpu_driver.h"
 #include "sxt/proof/inner_product/proof_computation.h"
 #include "sxt/proof/inner_product/proof_descriptor.h"
+#include "sxt/proof/sumcheck/chunked_gpu_driver.h"
+#include "sxt/proof/sumcheck/proof_computation.h"
 #include "sxt/proof/transcript/transcript.h"
 #include "sxt/ristretto/operation/compression.h"
 #include "sxt/ristretto/type/compressed_element.h"

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -115,11 +115,26 @@ void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
                           [&]<class T>(std::type_identity<T>) noexcept {
                             static_assert(std::same_as<T, s25t::element>,
                                           "only support curve-255 right now");
-                            // fill me in
+                            // transcript
                             callback_sumcheck_transcript transcript{
                                 reinterpret_cast<callback_sumcheck_transcript::callback_t>(
                                     const_cast<void*>(transcript_callback)),
                                 transcript_context};
+
+                            // prove
+                            prfsk::chunked_gpu_driver drv;
+                            (void)drv;
+                            /* auto fut = prfsk::prove_sum( */
+                            /*  */
+                            /* ); */
+#if 0
+xena::future<> prove_sum(basct::span<s25t::element> polynomials,
+                         basct::span<s25t::element> evaluation_point,
+                         sumcheck_transcript& transcript, const driver& drv,
+                         basct::cspan<s25t::element> mles,
+                         basct::cspan<std::pair<s25t::element, unsigned>> product_table,
+                         basct::cspan<unsigned> product_terms, unsigned n) noexcept;
+#endif
                           });
 }
 #pragma clang diagnostic pop

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -135,6 +135,15 @@ void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned 
                                 static_cast<const s25t::element*>(descriptor.mles),
                                 descriptor.n * descriptor.num_mles,
                             };
+                            basct::cspan<std::pair<s25t::element, unsigned>> product_table_span{
+                                static_cast<const std::pair<s25t::element, unsigned>*>(
+                                    descriptor.product_table),
+                                descriptor.num_products,
+                            };
+                            basct::cspan<unsigned> product_terms_span{
+                                descriptor.product_terms,
+                                descriptor.num_product_terms,
+                            };
                             prfsk::chunked_gpu_driver drv;
                             (void)drv;
                             /* auto fut = prfsk::prove_sum( */

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -104,10 +104,6 @@ gpu_backend::gpu_backend() noexcept { pre_initialize_gpu(); }
 //--------------------------------------------------------------------------------------------------
 // prove_sumcheck
 //--------------------------------------------------------------------------------------------------
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-function"
-#pragma clang diagnostic ignored "-Wunused-variable"
-#pragma clang diagnostic ignored "-Wunused-parameter"
 void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
                             const cbnb::sumcheck_descriptor& descriptor, void* transcript_callback,
                             void* transcript_context) noexcept {
@@ -148,17 +144,9 @@ void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned 
                             auto fut = prfsk::prove_sum(
                                 polynomials_span, evaluation_point_span, transcript, drv, mles_span,
                                 product_table_span, product_terms_span, descriptor.n);
-#if 0
-xena::future<> prove_sum(basct::span<s25t::element> polynomials,
-                         basct::span<s25t::element> evaluation_point,
-                         sumcheck_transcript& transcript, const driver& drv,
-                         basct::cspan<s25t::element> mles,
-                         basct::cspan<std::pair<s25t::element, unsigned>> product_table,
-                         basct::cspan<unsigned> product_terms, unsigned n) noexcept;
-#endif
+                            xens::get_scheduler().run();
                           });
 }
-#pragma clang diagnostic pop
 
 //--------------------------------------------------------------------------------------------------
 // compute_commitments

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -23,6 +23,7 @@
 #include "sxt/base/num/divide_up.h"
 #include "sxt/base/system/directory_recorder.h"
 #include "sxt/base/system/file_io.h"
+#include "sxt/cbindings/backend/callback_sumcheck_transcript.h"
 #include "sxt/cbindings/backend/computational_backend_utility.h"
 #include "sxt/cbindings/base/curve_id_utility.h"
 #include "sxt/cbindings/base/field_id_utility.h"
@@ -107,7 +108,18 @@ void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
                                  const void* transcript_callback, void* transcript_context,
                                  const void* mles, const void* product_table,
                                  const unsigned* product_terms, unsigned num_outputs,
-                                 unsigned n) noexcept {}
+                                 unsigned n) noexcept {
+  cbnb::switch_field_type(static_cast<cbnb::field_id_t>(field_id),
+                          [&]<class T>(std::type_identity<T>) noexcept {
+                            static_assert(std::same_as<T, s25t::element>,
+                                          "only support curve-255 right now");
+                            // fill me in
+                            callback_sumcheck_transcript transcript{
+                                reinterpret_cast<callback_sumcheck_transcript::callback_t>(
+                                    const_cast<void*>(transcript_callback)),
+                                transcript_context};
+                          });
+}
 #pragma clang diagnostic pop
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -106,11 +106,9 @@ gpu_backend::gpu_backend() noexcept { pre_initialize_gpu(); }
 #pragma clang diagnostic ignored "-Wunused-function"
 #pragma clang diagnostic ignored "-Wunused-variable"
 #pragma clang diagnostic ignored "-Wunused-parameter"
-void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                                 const void* transcript_callback, void* transcript_context,
-                                 const void* mles, const void* product_table,
-                                 const unsigned* product_terms, unsigned num_outputs,
-                                 unsigned n) noexcept {
+void gpu_backend::prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
+                            const cbnb::sumcheck_descriptor& descriptor, void* transcript_callback,
+                            void* transcript_context) noexcept {
   cbnb::switch_field_type(static_cast<cbnb::field_id_t>(field_id),
                           [&]<class T>(std::type_identity<T>) noexcept {
                             static_assert(std::same_as<T, s25t::element>,

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -96,6 +96,20 @@ static void pre_initialize_gpu() noexcept {
 gpu_backend::gpu_backend() noexcept { pre_initialize_gpu(); }
 
 //--------------------------------------------------------------------------------------------------
+// prove_sumcheck
+//--------------------------------------------------------------------------------------------------
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                                 const void* transcript_callback, void* transcript_context,
+                                 const void* mles, const void* product_table,
+                                 const unsigned* product_terms, unsigned num_outputs,
+                                 unsigned n) noexcept {}
+#pragma clang diagnostic pop
+
+//--------------------------------------------------------------------------------------------------
 // compute_commitments
 //--------------------------------------------------------------------------------------------------
 void gpu_backend::compute_commitments(basct::span<rstt::compressed_element> commitments,

--- a/sxt/cbindings/backend/gpu_backend.h
+++ b/sxt/cbindings/backend/gpu_backend.h
@@ -30,6 +30,11 @@ class gpu_backend final : public computational_backend {
 public:
   gpu_backend() noexcept;
 
+  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                      const void* transcript_callback, void* transcript_context, const void* mles,
+                      const void* product_table, const unsigned* product_terms,
+                      unsigned num_outputs, unsigned n) noexcept override;
+
   void compute_commitments(basct::span<rstt::compressed_element> commitments,
                            basct::cspan<mtxb::exponent_sequence> value_sequences,
                            basct::cspan<c21t::element_p3> generators) const noexcept override;

--- a/sxt/cbindings/backend/gpu_backend.h
+++ b/sxt/cbindings/backend/gpu_backend.h
@@ -30,10 +30,11 @@ class gpu_backend final : public computational_backend {
 public:
   gpu_backend() noexcept;
 
-  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
-                      const void* transcript_callback, void* transcript_context, const void* mles,
-                      const void* product_table, const unsigned* product_terms,
-                      unsigned num_outputs, unsigned n) noexcept override;
+  void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
+                         const cbnb::sumcheck_descriptor& descriptor,
+                         void* transcript_callback,
+                         void* transcript_context
+                         ) noexcept override;
 
   void compute_commitments(basct::span<rstt::compressed_element> commitments,
                            basct::cspan<mtxb::exponent_sequence> value_sequences,

--- a/sxt/cbindings/backend/gpu_backend.h
+++ b/sxt/cbindings/backend/gpu_backend.h
@@ -30,11 +30,9 @@ class gpu_backend final : public computational_backend {
 public:
   gpu_backend() noexcept;
 
-  void prove_sum(void* polynomials, void* evaluation_point, unsigned field_id,
-                         const cbnb::sumcheck_descriptor& descriptor,
-                         void* transcript_callback,
-                         void* transcript_context
-                         ) noexcept override;
+  void prove_sumcheck(void* polynomials, void* evaluation_point, unsigned field_id,
+                      const cbnb::sumcheck_descriptor& descriptor, void* transcript_callback,
+                      void* transcript_context) noexcept override;
 
   void compute_commitments(basct::span<rstt::compressed_element> commitments,
                            basct::cspan<mtxb::exponent_sequence> value_sequences,

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -47,8 +47,11 @@ sxt_cc_component(
     deps = [
         ":field_id",
         "//sxt/base/error:panic",
-        "//sxt/base/test:unit_test",
+        "//sxt/scalar25/type:element",
     ],
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ]
 )
 
 sxt_cc_component(

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -51,14 +51,14 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "field_id_utility",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
     deps = [
         ":field_id",
         "//sxt/base/error:panic",
         "//sxt/scalar25/type:element",
     ],
-    test_deps = [
-        "//sxt/base/test:unit_test",
-    ]
 )
 
 sxt_cc_component(

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -11,6 +11,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "field_id",
+    with_test = False,
+    deps = [
+    ],
+)
+
+sxt_cc_component(
     name = "curve_id_utility",
     deps = [
         ":curve_id",

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -18,6 +18,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "sumcheck_descriptor",
+    with_test = False,
+    deps = [
+    ],
+)
+
+sxt_cc_component(
     name = "curve_id_utility",
     deps = [
         ":curve_id",

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -43,6 +43,15 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "field_id_utility",
+    deps = [
+        ":field_id",
+        "//sxt/base/error:panic",
+        "//sxt/base/test:unit_test",
+    ],
+)
+
+sxt_cc_component(
     name = "multiexp_handle",
     with_test = False,
     deps = [

--- a/sxt/cbindings/base/field_id.cc
+++ b/sxt/cbindings/base/field_id.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/cbindings/base/field_id.h"

--- a/sxt/cbindings/base/field_id.cc
+++ b/sxt/cbindings/base/field_id.cc
@@ -1,2 +1,1 @@
 #include "sxt/cbindings/base/field_id.h"
-

--- a/sxt/cbindings/base/field_id.cc
+++ b/sxt/cbindings/base/field_id.cc
@@ -1,0 +1,2 @@
+#include "sxt/cbindings/base/field_id.h"
+

--- a/sxt/cbindings/base/field_id.h
+++ b/sxt/cbindings/base/field_id.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 namespace sxt::cbnb {

--- a/sxt/cbindings/base/field_id.h
+++ b/sxt/cbindings/base/field_id.h
@@ -1,0 +1,15 @@
+#pragma once
+
+namespace sxt::cbnb {
+//--------------------------------------------------------------------------------------------------
+// field_id_t
+//--------------------------------------------------------------------------------------------------
+/**
+ * Ids for the various fields we support.
+ *
+ * Note: The values should match those in blitzar_api.h.
+ */
+enum class field_id_t : unsigned {
+  scalar25519 = 0,
+};
+} // namespace sxt::cbnb

--- a/sxt/cbindings/base/field_id_utility.cc
+++ b/sxt/cbindings/base/field_id_utility.cc
@@ -1,2 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/cbindings/base/field_id_utility.h"
-

--- a/sxt/cbindings/base/field_id_utility.cc
+++ b/sxt/cbindings/base/field_id_utility.cc
@@ -1,0 +1,2 @@
+#include "sxt/cbindings/base/field_id_utility.h"
+

--- a/sxt/cbindings/base/field_id_utility.h
+++ b/sxt/cbindings/base/field_id_utility.h
@@ -1,6 +1,22 @@
 #pragma once
 
+#include <type_traits>
+
+#include "sxt/scalar25/type/element.h"
+#include "sxt/base/error/panic.h"
 #include "sxt/cbindings/base/field_id.h"
 
 namespace sxt::cbnb {
+//--------------------------------------------------------------------------------------------------
+// switch_field_type
+//--------------------------------------------------------------------------------------------------
+template <class F> void switch_field_type(field_id_t id, F f) {
+  switch (id) {
+  case field_id_t::scalar25519:
+    f(std::type_identity<s25t::element>{});
+    break;
+  default:
+    baser::panic("unsupported field id {}", static_cast<unsigned>(id));
+  }
+}
 } // namespace sxt::cbnb

--- a/sxt/cbindings/base/field_id_utility.h
+++ b/sxt/cbindings/base/field_id_utility.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "sxt/cbindings/base/field_id.h"
+
+namespace sxt::cbnb {
+} // namespace sxt::cbnb

--- a/sxt/cbindings/base/field_id_utility.h
+++ b/sxt/cbindings/base/field_id_utility.h
@@ -1,10 +1,26 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include <type_traits>
 
-#include "sxt/scalar25/type/element.h"
 #include "sxt/base/error/panic.h"
 #include "sxt/cbindings/base/field_id.h"
+#include "sxt/scalar25/type/element.h"
 
 namespace sxt::cbnb {
 //--------------------------------------------------------------------------------------------------

--- a/sxt/cbindings/base/field_id_utility.t.cc
+++ b/sxt/cbindings/base/field_id_utility.t.cc
@@ -16,8 +16,15 @@
  */
 #include "sxt/cbindings/base/field_id_utility.h"
 
+#include <type_traits>
+
 #include "sxt/base/test/unit_test.h"
 
 using namespace sxt;
+using namespace sxt::cbnb;
 
-TEST_CASE("todo") {}
+TEST_CASE("we can translate a runtime field id value to a compile-time type") {
+  switch_field_type(field_id_t::scalar25519, [&]<class T>(std::type_identity<T>) {
+    REQUIRE(std::is_same_v<T, s25t::element>);
+  });
+}

--- a/sxt/cbindings/base/field_id_utility.t.cc
+++ b/sxt/cbindings/base/field_id_utility.t.cc
@@ -1,7 +1,23 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/cbindings/base/field_id_utility.h"
 
 #include "sxt/base/test/unit_test.h"
+
 using namespace sxt;
 
-TEST_CASE("todo") {
-}
+TEST_CASE("todo") {}

--- a/sxt/cbindings/base/field_id_utility.t.cc
+++ b/sxt/cbindings/base/field_id_utility.t.cc
@@ -1,0 +1,7 @@
+#include "sxt/cbindings/base/field_id_utility.h"
+
+#include "sxt/base/test/unit_test.h"
+using namespace sxt;
+
+TEST_CASE("todo") {
+}

--- a/sxt/cbindings/base/sumcheck_descriptor.cc
+++ b/sxt/cbindings/base/sumcheck_descriptor.cc
@@ -1,0 +1,1 @@
+#include "sxt/cbindings/base/sumcheck_descriptor.h"

--- a/sxt/cbindings/base/sumcheck_descriptor.cc
+++ b/sxt/cbindings/base/sumcheck_descriptor.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/cbindings/base/sumcheck_descriptor.h"

--- a/sxt/cbindings/base/sumcheck_descriptor.h
+++ b/sxt/cbindings/base/sumcheck_descriptor.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 namespace sxt::cbnb {

--- a/sxt/cbindings/base/sumcheck_descriptor.h
+++ b/sxt/cbindings/base/sumcheck_descriptor.h
@@ -20,6 +20,7 @@ namespace sxt::cbnb {
 //--------------------------------------------------------------------------------------------------
 // sumcheck_descriptor
 //--------------------------------------------------------------------------------------------------
+// Note: This should match the structure used in blitzar_api.h
 struct sumcheck_descriptor {
   const void* mles;
   const void* product_table;

--- a/sxt/cbindings/base/sumcheck_descriptor.h
+++ b/sxt/cbindings/base/sumcheck_descriptor.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace sxt::cbnb {
+//--------------------------------------------------------------------------------------------------
+// sumcheck_descriptor
+//--------------------------------------------------------------------------------------------------
+struct sumcheck_descriptor {
+  const void* mles;
+  const void* product_table;
+  const unsigned* product_terms;
+  unsigned n;
+  unsigned num_mles;
+  unsigned num_products;
+  unsigned num_product_terms;
+  unsigned round_degree;
+};
+} // namespace sxt::cbnb

--- a/sxt/proof/sumcheck/proof_computation.cc
+++ b/sxt/proof/sumcheck/proof_computation.cc
@@ -41,6 +41,7 @@ xena::future<> prove_sum(basct::span<s25t::element> polynomials,
   SXT_RELEASE_ASSERT(
       // clang-format off
       polynomial_length > 1 &&
+      evaluation_point.size() == num_variables &&
       polynomials.size() == num_variables * polynomial_length &&
       mles.size() == n * num_mles
       // clang-format on


### PR DESCRIPTION
# Rationale for this change

Add C API for generating sumcheck proofs.

# What changes are included in this PR?

Extend blitzar_api.h with a new function sxt_prove_sumcheck for creating sumcheck proofs.

# Are these changes tested?

Yes.
