### PR TITLE
docs: update readme with benchmark related changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ Benchmarks are run against four different types of GPU:
 * [Nvidia A100 - Standard_NC24ads_A100_v4](https://learn.microsoft.com/en-us/azure/virtual-machines/nc-a100-v4-series)
 * [Nvidia A100 x4 - Standard_NC96ads_A100_v4](https://learn.microsoft.com/en-us/azure/virtual-machines/nc-a100-v4-series)
 
-<details open>
-<summary>Multi-Scalar Multiplication / Generalized Pedersen Commitment Results:</summary>
+<details>
+<summary>Expand to see the multi-scalar multiplication / generalized Pedersen commitment results</summary>
 
 The subsequent outcomes are derived from the preceding benchmark execution of the Pedersen commitment, during which the number of sequences, bytes per element, sequence length, and GPU type were varied.
 

--- a/README.md
+++ b/README.md
@@ -284,13 +284,14 @@ nix develop
 ```bash
 nix develop
 
-# Usage: benchmark <cpu|gpu> <n> <num_samples> <num_commitments> <element_nbytes> <verbose>
+# Usage: benchmark <cpu|gpu> <curve> <n> <num_samples> <num_commitments> <element_nbytes> <verbose>
+# - curve: the desired curve: curve25519, bn254, bls12_381, grumpkin
 # - n: the size of the multiexponentiation vector (or the sequence length).
 # - num_samples: the number of times to run the benchmark.
 # - num_commitments: the number of commitments to generate.
 # - element_nbytes: the number of bytes of each element in the vector (exponent size).
 # - verbose: whether to print the results of each run.
-bazel run -c opt //benchmark/multi_commitment:benchmark -- gpu 1000 5 1 32 1
+bazel run -c opt //benchmark/multi_commitment:benchmark gpu bn254 1000 10 1 32 0
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ nix develop
 # - num_commitments: the number of commitments to generate.
 # - element_nbytes: the number of bytes of each element in the vector (exponent size).
 # - verbose: whether to print the results of each run.
-bazel run -c opt //benchmark/multi_commitment:benchmark gpu bn254 1000 10 1 32 0
+bazel run -c opt //benchmark/multi_commitment:benchmark -- gpu bn254 1000 5 1 32 1
 ```
 
 </details>


### PR DESCRIPTION
# Rationale for this change
This PR improves the README by making the benchmarks graphs collapsed when opening and updates the text related to running the `multi_commitment` benchmark.

# What changes are included in this PR?
-The README is updated

# Are these changes tested?
Yes