### PR TITLE
build: upgrade CUDA to 12.8, rust to nightly 2025-04-03

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8-green?style=flat&logo=nvidia">
     </a>
 
   <p align="center">
@@ -166,7 +166,7 @@ See the [example](./example) folder for some examples.
 Prerequisites:
 * `x86_64` Linux instance.
 * Nix with flake support (check out [The Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)).
-* Nvidia GPU capable of running CUDA 12.6 code.
+* Nvidia GPU capable of running CUDA 12.8 code.
 
 From your terminal, run the following command in the root of the source directory to set
 up a build environment. 

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgsDrv": {
       "locked": {
-        "lastModified": 1735471104,
-        "narHash": "sha256-0q9NGQySwDQc7RhAV2ukfnu7Gxa5/ybJ2ANT8DQrQrs=",
+        "lastModified": 1780749050,
+        "narHash": "sha256-3av0pIjlOWQ6rDbNOmpUSvbNnJkGORQKKjb4LtCZsIY=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "88195a94f390381c6afcdaa933c2f6ff93959cb4",
+        "rev": "a799d3e3886da994fa307f817a6bc705ae538eeb",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -50,11 +50,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
         "type": "github"
       },
       "original": {
@@ -77,11 +77,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1724898214,
-        "narHash": "sha256-4yMO9+Lsr3zqTf4clAGGag/bfNTmc/ITOXbJQcOEok4=",
+        "lastModified": 1781147846,
+        "narHash": "sha256-hBdiQYd40xRtBWBiXHUxuQYWmJBiK19YO1FiYgrmEo0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0bc2c784e3a6ce30a2ab1b9f47325ccbed13039f",
+        "rev": "107c334f141854f563f8adf1db781dc453d92639",
         "type": "github"
       },
       "original": {

--- a/nix/cuda.nix
+++ b/nix/cuda.nix
@@ -7,8 +7,8 @@ with pkgs;
 pkgs.stdenvNoCC.mkDerivation {
   name = "cudatoolkit";
   src = fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run";
-    sha256 = "179fx44j0f6fm4m8afx5vhivv3ywyv7mv7shb7r2b5ji8drcxb3k";
+    url = "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run";
+    sha256 = "15wpl4k2yl14i84kgglysdg0wbf99y8k3x1r541qsqdpyp56p3r2";
   };
   patches = [
     # patch host_defines.h to work with libc++

--- a/nix/cuda.nix
+++ b/nix/cuda.nix
@@ -7,8 +7,8 @@ with pkgs;
 pkgs.stdenvNoCC.mkDerivation {
   name = "cudatoolkit";
   src = fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run";
-    sha256 = "15wpl4k2yl14i84kgglysdg0wbf99y8k3x1r541qsqdpyp56p3r2";
+    url = "https://developer.download.nvidia.com/compute/cuda/12.8.2/local_installers/cuda_12.8.2_570.211.01_linux.run";
+    sha256 = "08ny3i114vfl82h70i5ns6lfjkvjyrjlvcwzdd5z8v4nh634jvl3";
   };
   patches = [
     # patch host_defines.h to work with libc++

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,27 +1,30 @@
-{ pkgs }:
-let
-  clang = import ./clang.nix { inherit pkgs; };
-  cuda = import ./cuda.nix { inherit pkgs; };
-  bazel = import ./bazel.nix { inherit pkgs; inherit clang; inherit cuda; };
+{pkgs}: let
+  clang = import ./clang.nix {inherit pkgs;};
+  cuda = import ./cuda.nix {inherit pkgs;};
+  bazel = import ./bazel.nix {
+    inherit pkgs;
+    inherit clang;
+    inherit cuda;
+  };
 in
-with pkgs;
-mkShell {
-  buildInputs = [
-    bazel-buildtools
-    python3
-    rust-bin.nightly."2024-08-02".default
-    rust-bindgen
-    patchelf
-    nodejs
-    # custom packages
-    bazel
-    clang
-    cuda
-  ];
-  LD_LIBRARY_PATH = lib.makeLibraryPath [
-    "/usr/lib/wsl"
-    cudaDrivers
-  ];
-  shellHook = ''
-  '';
-}
+  with pkgs;
+    mkShell {
+      buildInputs = [
+        bazel-buildtools
+        python3
+        rust-bin.nightly."2025-04-03".default
+        rust-bindgen
+        patchelf
+        nodejs
+        # custom packages
+        bazel
+        clang
+        cuda
+      ];
+      LD_LIBRARY_PATH = lib.makeLibraryPath [
+        "/usr/lib/wsl"
+        cudaDrivers
+      ];
+      shellHook = ''
+      '';
+    }

--- a/rust/blitzar-sys/README.md
+++ b/rust/blitzar-sys/README.md
@@ -45,7 +45,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8-green?style=flat&logo=nvidia">
     </a>
   </a>
 


### PR DESCRIPTION
# Rationale for this change
Recent requirements to use ubuntu24.04 in kubernetes deployments of blitzar dependents have made it difficult or impossible to use CUDA 12.6. Nvidia does not provide an ubuntu24.04 driver image that is compatible with the current blitzar. Using CUDA 12.8 should resolve the issue.

Also, due to some rust dependencies invalidating use of edition 2021 or pre-1.86, the rust overlay has also been upgraded.

# What changes are included in this PR?
- CUDA bumped to 12.8 in the nix environment.
- mentions of CUDA 12.1/12.6 have also been adjusted.
- rust overlay version upgraded to nightly 2024-04-03
- the nixpkgs providing the cuda drivers has been updated in the flake.lock

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
