### PR TITLE
fix: fix future continuation for ready futures (PROOF-928)

### DIFF
--- a/sxt/execution/async/future.h
+++ b/sxt/execution/async/future.h
@@ -107,6 +107,7 @@ public:
     if (state_.ready()) {
       future_state<Tp> state_p;
       invoke_continuation_fn(state_p, f, state_);
+      state_p.make_ready();
       return future<Tp>{std::move(state_p)};
     }
     auto ps = this->promise();

--- a/sxt/execution/async/future.t.cc
+++ b/sxt/execution/async/future.t.cc
@@ -143,6 +143,7 @@ TEST_CASE("future manages an asynchronously computed result") {
       val.reset();
       return 456;
     });
+    REQUIRE(fut_p.ready());
     REQUIRE(fut_p.value() == 456);
   }
 


### PR DESCRIPTION
# Rationale for this change

If a ready future is continued, the continuation future should also be ready.

# What changes are included in this PR?

* Fix continuations for futures that are already ready.

# Are these changes tested?

Yes.
