### PR TITLE
feat: add shared future (PROOF-928)

### DIFF
--- a/sxt/execution/async/BUILD
+++ b/sxt/execution/async/BUILD
@@ -144,6 +144,30 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "shared_future",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+    ],
+    deps = [
+        ":future",
+        ":shared_future_state",
+    ],
+)
+
+sxt_cc_component(
+    name = "shared_future_state",
+    test_deps = [
+        "//sxt/base/test:unit_test",
+        "//sxt/memory/resource:counting_resource",
+    ],
+    deps = [
+        ":future",
+        ":promise",
+        "//sxt/base/error:assert",
+    ],
+)
+
+sxt_cc_component(
     name = "future_utility",
     impl_deps = [
         ":coroutine",

--- a/sxt/execution/async/coroutine.h
+++ b/sxt/execution/async/coroutine.h
@@ -21,6 +21,7 @@
 #include "sxt/execution/async/awaiter.h"
 #include "sxt/execution/async/coroutine_promise.h"
 #include "sxt/execution/async/future.h"
+#include "sxt/execution/async/shared_future.h"
 
 namespace sxt {
 //--------------------------------------------------------------------------------------------------
@@ -37,6 +38,10 @@ template <class Fut>
 auto operator co_await(Fut&& fut) noexcept {
   using T = typename Fut::value_type;
   return xena::awaiter<T>{xena::future<T>{std::move(fut)}};
+}
+
+template <class T> xena::awaiter<T> operator co_await(const xena::shared_future<T>& fut) noexcept {
+  return xena::awaiter<T>{fut.make_future()};
 }
 } // namespace sxt
 

--- a/sxt/execution/async/coroutine.t.cc
+++ b/sxt/execution/async/coroutine.t.cc
@@ -28,6 +28,7 @@ using namespace sxt::xena;
 static future<> f_v() noexcept;
 static future<int> f_i() noexcept;
 static future<int> f_i2() noexcept;
+static future<int> f_mi() noexcept;
 static future<int> f_dev(promise<int>& p);
 
 TEST_CASE("futures interoperate with coroutines") {
@@ -57,6 +58,12 @@ TEST_CASE("futures interoperate with coroutines") {
     REQUIRE(res.value() == 124);
     REQUIRE(basdv::get_device() == 0);
   }
+
+  SECTION("we can await shared futures") {
+    auto res = f_mi();
+    REQUIRE(res.ready());
+    REQUIRE(res.value() == 124);
+  }
 }
 
 static future<> f_v() noexcept { co_return; }
@@ -65,6 +72,11 @@ static future<int> f_i() noexcept { co_return 123; }
 
 static future<int> f_i2() noexcept {
   auto x = co_await f_i();
+  co_return x + 1;
+}
+
+static future<int> f_mi() noexcept {
+  auto x = co_await shared_future<int>{f_i()};
   co_return x + 1;
 }
 

--- a/sxt/execution/async/shared_future.cc
+++ b/sxt/execution/async/shared_future.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/async/shared_future.h"

--- a/sxt/execution/async/shared_future.h
+++ b/sxt/execution/async/shared_future.h
@@ -1,0 +1,46 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <cassert>
+#include <utility>
+
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/async/shared_future_state.h"
+
+namespace sxt::xena {
+//--------------------------------------------------------------------------------------------------
+// shared_future
+//--------------------------------------------------------------------------------------------------
+template <class T = void> class shared_future {
+public:
+  shared_future() noexcept = default;
+
+  shared_future(future<T>&& fut) noexcept {
+    assert(fut.promise() != nullptr || fut.ready());
+    state_ = std::make_shared<shared_future_state<T>>(std::move(fut));
+  }
+
+  future<T> make_future() const noexcept {
+    assert(state_ != nullptr);
+    return state_->make_future();
+  }
+
+private:
+  std::shared_ptr<shared_future_state<T>> state_;
+};
+} // namespace sxt::xena

--- a/sxt/execution/async/shared_future.t.cc
+++ b/sxt/execution/async/shared_future.t.cc
@@ -1,0 +1,32 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/async/shared_future.h"
+
+#include "sxt/base/test/unit_test.h"
+
+using namespace sxt;
+using namespace sxt::xena;
+
+TEST_CASE("we can manage a shared future") {
+  promise<int> ps;
+  shared_future<int> fut{future<int>{ps}};
+  auto futp = fut.make_future();
+  REQUIRE(!futp.ready());
+  ps.set_value(123);
+  REQUIRE(futp.ready());
+  REQUIRE(futp.value() == 123);
+}

--- a/sxt/execution/async/shared_future_state.cc
+++ b/sxt/execution/async/shared_future_state.cc
@@ -1,0 +1,17 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/async/shared_future_state.h"

--- a/sxt/execution/async/shared_future_state.h
+++ b/sxt/execution/async/shared_future_state.h
@@ -1,0 +1,87 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <list>
+#include <memory>
+#include <utility>
+
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/async/future.h"
+#include "sxt/execution/async/promise.h"
+#include "sxt/execution/async/task.h"
+
+namespace sxt::xena {
+//--------------------------------------------------------------------------------------------------
+// shared_future_state
+//--------------------------------------------------------------------------------------------------
+/**
+ * Manage state for a future that can be awaited multiple times.
+ *
+ * This is a highly simplified version of a shared_future derived from seastar
+ *
+ * See https://seastar.io/futures-promises/
+ */
+template <class T>
+class shared_future_state final : public task,
+                                  public std::enable_shared_from_this<shared_future_state<T>> {
+public:
+  shared_future_state() noexcept = default;
+  shared_future_state(future<T>&& fut) noexcept : fut_{std::move(fut)} {
+    SXT_DEBUG_ASSERT(fut_.promise() != nullptr || fut_.ready());
+  }
+
+  shared_future_state(const shared_future_state&) = delete;
+  shared_future_state(shared_future_state&&) = delete;
+
+  shared_future_state& operator=(const shared_future_state&) = delete;
+  shared_future_state& operator=(shared_future_state&&) = delete;
+
+  future<T> make_future() noexcept {
+    if (fut_.ready()) {
+      if constexpr (std::is_same_v<T, void>) {
+        return make_ready_future();
+      } else {
+        return make_ready_future<T>(T{fut_.value()});
+      }
+    }
+    if (promises_.empty()) {
+      fut_.promise()->set_continuation(*this);
+      keep_alive_ = this->shared_from_this();
+    }
+    promises_.emplace_back();
+    return future<T>{promises_.back()};
+  };
+
+private:
+  void run_and_dispose() noexcept override {
+    while (!promises_.empty()) {
+      if constexpr (std::is_same_v<T, void>) {
+        promises_.back().make_ready();
+      } else {
+        promises_.back().set_value(fut_.value());
+      }
+      promises_.pop_back();
+    }
+    keep_alive_.reset();
+  }
+
+  std::shared_ptr<shared_future_state<T>> keep_alive_;
+  future<T> fut_;
+  std::list<promise<T>> promises_;
+};
+} // namespace sxt::xena

--- a/sxt/execution/async/shared_future_state.t.cc
+++ b/sxt/execution/async/shared_future_state.t.cc
@@ -1,0 +1,92 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/async/shared_future_state.h"
+
+#include "sxt/base/test/unit_test.h"
+#include "sxt/memory/resource/counting_resource.h"
+
+using namespace sxt;
+using namespace sxt::xena;
+
+TEST_CASE("we can manage shared future state") {
+  promise<int> ps;
+  auto s = std::make_shared<shared_future_state<int>>(future<int>{ps});
+
+  SECTION("we can create a future from a shared ready state") {
+    ps.set_value(123);
+    auto fut = s->make_future();
+    REQUIRE(fut.ready());
+    REQUIRE(fut.value() == 123);
+  }
+
+  SECTION("we can create a future from a shared pending event") {
+    auto fut = s->make_future();
+    REQUIRE(!fut.ready());
+    ps.set_value(123);
+    REQUIRE(fut.ready());
+    REQUIRE(fut.value() == 123);
+  }
+
+  SECTION("we can create multiple futures from a shared state") {
+    auto fut1 = s->make_future();
+    REQUIRE(!fut1.ready());
+
+    auto fut2 = s->make_future();
+    REQUIRE(!fut2.ready());
+
+    ps.set_value(123);
+
+    REQUIRE(fut1.ready());
+    REQUIRE(fut1.value() == 123);
+
+    REQUIRE(fut2.ready());
+    REQUIRE(fut2.value() == 123);
+  }
+}
+
+TEST_CASE("the lifetime of future states are properly managed") {
+  memr::counting_resource resource;
+  REQUIRE(resource.bytes_allocated() == 0);
+  promise<int> ps;
+  auto s = std::allocate_shared<shared_future_state<int>>(
+      std::pmr::polymorphic_allocator<>{&resource}, future<int>{ps});
+  REQUIRE(resource.bytes_allocated() > 0);
+
+  SECTION("shared future states are kept alive if there is a pending promise") {
+    auto fut = s->make_future();
+    s.reset();
+    REQUIRE(resource.bytes_deallocated() == 0);
+    REQUIRE(s == nullptr);
+    REQUIRE(!fut.ready());
+    ps.set_value(123);
+    REQUIRE(fut.ready());
+    REQUIRE(fut.value() == 123);
+    REQUIRE(resource.bytes_deallocated() == resource.bytes_allocated());
+  }
+}
+
+TEST_CASE("we can manage void future states") {
+  promise<> ps;
+  auto s = std::make_shared<shared_future_state<void>>(future<void>{ps});
+
+  SECTION("we can create a future from a shared ready state") {
+    auto fut = s->make_future();
+    REQUIRE(!fut.ready());
+    ps.make_ready();
+    REQUIRE(fut.ready());
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Add a shared_future that can be awaited multiple times.

This is adopted from https://docs.seastar.io/master/classseastar_1_1shared__future.html

shared_future will be used to improve the GPU scheduling.

# What changes are included in this PR?

* Adds a shared_future class that can be awaited multiple times.

# Are these changes tested?

Yes
