### PR TITLE
feat: rework pinned memory management (PROOF-928)

### DIFF
--- a/sxt/base/device/pinned_buffer.cc
+++ b/sxt/base/device/pinned_buffer.cc
@@ -1,6 +1,6 @@
 /** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
  *
- * Copyright 2024-present Space and Time Labs, Inc.
+ * Copyright 2025-present Space and Time Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,16 +17,19 @@
 #include "sxt/base/device/pinned_buffer.h"
 
 #include "sxt/base/device/pinned_buffer_pool.h"
+#include "sxt/base/error/assert.h"
 
 namespace sxt::basdv {
 //--------------------------------------------------------------------------------------------------
-// consructor
+// constructor
 //--------------------------------------------------------------------------------------------------
-pinned_buffer::pinned_buffer() noexcept : handle_{get_pinned_buffer_pool()->acquire_handle()} {}
-
-pinned_buffer::pinned_buffer(pinned_buffer&& ptr) noexcept : handle_{ptr.handle_} {
-  ptr.handle_ = nullptr;
+pinned_buffer::pinned_buffer(size_t size) noexcept
+    : handle_{get_pinned_buffer_pool()->acquire_handle()}, size_{size} {
+  SXT_RELEASE_ASSERT(size_ <= this->capacity());
 }
+
+pinned_buffer::pinned_buffer(pinned_buffer&& other) noexcept
+    : handle_{std::exchange(other.handle_, nullptr)}, size_{std::exchange(other.size_, 0)} {}
 
 //--------------------------------------------------------------------------------------------------
 // destructor
@@ -40,17 +43,54 @@ pinned_buffer::~pinned_buffer() noexcept {
 //--------------------------------------------------------------------------------------------------
 // operator=
 //--------------------------------------------------------------------------------------------------
-pinned_buffer& pinned_buffer::operator=(pinned_buffer&& ptr) noexcept {
-  if (handle_ != nullptr) {
-    get_pinned_buffer_pool()->release_handle(handle_);
-  }
-  handle_ = ptr.handle_;
-  ptr.handle_ = nullptr;
+pinned_buffer& pinned_buffer::operator=(pinned_buffer&& other) noexcept {
+  this->reset();
+  handle_ = std::exchange(other.handle_, nullptr);
+  size_ = std::exchange(other.size_, 0);
   return *this;
 }
 
 //--------------------------------------------------------------------------------------------------
-// size
+// capacity
 //--------------------------------------------------------------------------------------------------
-size_t pinned_buffer::size() noexcept { return pinned_buffer_size; }
+size_t pinned_buffer::capacity() noexcept { return pinned_buffer_size; }
+
+//--------------------------------------------------------------------------------------------------
+// resize
+//--------------------------------------------------------------------------------------------------
+void pinned_buffer::resize(size_t size) noexcept {
+  SXT_RELEASE_ASSERT(size <= this->capacity());
+  if (handle_ == nullptr) {
+    handle_ = get_pinned_buffer_pool()->acquire_handle();
+  }
+  size_ = size;
+}
+
+//--------------------------------------------------------------------------------------------------
+// fill
+//--------------------------------------------------------------------------------------------------
+basct::cspan<std::byte> pinned_buffer::fill_from_host(basct::cspan<std::byte> src) noexcept {
+  if (src.empty()) {
+    return src;
+  }
+  if (handle_ == nullptr) {
+    handle_ = get_pinned_buffer_pool()->acquire_handle();
+  }
+  auto n = std::min(src.size(), this->capacity() - size_);
+  std::copy_n(src.data(), n, static_cast<std::byte*>(handle_->ptr) + size_);
+  size_ += n;
+  return src.subspan(n);
+}
+
+//--------------------------------------------------------------------------------------------------
+// reset
+//--------------------------------------------------------------------------------------------------
+void pinned_buffer::reset() noexcept {
+  if (handle_ == nullptr) {
+    return;
+  }
+  get_pinned_buffer_pool()->release_handle(handle_);
+  handle_ = nullptr;
+  size_ = 0;
+}
 } // namespace sxt::basdv

--- a/sxt/base/device/pinned_buffer.h
+++ b/sxt/base/device/pinned_buffer.h
@@ -1,6 +1,6 @@
 /** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
  *
- * Copyright 2024-present Space and Time Labs, Inc.
+ * Copyright 2025-present Space and Time Labs, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
  */
 #pragma once
 
