### PR TITLE
feat: add sumcheck support for grumpkin curve (PROOF-913)

### DIFF
--- a/cbindings/blitzar_api.h
+++ b/cbindings/blitzar_api.h
@@ -31,6 +31,7 @@ extern "C" {
 #define SXT_CURVE_GRUMPKIN 3
 
 #define SXT_FIELD_SCALAR255 0
+#define SXT_FIELD_GRUMPKIN 1
 
 /** config struct to hold the chosen backend */
 struct sxt_config {

--- a/sxt/cbindings/backend/cpu_backend.cc
+++ b/sxt/cbindings/backend/cpu_backend.cc
@@ -76,7 +76,6 @@ void cpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
   auto num_variables = static_cast<size_t>(std::max(basn::ceil_log2(descriptor.n), 1));
   cbnb::switch_field_type(
       static_cast<cbnb::field_id_t>(field_id), [&]<class T>(std::type_identity<T>) noexcept {
-        static_assert(std::same_as<T, s25t::element>, "only support curve-255 right now");
         // transcript
         callback_sumcheck_transcript<T> transcript{
             reinterpret_cast<callback_sumcheck_transcript<T>::callback_t>(
@@ -84,20 +83,20 @@ void cpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
             transcript_context};
 
         // prove
-        basct::span<s25t::element> polynomials_span{
-            static_cast<s25t::element*>(polynomials),
+        basct::span<T> polynomials_span{
+            static_cast<T*>(polynomials),
             (descriptor.round_degree + 1u) * num_variables,
         };
-        basct::span<s25t::element> evaluation_point_span{
-            static_cast<s25t::element*>(evaluation_point),
+        basct::span<T> evaluation_point_span{
+            static_cast<T*>(evaluation_point),
             num_variables,
         };
-        basct::cspan<s25t::element> mles_span{
-            static_cast<const s25t::element*>(descriptor.mles),
+        basct::cspan<T> mles_span{
+            static_cast<const T*>(descriptor.mles),
             descriptor.n * descriptor.num_mles,
         };
-        basct::cspan<std::pair<s25t::element, unsigned>> product_table_span{
-            static_cast<const std::pair<s25t::element, unsigned>*>(descriptor.product_table),
+        basct::cspan<std::pair<T, unsigned>> product_table_span{
+            static_cast<const std::pair<T, unsigned>*>(descriptor.product_table),
             descriptor.num_products,
         };
         basct::cspan<unsigned> product_terms_span{

--- a/sxt/cbindings/backend/gpu_backend.cc
+++ b/sxt/cbindings/backend/gpu_backend.cc
@@ -109,7 +109,6 @@ void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
   auto num_variables = static_cast<size_t>(std::max(basn::ceil_log2(descriptor.n), 1));
   cbnb::switch_field_type(
       static_cast<cbnb::field_id_t>(field_id), [&]<class T>(std::type_identity<T>) noexcept {
-        static_assert(std::same_as<T, s25t::element>, "only support curve-255 right now");
         // transcript
         callback_sumcheck_transcript<T> transcript{
             reinterpret_cast<callback_sumcheck_transcript<T>::callback_t>(
@@ -117,20 +116,20 @@ void gpu_backend::prove_sumcheck(void* polynomials, void* evaluation_point, unsi
             transcript_context};
 
         // prove
-        basct::span<s25t::element> polynomials_span{
-            static_cast<s25t::element*>(polynomials),
+        basct::span<T> polynomials_span{
+            static_cast<T*>(polynomials),
             (descriptor.round_degree + 1u) * num_variables,
         };
-        basct::span<s25t::element> evaluation_point_span{
-            static_cast<s25t::element*>(evaluation_point),
+        basct::span<T> evaluation_point_span{
+            static_cast<T*>(evaluation_point),
             num_variables,
         };
-        basct::cspan<s25t::element> mles_span{
-            static_cast<const s25t::element*>(descriptor.mles),
+        basct::cspan<T> mles_span{
+            static_cast<const T*>(descriptor.mles),
             descriptor.n * descriptor.num_mles,
         };
-        basct::cspan<std::pair<s25t::element, unsigned>> product_table_span{
-            static_cast<const std::pair<s25t::element, unsigned>*>(descriptor.product_table),
+        basct::cspan<std::pair<T, unsigned>> product_table_span{
+            static_cast<const std::pair<T, unsigned>*>(descriptor.product_table),
             descriptor.num_products,
         };
         basct::cspan<unsigned> product_terms_span{

--- a/sxt/cbindings/base/BUILD
+++ b/sxt/cbindings/base/BUILD
@@ -57,6 +57,7 @@ sxt_cc_component(
     deps = [
         ":field_id",
         "//sxt/base/error:panic",
+        "//sxt/fieldgk/realization:field",
         "//sxt/scalar25/realization:field",
     ],
 )

--- a/sxt/cbindings/base/field_id.h
+++ b/sxt/cbindings/base/field_id.h
@@ -27,5 +27,6 @@ namespace sxt::cbnb {
  */
 enum class field_id_t : unsigned {
   scalar25519 = 0,
+  grumpkin = 1,
 };
 } // namespace sxt::cbnb

--- a/sxt/cbindings/base/field_id_utility.h
+++ b/sxt/cbindings/base/field_id_utility.h
@@ -20,6 +20,7 @@
 
 #include "sxt/base/error/panic.h"
 #include "sxt/cbindings/base/field_id.h"
+#include "sxt/fieldgk/realization/field.h"
 #include "sxt/scalar25/realization/field.h"
 
 namespace sxt::cbnb {
@@ -30,6 +31,9 @@ template <class F> void switch_field_type(field_id_t id, F f) {
   switch (id) {
   case field_id_t::scalar25519:
     f(std::type_identity<s25t::element>{});
+    break;
+  case field_id_t::grumpkin:
+    f(std::type_identity<fgkt::element>{});
     break;
   default:
     baser::panic("unsupported field id {}", static_cast<unsigned>(id));

--- a/sxt/fieldgk/operation/BUILD
+++ b/sxt/fieldgk/operation/BUILD
@@ -84,6 +84,16 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+  name = "muladd",
+  with_test = False,
+  deps = [
+    ":add",
+    ":mul",
+    "//sxt/base/macro:cuda_callable",
+  ],
+)
+
+sxt_cc_component(
     name = "neg",
     test_deps = [
         "//sxt/base/test:unit_test",

--- a/sxt/fieldgk/operation/BUILD
+++ b/sxt/fieldgk/operation/BUILD
@@ -84,13 +84,13 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
-  name = "muladd",
-  with_test = False,
-  deps = [
-    ":add",
-    ":mul",
-    "//sxt/base/macro:cuda_callable",
-  ],
+    name = "muladd",
+    with_test = False,
+    deps = [
+        ":add",
+        ":mul",
+        "//sxt/base/macro:cuda_callable",
+    ],
 )
 
 sxt_cc_component(

--- a/sxt/fieldgk/operation/muladd.cc
+++ b/sxt/fieldgk/operation/muladd.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/fieldgk/operation/muladd.h"

--- a/sxt/fieldgk/operation/muladd.cc
+++ b/sxt/fieldgk/operation/muladd.cc
@@ -1,0 +1,1 @@
+#include "sxt/fieldgk/operation/muladd.h"

--- a/sxt/fieldgk/operation/muladd.h
+++ b/sxt/fieldgk/operation/muladd.h
@@ -10,7 +10,8 @@ namespace sxt::fgko {
 //--------------------------------------------------------------------------------------------------
 inline CUDA_CALLABLE void muladd(fgkt::element& s, const fgkt::element& a, const fgkt::element& b,
                                  const fgkt::element& c) noexcept {
+  auto cp = c;
   mul(s, a, b);
-  add(s, s, c);
+  add(s, s, cp);
 }
 } // namespace sxt::fgko

--- a/sxt/fieldgk/operation/muladd.h
+++ b/sxt/fieldgk/operation/muladd.h
@@ -8,9 +8,8 @@ namespace sxt::fgko {
 //--------------------------------------------------------------------------------------------------
 // muladd
 //--------------------------------------------------------------------------------------------------
-CUDA_CALLABLE
-void muladd(fgkt::element& s, const fgkt::element& a, const fgkt::element& b,
-            const fgkt::element& c) noexcept {
+inline CUDA_CALLABLE void muladd(fgkt::element& s, const fgkt::element& a, const fgkt::element& b,
+                                 const fgkt::element& c) noexcept {
   mul(s, a, b);
   add(s, s, c);
 }

--- a/sxt/fieldgk/operation/muladd.h
+++ b/sxt/fieldgk/operation/muladd.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/base/macro/cuda_callable.h"

--- a/sxt/fieldgk/operation/muladd.h
+++ b/sxt/fieldgk/operation/muladd.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "sxt/base/macro/cuda_callable.h"
+#include "sxt/fieldgk/operation/add.h"
+#include "sxt/fieldgk/operation/mul.h"
+
+namespace sxt::fgko {
+//--------------------------------------------------------------------------------------------------
+// muladd
+//--------------------------------------------------------------------------------------------------
+CUDA_CALLABLE
+void muladd(fgkt::element& s, const fgkt::element& a, const fgkt::element& b,
+            const fgkt::element& c) noexcept {
+  mul(s, a, b);
+  add(s, s, c);
+}
+} // namespace sxt::fgko

--- a/sxt/fieldgk/realization/BUILD
+++ b/sxt/fieldgk/realization/BUILD
@@ -16,4 +16,3 @@ sxt_cc_component(
         "//sxt/fieldgk/type:element",
     ],
 )
-

--- a/sxt/fieldgk/realization/BUILD
+++ b/sxt/fieldgk/realization/BUILD
@@ -1,0 +1,19 @@
+load(
+    "//bazel:sxt_build_system.bzl",
+    "sxt_cc_component",
+)
+
+sxt_cc_component(
+    name = "field",
+    with_test = False,
+    deps = [
+        "//sxt/base/field:element",
+        "//sxt/fieldgk/operation:add",
+        "//sxt/fieldgk/operation:mul",
+        "//sxt/fieldgk/operation:muladd",
+        "//sxt/fieldgk/operation:neg",
+        "//sxt/fieldgk/operation:sub",
+        "//sxt/fieldgk/type:element",
+    ],
+)
+

--- a/sxt/fieldgk/realization/field.cc
+++ b/sxt/fieldgk/realization/field.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/fieldgk/realization/field.h"

--- a/sxt/fieldgk/realization/field.cc
+++ b/sxt/fieldgk/realization/field.cc
@@ -1,0 +1,1 @@
+#include "sxt/fieldgk/realization/field.h"

--- a/sxt/fieldgk/realization/field.h
+++ b/sxt/fieldgk/realization/field.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "sxt/base/field/element.h"
+#include "sxt/fieldgk/operation/add.h"
+#include "sxt/fieldgk/operation/mul.h"
+#include "sxt/fieldgk/operation/muladd.h"
+#include "sxt/fieldgk/operation/neg.h"
+#include "sxt/fieldgk/operation/sub.h"
+#include "sxt/fieldgk/type/element.h"
+
+static_assert(sxt::basfld::element<sxt::fgkt::element>);

--- a/sxt/fieldgk/realization/field.h
+++ b/sxt/fieldgk/realization/field.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 #include "sxt/base/field/element.h"

--- a/sxt/fieldgk/type/BUILD
+++ b/sxt/fieldgk/type/BUILD
@@ -16,6 +16,7 @@ sxt_cc_component(
     ],
     deps = [
       ":operation_adl_stub",
+      "//sxt/fieldgk/base:constants",
     ],
     is_cuda = True,
     test_deps = [

--- a/sxt/fieldgk/type/BUILD
+++ b/sxt/fieldgk/type/BUILD
@@ -4,10 +4,18 @@ load(
 )
 
 sxt_cc_component(
+    name = "operation_adl_stub",
+    with_test = False,
+)
+
+sxt_cc_component(
     name = "element",
     impl_deps = [
         "//sxt/fieldgk/base:byte_conversion",
         "//sxt/fieldgk/base:reduce",
+    ],
+    deps = [
+      ":operation_adl_stub",
     ],
     is_cuda = True,
     test_deps = [

--- a/sxt/fieldgk/type/BUILD
+++ b/sxt/fieldgk/type/BUILD
@@ -14,13 +14,13 @@ sxt_cc_component(
         "//sxt/fieldgk/base:byte_conversion",
         "//sxt/fieldgk/base:reduce",
     ],
-    deps = [
-      ":operation_adl_stub",
-      "//sxt/fieldgk/base:constants",
-    ],
     is_cuda = True,
     test_deps = [
         "//sxt/base/test:unit_test",
+        "//sxt/fieldgk/base:constants",
+    ],
+    deps = [
+        ":operation_adl_stub",
         "//sxt/fieldgk/base:constants",
     ],
 )

--- a/sxt/fieldgk/type/element.h
+++ b/sxt/fieldgk/type/element.h
@@ -46,9 +46,7 @@ public:
 
   constexpr uint64_t* data() noexcept { return data_; }
 
-  static constexpr element identity() noexcept {
-    return {0, 0, 0, 0};
-  }
+  static constexpr element identity() noexcept { return {0, 0, 0, 0}; }
 
   static constexpr element one() noexcept {
     return {fgkb::r_v[0], fgkb::r_v[1], fgkb::r_v[2], fgkb::r_v[3]};

--- a/sxt/fieldgk/type/element.h
+++ b/sxt/fieldgk/type/element.h
@@ -20,6 +20,7 @@
 #include <cstdint>
 #include <iosfwd>
 
+#include "sxt/fieldgk/base/constants.h"
 #include "sxt/fieldgk/type/operation_adl_stub.h"
 
 namespace sxt::fgkt {
@@ -44,6 +45,14 @@ public:
   constexpr const uint64_t* data() const noexcept { return data_; }
 
   constexpr uint64_t* data() noexcept { return data_; }
+
+  static constexpr element identity() noexcept {
+    return {0, 0, 0, 0};
+  }
+
+  static constexpr element one() noexcept {
+    return {fgkb::r_v[0], fgkb::r_v[1], fgkb::r_v[2], fgkb::r_v[3]};
+  }
 
 private:
   uint64_t data_[num_limbs_v];

--- a/sxt/fieldgk/type/element.h
+++ b/sxt/fieldgk/type/element.h
@@ -20,11 +20,13 @@
 #include <cstdint>
 #include <iosfwd>
 
+#include "sxt/fieldgk/type/operation_adl_stub.h"
+
 namespace sxt::fgkt {
 //--------------------------------------------------------------------------------------------------
 // element
 //--------------------------------------------------------------------------------------------------
-class element {
+class element : public fgko::operation_adl_stub {
 public:
   static constexpr size_t num_limbs_v = 4;
 

--- a/sxt/fieldgk/type/operation_adl_stub.cc
+++ b/sxt/fieldgk/type/operation_adl_stub.cc
@@ -1,0 +1,1 @@
+#include "sxt/fieldgk/type/operation_adl_stub.h"

--- a/sxt/fieldgk/type/operation_adl_stub.cc
+++ b/sxt/fieldgk/type/operation_adl_stub.cc
@@ -1,1 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #include "sxt/fieldgk/type/operation_adl_stub.h"

--- a/sxt/fieldgk/type/operation_adl_stub.h
+++ b/sxt/fieldgk/type/operation_adl_stub.h
@@ -1,0 +1,12 @@
+#pragma once
+
+namespace sxt::fgko {
+//--------------------------------------------------------------------------------------------------
+// operation_adl_stub
+//--------------------------------------------------------------------------------------------------
+/**
+ * A stub class that can be inherited so that functions in the fgko namespace
+ * will participate in ADL.
+ */
+struct operation_adl_stub {};
+} // namespace sxt::fgko

--- a/sxt/fieldgk/type/operation_adl_stub.h
+++ b/sxt/fieldgk/type/operation_adl_stub.h
@@ -1,3 +1,19 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 #pragma once
 
 namespace sxt::fgko {

--- a/sxt/proof/sumcheck/BUILD
+++ b/sxt/proof/sumcheck/BUILD
@@ -240,6 +240,8 @@ sxt_cc_component(
         "//sxt/base/test:unit_test",
         "//sxt/execution/async:future",
         "//sxt/execution/schedule:scheduler",
+        "//sxt/fieldgk/realization:field",
+        "//sxt/fieldgk/type:literal",
         "//sxt/proof/transcript",
         "//sxt/scalar25/operation:overload",
         "//sxt/scalar25/realization:field",

--- a/sxt/proof/sumcheck/cpu_driver.h
+++ b/sxt/proof/sumcheck/cpu_driver.h
@@ -62,7 +62,7 @@ public:
     auto product_terms = work.product_terms;
 
     for (auto& val : polynomial) {
-      val = {};
+      val = T::identity();
     }
 
     // expand paired terms

--- a/sxt/proof/sumcheck/proof_computation.t.cc
+++ b/sxt/proof/sumcheck/proof_computation.t.cc
@@ -48,34 +48,6 @@ using fgkt::operator""_fgk;
 using T = s25t::element;
 using Tp = fgkt::element;
 
-#if 0
-static void test_proof_grumpkin(const driver<Tp>& drv) {
-  prft::transcript base_transcript{"abc"};
-  reference_transcript<Tp> transcript{base_transcript};
-  std::vector<Tp> polynomials(2);
-  std::vector<Tp> evaluation_point(1);
-  std::vector<Tp> mles = {
-      0x8_fgk,
-      0x3_fgk,
-  };
-  std::vector<std::pair<Tp, unsigned>> product_table = {
-      {0x1_fgk, 1},
-  };
-  std::vector<unsigned> product_terms = {0};
-
-  SECTION("we can prove a sum with n=1") {
-    /* auto fut = prove_sum<Tp>(polynomials, evaluation_point, transcript, drv, mles, product_table, */
-    /*                          product_terms, 1); */
-    xens::get_scheduler().run();
-    /* REQUIRE(fut.ready()); */
-    REQUIRE(polynomials[0] == mles[0]);
-    fgkt::element expected;
-    fgko::neg(expected, mles[0]);
-    REQUIRE(polynomials[1] == expected);
-  }
-}
-#endif
-
 static void test_proof(const driver<T>& drv) {
   prft::transcript base_transcript{"abc"};
   reference_transcript<T> transcript{base_transcript};
@@ -266,29 +238,23 @@ TEST_CASE("we can create a sumcheck proof") {
 
   SECTION("we can construct proofs with the grumpkin field") {
     prft::transcript base_transcript{"abc"};
-    /* reference_transcript<Tp> transcript{base_transcript}; */
-    /* std::vector<Tp> polynomials(2); */
-    /* std::vector<Tp> evaluation_point(1); */
-    /* std::vector<Tp> mles = { */
-    /*     0x8_fgk, */
-    /*     0x3_fgk, */
-    /* }; */
-    /* std::vector<std::pair<Tp, unsigned>> product_table = { */
-    /*     {0x1_fgk, 1}, */
-    /* }; */
-    /* std::vector<unsigned> product_terms = {0}; */
-
-#if 0
-  SECTION("we can prove a sum with n=1") {
-    /* auto fut = prove_sum<Tp>(polynomials, evaluation_point, transcript, drv, mles, product_table, */
-    /*                          product_terms, 1); */
-    xens::get_scheduler().run();
-    /* REQUIRE(fut.ready()); */
+    reference_transcript<Tp> transcript{base_transcript};
+    std::vector<Tp> polynomials(2);
+    std::vector<Tp> evaluation_point(1);
+    std::vector<Tp> mles = {
+        0x8_fgk,
+        0x3_fgk,
+    };
+    std::vector<std::pair<Tp, unsigned>> product_table = {
+        {0x1_fgk, 1},
+    };
+    std::vector<unsigned> product_terms = {0};
+    cpu_driver<Tp> drv;
+    prove_sum<Tp>(polynomials, evaluation_point, transcript, drv, mles, product_table,
+                  product_terms, 1);
     REQUIRE(polynomials[0] == mles[0]);
     fgkt::element expected;
     fgko::neg(expected, mles[0]);
     REQUIRE(polynomials[1] == expected);
-  }
-#endif
   }
 }

--- a/sxt/proof/sumcheck/proof_computation.t.cc
+++ b/sxt/proof/sumcheck/proof_computation.t.cc
@@ -25,6 +25,8 @@
 #include "sxt/base/test/unit_test.h"
 #include "sxt/execution/async/future.h"
 #include "sxt/execution/schedule/scheduler.h"
+#include "sxt/fieldgk/realization/field.h"
+#include "sxt/fieldgk/type/literal.h"
 #include "sxt/proof/sumcheck/chunked_gpu_driver.h"
 #include "sxt/proof/sumcheck/cpu_driver.h"
 #include "sxt/proof/sumcheck/gpu_driver.h"
@@ -41,10 +43,40 @@
 using namespace sxt;
 using namespace sxt::prfsk;
 using s25t::operator""_s25;
+using fgkt::operator""_fgk;
 
 using T = s25t::element;
+using Tp = fgkt::element;
 
-static void test_proof(const driver<T>& drv) noexcept {
+#if 0
+static void test_proof_grumpkin(const driver<Tp>& drv) {
+  prft::transcript base_transcript{"abc"};
+  reference_transcript<Tp> transcript{base_transcript};
+  std::vector<Tp> polynomials(2);
+  std::vector<Tp> evaluation_point(1);
+  std::vector<Tp> mles = {
+      0x8_fgk,
+      0x3_fgk,
+  };
+  std::vector<std::pair<Tp, unsigned>> product_table = {
+      {0x1_fgk, 1},
+  };
+  std::vector<unsigned> product_terms = {0};
+
+  SECTION("we can prove a sum with n=1") {
+    /* auto fut = prove_sum<Tp>(polynomials, evaluation_point, transcript, drv, mles, product_table, */
+    /*                          product_terms, 1); */
+    xens::get_scheduler().run();
+    /* REQUIRE(fut.ready()); */
+    REQUIRE(polynomials[0] == mles[0]);
+    fgkt::element expected;
+    fgko::neg(expected, mles[0]);
+    REQUIRE(polynomials[1] == expected);
+  }
+}
+#endif
+
+static void test_proof(const driver<T>& drv) {
   prft::transcript base_transcript{"abc"};
   reference_transcript<T> transcript{base_transcript};
   std::vector<s25t::element> polynomials(2);

--- a/sxt/proof/sumcheck/proof_computation.t.cc
+++ b/sxt/proof/sumcheck/proof_computation.t.cc
@@ -263,4 +263,32 @@ TEST_CASE("we can create a sumcheck proof") {
     chunked_gpu_driver<T> drv{fraction};
     test_proof(drv);
   }
+
+  SECTION("we can construct proofs with the grumpkin field") {
+    prft::transcript base_transcript{"abc"};
+    /* reference_transcript<Tp> transcript{base_transcript}; */
+    /* std::vector<Tp> polynomials(2); */
+    /* std::vector<Tp> evaluation_point(1); */
+    /* std::vector<Tp> mles = { */
+    /*     0x8_fgk, */
+    /*     0x3_fgk, */
+    /* }; */
+    /* std::vector<std::pair<Tp, unsigned>> product_table = { */
+    /*     {0x1_fgk, 1}, */
+    /* }; */
+    /* std::vector<unsigned> product_terms = {0}; */
+
+#if 0
+  SECTION("we can prove a sum with n=1") {
+    /* auto fut = prove_sum<Tp>(polynomials, evaluation_point, transcript, drv, mles, product_table, */
+    /*                          product_terms, 1); */
+    xens::get_scheduler().run();
+    /* REQUIRE(fut.ready()); */
+    REQUIRE(polynomials[0] == mles[0]);
+    fgkt::element expected;
+    fgko::neg(expected, mles[0]);
+    REQUIRE(polynomials[1] == expected);
+  }
+#endif
+  }
 }

--- a/sxt/proof/transcript/BUILD
+++ b/sxt/proof/transcript/BUILD
@@ -53,9 +53,12 @@ sxt_cc_component(
     impl_deps = [
         "//sxt/scalar25/operation:reduce",
         "//sxt/scalar25/type:element",
+        "//sxt/fieldgk/base:byte_conversion",
+        "//sxt/fieldgk/type:element",
     ],
     test_deps = [
         "//sxt/base/test:unit_test",
+        "//sxt/fieldgk/type:element",
         "//sxt/ristretto/type:compressed_element",
         "//sxt/scalar25/operation:reduce",
         "//sxt/scalar25/type:element",

--- a/sxt/proof/transcript/transcript_primitive.h
+++ b/sxt/proof/transcript/transcript_primitive.h
@@ -26,6 +26,10 @@ namespace sxt::s25t {
 class element;
 }
 
+namespace sxt::fgkt {
+class element;
+}
+
 namespace sxt::prft {
 //--------------------------------------------------------------------------------------------------
 // is_transcript_primitive_v
@@ -33,5 +37,6 @@ namespace sxt::prft {
 template <class T>
 constexpr bool is_transcript_primitive_v =
     std::is_integral_v<T> || std::is_same_v<T, unsigned char> ||
-    std::is_same_v<T, rstt::compressed_element> || std::is_same_v<T, s25t::element>;
+    std::is_same_v<T, rstt::compressed_element> || std::is_same_v<T, s25t::element> ||
+    std::is_same_v<T, fgkt::element>;
 } // namespace sxt::prft

--- a/sxt/proof/transcript/transcript_utility.cc
+++ b/sxt/proof/transcript/transcript_utility.cc
@@ -16,6 +16,8 @@
  */
 #include "sxt/proof/transcript/transcript_utility.h"
 
+#include "sxt/fieldgk/base/byte_conversion.h"
+#include "sxt/fieldgk/type/element.h"
 #include "sxt/scalar25/operation/reduce.h"
 #include "sxt/scalar25/type/element.h"
 
@@ -26,6 +28,12 @@ namespace sxt::prft {
 void challenge_value(s25t::element& value, transcript& trans, std::string_view label) noexcept {
   trans.challenge_bytes({reinterpret_cast<uint8_t*>(&value), sizeof(s25t::element)}, label);
   s25o::reduce32(value);
+}
+
+void challenge_value(fgkt::element& value, transcript& trans, std::string_view label) noexcept {
+  uint64_t data[4];
+  trans.challenge_bytes({reinterpret_cast<uint8_t*>(data), 32}, label);
+  fgkb::to_bytes_le(reinterpret_cast<uint8_t*>(value.data()), data);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/sxt/proof/transcript/transcript_utility.cc
+++ b/sxt/proof/transcript/transcript_utility.cc
@@ -31,9 +31,9 @@ void challenge_value(s25t::element& value, transcript& trans, std::string_view l
 }
 
 void challenge_value(fgkt::element& value, transcript& trans, std::string_view label) noexcept {
-  uint64_t data[4];
-  trans.challenge_bytes({reinterpret_cast<uint8_t*>(data), 32}, label);
-  fgkb::to_bytes_le(reinterpret_cast<uint8_t*>(value.data()), data);
+  auto data = reinterpret_cast<uint8_t*>(value.data());
+  trans.challenge_bytes({data, sizeof(fgkt::element)}, label);
+  fgkb::to_bytes_le(data, value.data());
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -45,6 +45,15 @@ void challenge_values(basct::span<s25t::element> values, transcript& trans,
       {reinterpret_cast<uint8_t*>(values.data()), values.size() * sizeof(s25t::element)}, label);
   for (auto& val : values) {
     s25o::reduce32(val);
+  }
+}
+
+void challenge_values(basct::span<fgkt::element> values, transcript& trans,
+                      std::string_view label) noexcept {
+  trans.challenge_bytes(
+      {reinterpret_cast<uint8_t*>(values.data()), sizeof(fgkt::element) * values.size()}, label);
+  for (auto& val : values) {
+    fgkb::to_bytes_le(reinterpret_cast<uint8_t*>(val.data()), val.data());
   }
 }
 } // namespace sxt::prft

--- a/sxt/proof/transcript/transcript_utility.h
+++ b/sxt/proof/transcript/transcript_utility.h
@@ -27,6 +27,10 @@ namespace sxt::s25t {
 class element;
 }
 
+namespace sxt::fgkt {
+class element;
+}
+
 namespace sxt::prft {
 //--------------------------------------------------------------------------------------------------
 // append_value
@@ -55,6 +59,8 @@ inline void append_values(transcript& trans, std::string_view label,
 // challenge_value
 //--------------------------------------------------------------------------------------------------
 void challenge_value(s25t::element& value, transcript& trans, std::string_view label) noexcept;
+
+void challenge_value(fgkt::element& value, transcript& trans, std::string_view label) noexcept;
 
 //--------------------------------------------------------------------------------------------------
 // challenge_values

--- a/sxt/proof/transcript/transcript_utility.h
+++ b/sxt/proof/transcript/transcript_utility.h
@@ -68,6 +68,9 @@ void challenge_value(fgkt::element& value, transcript& trans, std::string_view l
 void challenge_values(basct::span<s25t::element> values, transcript& trans,
                       std::string_view label) noexcept;
 
+void challenge_values(basct::span<fgkt::element> values, transcript& trans,
+                      std::string_view label) noexcept;
+
 //--------------------------------------------------------------------------------------------------
 // set_domain
 //--------------------------------------------------------------------------------------------------

--- a/sxt/proof/transcript/transcript_utility.t.cc
+++ b/sxt/proof/transcript/transcript_utility.t.cc
@@ -104,4 +104,10 @@ TEST_CASE("we can get challenge values from a transcript") {
       REQUIRE(std::memcmp(xip.data(), xi.data(), sizeof(s25t::element)) == 0);
     }
   }
+
+  SECTION("we can challenge an array of grumpkin curve values") {
+    fgkt::element vals[2];
+    challenge_values(vals, trans, "123");
+    REQUIRE(vals[0] != vals[1]);
+  }
 }

--- a/sxt/proof/transcript/transcript_utility.t.cc
+++ b/sxt/proof/transcript/transcript_utility.t.cc
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "sxt/base/test/unit_test.h"
+#include "sxt/fieldgk/type/element.h"
 #include "sxt/ristretto/type/compressed_element.h"
 #include "sxt/scalar25/operation/reduce.h"
 #include "sxt/scalar25/type/element.h"
@@ -73,6 +74,13 @@ TEST_CASE("we can get challenge values from a transcript") {
 
   SECTION("challenge values aren't equal") {
     s25t::element x1, x2;
+    challenge_value(x1, trans, "xyz");
+    challenge_value(x2, trans, "123");
+    REQUIRE(x1 != x2);
+  }
+
+  SECTION("we can challenge values from the grumpkin field") {
+    fgkt::element x1, x2;
     challenge_value(x1, trans, "xyz");
     challenge_value(x2, trans, "123");
     REQUIRE(x1 != x2);


### PR DESCRIPTION
# Rationale for this change

Support using grumpkin field with sumcheck.

# What changes are included in this PR?

* Small modifications to fieldgk to support field concept.
* Add transcript operations for fieldgk

# Are these changes tested?

Yes
