### PR TITLE
bench: add bn254 scalar filed to the sumcheck benchmark

### DIFF
--- a/benchmark/sumcheck/BUILD
+++ b/benchmark/sumcheck/BUILD
@@ -13,6 +13,8 @@ sxt_cc_benchmark(
         "//sxt/base/num:fast_random_number_generator",
         "//sxt/execution/async:future",
         "//sxt/execution/schedule:scheduler",
+        "//sxt/fieldgk/random:element",
+        "//sxt/fieldgk/realization:field",
         "//sxt/memory/management:managed_array",
         "//sxt/proof/sumcheck:chunked_gpu_driver",
         "//sxt/proof/sumcheck:cpu_driver",

--- a/benchmark/sumcheck/benchmark.m.cc
+++ b/benchmark/sumcheck/benchmark.m.cc
@@ -26,6 +26,8 @@
 #include "sxt/base/num/fast_random_number_generator.h"
 #include "sxt/execution/async/future.h"
 #include "sxt/execution/schedule/scheduler.h"
+#include "sxt/fieldgk/random/element.h"
+#include "sxt/fieldgk/realization/field.h"
 #include "sxt/memory/management/managed_array.h"
 #include "sxt/proof/sumcheck/chunked_gpu_driver.h"
 #include "sxt/proof/sumcheck/cpu_driver.h"
@@ -59,6 +61,8 @@ static bool read_params(params& p, int argc, char* argv[]) noexcept {
   s = {argv[1]};
   if (s == "curve25519") {
     p.field = "curve25519";
+  } else if (s == "bn254") {
+    p.field = "bn254";
   } else {
     baser::panic("invalid scalar field: {}\n", s);
   }
@@ -199,6 +203,11 @@ int main(int argc, char* argv[]) {
       s25rn::generate_random_element(element, rng);
     };
     run_benchmark<s25t::element>(p, generator);
+  } else if (p.field == "bn254") {
+    auto generator = [](fgkt::element& element, basn::fast_random_number_generator& rng) {
+      fgkrn::generate_random_element(element, rng);
+    };
+    run_benchmark<fgkt::element>(p, generator);
   } else {
     baser::panic("unsupported scalar field: {}", p.field);
   }

--- a/benchmark/sumcheck/benchmark.m.cc
+++ b/benchmark/sumcheck/benchmark.m.cc
@@ -95,8 +95,8 @@ static bool read_params(params& p, int argc, char* argv[]) noexcept {
 }
 
 template <class U>
-static void check_verifiy(basct::cspan<U> round_polynomials, unsigned round_degree,
-                          unsigned num_rounds) noexcept {
+static void check_verify(basct::cspan<U> round_polynomials, unsigned round_degree,
+                         unsigned num_rounds) noexcept {
   prft::transcript base_transcript{"abc123"};
   prfsk::reference_transcript<U> transcript{base_transcript};
   memmg::managed_array<U> evaluation_point(num_rounds);
@@ -144,7 +144,7 @@ static void run_benchmark(params& p, GeneratorFunc generator_func) {
     auto fut = prfsk::prove_sum<U>(polynomials, evaluation_point, transcript, drv, mles,
                                    product_table, product_terms, p.n);
     xens::get_scheduler().run();
-    check_verifiy<U>(polynomials, p.degree, num_rounds);
+    check_verify<U>(polynomials, p.degree, num_rounds);
   }
 
   // sample


### PR DESCRIPTION
# Rationale for this change
The sumcheck benchmark currently only measures the Curve25519 field. The sumcheck benchmark is updated to support multiple fields. Additionally, the bn254 scalar field is added to the sumcheck benchmark.

# What changes are included in this PR?
- The sumcheck benchmark is updated to support multiple curves in commit 7655b9ec268d8045e2a8dbb9e5d9564d6a4e8b7a
- The bn254 scalar field is added to the sumcheck benchmark e342db622c11d0cebf129e961907b82959a01d08

# Are these changes tested?
Yes