+#include <cstddef>
+
+#include "sxt/base/container/span.h"
 #include "sxt/base/device/pinned_buffer_handle.h"
 
 namespace sxt::basdv {
@@ -24,26 +27,48 @@ namespace sxt::basdv {
 //--------------------------------------------------------------------------------------------------
 class pinned_buffer {
 public:
-  pinned_buffer() noexcept;
-  pinned_buffer(pinned_buffer&& ptr) noexcept;
+  pinned_buffer() noexcept = default;
+
+  explicit pinned_buffer(size_t size) noexcept;
+
   pinned_buffer(const pinned_buffer&) noexcept = delete;
+  pinned_buffer(pinned_buffer&& other) noexcept;
 
   ~pinned_buffer() noexcept;
 
-  pinned_buffer& operator=(pinned_buffer&& ptr) noexcept;
-  pinned_buffer& operator=(const pinned_buffer& ptr) noexcept = delete;
+  pinned_buffer& operator=(const pinned_buffer&) noexcept = delete;
+  pinned_buffer& operator=(pinned_buffer&& other) noexcept;
 
-  static size_t size() noexcept;
+  bool empty() const noexcept { return size_ == 0; }
 
-  void* data() noexcept { return handle_->ptr; }
+  bool full() const noexcept { return size_ == this->capacity(); }
 
-  const void* data() const noexcept { return handle_->ptr; }
+  size_t size() const noexcept { return size_; }
 
-  operator void*() noexcept { return handle_->ptr; }
+  static size_t capacity() noexcept;
 
-  operator const void*() const noexcept { return handle_->ptr; }
+  void* data() noexcept {
+    if (handle_ == nullptr) {
+      return nullptr;
+    }
+    return handle_->ptr;
+  }
+
+  const void* data() const noexcept {
+    if (handle_ == nullptr) {
+      return nullptr;
+    }
+    return handle_->ptr;
+  }
+
+  void resize(size_t size) noexcept;
+
+  basct::cspan<std::byte> fill_from_host(basct::cspan<std::byte> src) noexcept;
+
+  void reset() noexcept;
 
 private:
-  pinned_buffer_handle* handle_;
+  pinned_buffer_handle* handle_ = nullptr;
+  size_t size_ = 0;
 };
 } // namespace sxt::basdv

--- a/sxt/execution/device/BUILD
+++ b/sxt/execution/device/BUILD
@@ -12,6 +12,31 @@ sxt_cc_component(
 )
 
 sxt_cc_component(
+    name = "to_device_copier",
+    impl_deps = [
+        ":synchronization",
+        "//sxt/base/device:memory_utility",
+        "//sxt/base/functional:function_ref",
+        "//sxt/execution/async:coroutine",
+    ],
+    test_deps = [
+        "//sxt/base/device:pinned_buffer_pool",
+        "//sxt/base/device:synchronization",
+        "//sxt/base/test:unit_test",
+        "//sxt/execution/schedule:scheduler",
+        "//sxt/memory/management:managed_array",
+        "//sxt/memory/resource:managed_device_resource",
+    ],
+    deps = [
+        "//sxt/base/container:span",
+        "//sxt/base/device:pinned_buffer",
+        "//sxt/base/device:stream",
+        "//sxt/base/error:assert",
+        "//sxt/execution/async:future",
+    ],
+)
+
+sxt_cc_component(
     name = "device_viewable",
     test_deps = [
         "//sxt/base/device:active_device_guard",
@@ -192,10 +217,7 @@ sxt_cc_component(
 
 sxt_cc_component(
     name = "generate",
-    impl_deps = [
-    ],
     test_deps = [
-        "//sxt/base/device:pinned_buffer",
         "//sxt/base/device:stream",
         "//sxt/base/device:synchronization",
         "//sxt/base/test:unit_test",
@@ -217,7 +239,7 @@ sxt_cc_component(
 sxt_cc_component(
     name = "copy",
     impl_deps = [
-        ":generate",
+        ":to_device_copier",
         "//sxt/base/device:memory_utility",
         "//sxt/base/device:stream",
         "//sxt/execution/async:coroutine",

--- a/sxt/execution/device/copy.cc
+++ b/sxt/execution/device/copy.cc
@@ -25,30 +25,9 @@
 #include "sxt/base/error/assert.h"
 #include "sxt/execution/async/coroutine.h"
 #include "sxt/execution/device/synchronization.h"
+#include "sxt/execution/device/to_device_copier.h"
 
 namespace sxt::xendv {
-//--------------------------------------------------------------------------------------------------
-// strided_copy_host_to_device_one_sweep
-//--------------------------------------------------------------------------------------------------
-static xena::future<> strided_copy_host_to_device_one_sweep(std::byte* dst,
-                                                            const basdv::stream& stream,
-                                                            const std::byte* src, size_t n,
-                                                            size_t count, size_t stride) noexcept {
-  auto num_bytes = n * count;
-  if (num_bytes == 0) {
-    co_return;
-  }
-  basdv::pinned_buffer buffer;
-  auto data = static_cast<std::byte*>(buffer.data());
-  for (size_t i = 0; i < count; ++i) {
-    std::memcpy(data, src, n);
-    data += n;
-    src += stride;
-  }
-  basdv::async_memcpy_host_to_device(static_cast<void*>(dst), buffer.data(), num_bytes, stream);
-  co_await await_stream(stream);
-}
-
 //--------------------------------------------------------------------------------------------------
 // strided_copy_host_to_device
 //--------------------------------------------------------------------------------------------------
@@ -62,45 +41,9 @@ xena::future<> strided_copy_host_to_device(std::byte* dst, const basdv::stream& 
       stride >= n
       // clang-format on
   );
-  auto num_bytes = n * count;
-  if (num_bytes <= basdv::pinned_buffer::size()) {
-    co_return co_await strided_copy_host_to_device_one_sweep(dst, stream, src, n, count, stride);
+  to_device_copier copier{basct::span<std::byte>{dst, count * n}, stream};
+  for (size_t i = 0; i < count; ++i) {
+    co_await copier.copy(basct::cspan<std::byte>{src + i * stride, n});
   }
-  auto cur_n = n;
-
-  auto fill_buffer = [&](basdv::pinned_buffer& buffer) noexcept {
-    size_t remaining_size = buffer.size();
-    auto data = static_cast<std::byte*>(buffer.data());
-    while (remaining_size > 0 && count > 0) {
-      auto chunk_size = std::min(remaining_size, cur_n);
-      std::memcpy(data, src, chunk_size);
-      src += chunk_size;
-      data += chunk_size;
-      remaining_size -= chunk_size;
-      cur_n -= chunk_size;
-      if (cur_n == 0) {
-        --count;
-        cur_n = n;
-        src += stride - n;
-      }
-    }
-    return buffer.size() - remaining_size;
-  };
-
-  // copy
-  basdv::pinned_buffer cur_buffer, alt_buffer;
-  auto chunk_size = fill_buffer(cur_buffer);
-  SXT_DEBUG_ASSERT(count > 0, "copy can't be done in a single sweep");
-  while (count > 0) {
-    basdv::async_memcpy_host_to_device(static_cast<void*>(dst), cur_buffer.data(), chunk_size,
-                                       stream);
-    dst += chunk_size;
-    chunk_size = fill_buffer(alt_buffer);
-    co_await await_stream(stream);
-    std::swap(cur_buffer, alt_buffer);
-  }
-  basdv::async_memcpy_host_to_device(static_cast<void*>(dst), cur_buffer.data(), chunk_size,
-                                     stream);
-  co_await await_stream(stream);
 }
 } // namespace sxt::xendv

--- a/sxt/execution/device/copy.t.cc
+++ b/sxt/execution/device/copy.t.cc
@@ -31,7 +31,7 @@ using namespace sxt;
 using namespace sxt::xendv;
 
 TEST_CASE("we can copy strided memory from host to device") {
-  const auto bufsize = basdv::pinned_buffer::size();
+  const auto bufsize = basdv::pinned_buffer::capacity();
   std::vector<uint8_t> src;
   std::pmr::vector<uint8_t> dst{memr::get_managed_device_resource()};
 

--- a/sxt/execution/device/generate.t.cc
+++ b/sxt/execution/device/generate.t.cc
@@ -83,7 +83,6 @@ TEST_CASE("we can generate an array into device memory") {
     REQUIRE(fut.ready());
     basdv::synchronize_device();
     for (int i = 0; i < bufsize; ++i) {
-      /* std::println(stderr, "dst_p[{}] = {}", i, dst_p[i]); */
       REQUIRE(dst_p[i] == i);
     }
   }

--- a/sxt/execution/device/generate.t.cc
+++ b/sxt/execution/device/generate.t.cc
@@ -31,7 +31,7 @@ using namespace sxt;
 using namespace sxt::xendv;
 
 TEST_CASE("we can generate an array into device memory") {
-  const auto bufsize = basdv::pinned_buffer::size();
+  const auto bufsize = basdv::pinned_buffer::capacity();
   std::pmr::vector<uint8_t> dst{memr::get_managed_device_resource()};
 
   basdv::stream stream;
@@ -83,6 +83,7 @@ TEST_CASE("we can generate an array into device memory") {
     REQUIRE(fut.ready());
     basdv::synchronize_device();
     for (int i = 0; i < bufsize; ++i) {
+      /* std::println(stderr, "dst_p[{}] = {}", i, dst_p[i]); */
       REQUIRE(dst_p[i] == i);
     }
   }

--- a/sxt/execution/device/to_device_copier.cc
+++ b/sxt/execution/device/to_device_copier.cc
@@ -1,0 +1,68 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/device/to_device_copier.h"
+
+#include "sxt/base/device/memory_utility.h"
+#include "sxt/base/error/assert.h"
+#include "sxt/execution/async/coroutine.h"
+#include "sxt/execution/device/synchronization.h"
+
+namespace sxt::xendv {
+//--------------------------------------------------------------------------------------------------
+// constructor
+//--------------------------------------------------------------------------------------------------
+to_device_copier::to_device_copier(basct::span<std::byte> dst, const basdv::stream& stream) noexcept
+    : dst_{dst}, stream_{stream} {}
+
+//--------------------------------------------------------------------------------------------------
+// copy
+//--------------------------------------------------------------------------------------------------
+xena::future<> to_device_copier::copy(basct::cspan<std::byte> src) noexcept {
+  SXT_RELEASE_ASSERT(src.size() <= dst_.size());
+  if (dst_.empty()) {
+    co_return;
+  }
+  while (true) {
+    if (src.empty()) {
+      co_return;
+    }
+    src = active_buffer_.fill_from_host(src);
+    if (active_buffer_.size() == dst_.size()) {
+      break;
+    }
+    if (!active_buffer_.full()) {
+      SXT_DEBUG_ASSERT(src.empty());
+      co_return;
+    }
+    if (!alt_buffer_.empty()) {
+      co_await await_stream(stream_);
+      alt_buffer_.reset();
+    }
+    basdv::async_memcpy_host_to_device(static_cast<void*>(dst_.data()), active_buffer_.data(),
+                                       active_buffer_.size(), stream_);
+    dst_ = dst_.subspan(active_buffer_.size());
+    std::swap(active_buffer_, alt_buffer_);
+  }
+  SXT_RELEASE_ASSERT(src.empty());
+  basdv::async_memcpy_host_to_device(static_cast<void*>(dst_.data()), active_buffer_.data(),
+                                     active_buffer_.size(), stream_);
+  co_await await_stream(stream_);
+  dst_ = {};
+  active_buffer_.reset();
+  alt_buffer_.reset();
+}
+} // namespace sxt::xendv

--- a/sxt/execution/device/to_device_copier.h
+++ b/sxt/execution/device/to_device_copier.h
@@ -1,0 +1,58 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <optional>
+
+#include "sxt/base/container/span.h"
+#include "sxt/base/device/pinned_buffer.h"
+#include "sxt/base/device/stream.h"
+#include "sxt/base/functional/function_ref.h"
+#include "sxt/execution/async/future.h"
+
+namespace sxt::xendv {
+//--------------------------------------------------------------------------------------------------
+// to_device_copier
+//--------------------------------------------------------------------------------------------------
+class to_device_copier {
+public:
+  to_device_copier(basct::span<std::byte> dst, const basdv::stream& stream) noexcept;
+
+  template <class Cont>
+    requires requires(Cont& dst) {
+      dst.data();
+      dst.size();
+    }
+  to_device_copier(Cont& dst, basdv::stream& stream) noexcept
+      : to_device_copier{basct::span<std::byte>{reinterpret_cast<std::byte*>(dst.data()),
+                                                dst.size() * sizeof(*dst.data())},
+                         stream} {}
+
+  xena::future<> copy(basct::cspan<std::byte> src) noexcept;
+
+  template <class Cont> xena::future<> copy(const Cont& src) noexcept {
+    return this->copy(basct::cspan<std::byte>{reinterpret_cast<const std::byte*>(src.data()),
+                                              src.size() * sizeof(*src.data())});
+  }
+
+private:
+  basct::span<std::byte> dst_;
+  const basdv::stream& stream_;
+  basdv::pinned_buffer active_buffer_;
+  basdv::pinned_buffer alt_buffer_;
+};
+} // namespace sxt::xendv

--- a/sxt/execution/device/to_device_copier.t.cc
+++ b/sxt/execution/device/to_device_copier.t.cc
@@ -36,7 +36,7 @@ TEST_CASE("we can copy memory from host to device") {
 
   SECTION("we can copy an empty array") {
     to_device_copier copier{dev, stream};
-    auto fut = copier.copy(host);
+    auto fut = copy(copier, host);
     REQUIRE(fut.ready());
   }
 
@@ -45,7 +45,7 @@ TEST_CASE("we can copy memory from host to device") {
     to_device_copier copier{dev, stream};
 
     host = {123};
-    auto fut = copier.copy(host);
+    auto fut = copy(copier, host);
     REQUIRE(!fut.ready());
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
@@ -58,11 +58,11 @@ TEST_CASE("we can copy memory from host to device") {
     to_device_copier copier{dev, stream};
 
     host = {123};
-    auto fut = copier.copy(host);
+    auto fut = copy(copier, host);
     REQUIRE(fut.ready());
 
     host = {456};
-    fut = copier.copy(host);
+    fut = copy(copier, host);
     REQUIRE(!fut.ready());
 
     xens::get_scheduler().run();
@@ -77,7 +77,7 @@ TEST_CASE("we can copy memory from host to device") {
     to_device_copier copier{dev, stream};
     host.resize(dev.size());
     std::iota(host.begin(), host.end(), 0);
-    auto fut = copier.copy(host);
+    auto fut = copy(copier, host);
     REQUIRE(!fut.ready());
     xens::get_scheduler().run();
     REQUIRE(fut.ready());
@@ -92,10 +92,10 @@ TEST_CASE("we can copy memory from host to device") {
     host.resize(sz);
     std::iota(host.begin(), host.end(), 0);
 
-    auto fut = copier.copy(basct::cspan<int>{host.data(), sz - 1});
+    auto fut = copy(copier, basct::cspan<int>{host.data(), sz - 1});
     REQUIRE(fut.ready());
 
-    fut = copier.copy(basct::cspan<int>{host.data() + sz - 1, 1});
+    fut = copy(copier, basct::cspan<int>{host.data() + sz - 1, 1});
     REQUIRE(!fut.ready());
 
     xens::get_scheduler().run();
@@ -111,11 +111,11 @@ TEST_CASE("we can copy memory from host to device") {
     host.resize(sz);
     std::iota(host.begin(), host.end(), 0);
 
-    auto fut = copier.copy(basct::cspan<int>{host.data(), sz - 1});
+    auto fut = copy(copier, basct::cspan<int>{host.data(), sz - 1});
     REQUIRE(!fut.ready());
     xens::get_scheduler().run();
 
-    fut = copier.copy(basct::cspan<int>{host.data() + sz - 1, 1});
+    fut = copy(copier, basct::cspan<int>{host.data() + sz - 1, 1});
     REQUIRE(!fut.ready());
 
     xens::get_scheduler().run();
@@ -131,7 +131,7 @@ TEST_CASE("we can copy memory from host to device") {
     host.resize(sz);
     std::iota(host.begin(), host.end(), 0);
 
-    auto fut = copier.copy(host);
+    auto fut = copy(copier, host);
     REQUIRE(!fut.ready());
     xens::get_scheduler().run();
     REQUIRE(fut.ready());

--- a/sxt/execution/device/to_device_copier.t.cc
+++ b/sxt/execution/device/to_device_copier.t.cc
@@ -1,0 +1,141 @@
+/** Proofs GPU - Space and Time's cryptographic proof algorithms on the CPU and GPU.
+ *
+ * Copyright 2025-present Space and Time Labs, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "sxt/execution/device/to_device_copier.h"
+
+#include <memory_resource>
+#include <numeric>
+#include <vector>
+
+#include "sxt/base/device/pinned_buffer_pool.h"
+#include "sxt/base/device/synchronization.h"
+#include "sxt/base/test/unit_test.h"
+#include "sxt/execution/schedule/scheduler.h"
+#include "sxt/memory/resource/managed_device_resource.h"
+
+using namespace sxt;
+using namespace sxt::xendv;
+
+TEST_CASE("we can copy memory from host to device") {
+  std::pmr::vector<int> dev{memr::get_managed_device_resource()};
+  std::pmr::vector<int> host;
+  basdv::stream stream;
+
+  SECTION("we can copy an empty array") {
+    to_device_copier copier{dev, stream};
+    auto fut = copier.copy(host);
+    REQUIRE(fut.ready());
+  }
+
+  SECTION("we can a single integer") {
+    dev.resize(1);
+    to_device_copier copier{dev, stream};
+
+    host = {123};
+    auto fut = copier.copy(host);
+    REQUIRE(!fut.ready());
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    REQUIRE(dev == host);
+  }
+
+  SECTION("we can copy two integers in to two passes") {
+    dev.resize(2);
+    to_device_copier copier{dev, stream};
+
+    host = {123};
+    auto fut = copier.copy(host);
+    REQUIRE(fut.ready());
+
+    host = {456};
+    fut = copier.copy(host);
+    REQUIRE(!fut.ready());
+
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    std::pmr::vector<int> expected = {123, 456};
+    REQUIRE(dev == expected);
+  }
+
+  SECTION("we can copy a full buffer") {
+    dev.resize(basdv::pinned_buffer_size / sizeof(int));
+    to_device_copier copier{dev, stream};
+    host.resize(dev.size());
+    std::iota(host.begin(), host.end(), 0);
+    auto fut = copier.copy(host);
+    REQUIRE(!fut.ready());
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    REQUIRE(dev == host);
+  }
+
+  SECTION("we can copy data larger than the full buffer") {
+    dev.resize(basdv::pinned_buffer_size / sizeof(int) + 1u);
+    auto sz = dev.size();
+    to_device_copier copier{dev, stream};
+    host.resize(sz);
+    std::iota(host.begin(), host.end(), 0);
+
+    auto fut = copier.copy(basct::cspan<int>{host.data(), sz - 1});
+    REQUIRE(fut.ready());
+
+    fut = copier.copy(basct::cspan<int>{host.data() + sz - 1, 1});
+    REQUIRE(!fut.ready());
+
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    REQUIRE(dev == host);
+  }
+
+  SECTION("we can copy data larger than two full buffers") {
+    dev.resize(2u * basdv::pinned_buffer_size / sizeof(int) + 1u);
+    auto sz = dev.size();
+    to_device_copier copier{dev, stream};
+    host.resize(sz);
+    std::iota(host.begin(), host.end(), 0);
+
+    auto fut = copier.copy(basct::cspan<int>{host.data(), sz - 1});
+    REQUIRE(!fut.ready());
+    xens::get_scheduler().run();
+
+    fut = copier.copy(basct::cspan<int>{host.data() + sz - 1, 1});
+    REQUIRE(!fut.ready());
+
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    REQUIRE(dev == host);
+  }
+
+  SECTION("we can copy data many multiples of a single buffer size") {
+    dev.resize(10u * basdv::pinned_buffer_size / sizeof(int) + 11u);
+    auto sz = dev.size();
+    to_device_copier copier{dev, stream};
+    host.resize(sz);
+    std::iota(host.begin(), host.end(), 0);
+
+    auto fut = copier.copy(host);
+    REQUIRE(!fut.ready());
+    xens::get_scheduler().run();
+    REQUIRE(fut.ready());
+    basdv::synchronize_device();
+    REQUIRE(dev == host);
+  }
+}


### PR DESCRIPTION
# Rationale for this change

Rework pinned memory buffers and add a to_device_copier where memory can be copied incrementally.

# What changes are included in this PR?

* Reworks pinned_buffer to be easier to use
* Adds a to_device_copier
* Refactors code to use to_device_copier

# Are these changes tested?

Yes
