### PR TITLE
ci: switch to nvidia runner for gpu dependent jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,15 @@ jobs:
 
       - run: git config --global --add safe.directory $(realpath .)
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Semantic release
         run: |
-          nix develop --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
+          nix develop --extra-experimental-features "nix-command flakes" --command npm install semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   release:
     name: Build Publish Library - Linux-x86_64
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
   
   test-cpp:
     name: C++ code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -42,7 +42,7 @@ jobs:
           #
           # test-cpp-compute-sanitizer:
           #   name: C++ code with compute sanitizer
-          #   runs-on: public-blitzar-T4-gpu-vm
+          #   runs-on: nvidia-nc4as-t4
           #   timeout-minutes: 600
           #   steps:
           #     - name: Checkout Code
@@ -63,7 +63,7 @@ jobs:
          
   test-cpp-opt:
     name: C++ code with optimizations
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -74,7 +74,7 @@ jobs:
   
   test-cpp-asan:
     name: C++ code with address sanitizer
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -85,7 +85,7 @@ jobs:
 
   test-rust:
     name: Rust Sys Crate
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -19,9 +19,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
   
       - name: Run check
-        run: nix develop --command ./tools/code_format/check_format.py check
+        run: nix develop --extra-experimental-features "nix-command flakes" --command ./tools/code_format/check_format.py check
   
   test-cpp:
     name: C++ code
@@ -31,8 +36,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run cpp tests
-        run: TEST_TMPDIR=$HOME/.bazel_test nix develop --command bazel test //...
+        run: TEST_TMPDIR=$HOME/.bazel_test nix develop --extra-experimental-features "nix-command flakes" --command bazel test //...
   
           # Note: There are some steps we need to our
           # custom nix derivation from https://github.com/spaceandtimefdn/blitzar/pull/96
@@ -68,9 +78,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
   
       - name: Run cpp tests with optimization flags on
-        run: TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command bazel test --jobs=1 -c opt //...
+        run: TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command bazel test --jobs=1 -c opt //...
   
   test-cpp-asan:
     name: C++ code with address sanitizer
@@ -80,8 +95,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run cpp-asan tests
-        run: TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --command bazel test --config=asan //sxt/...
+        run: TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --extra-experimental-features "nix-command flakes" --command bazel test --config=asan //sxt/...
 
   test-rust:
     name: Rust Sys Crate
@@ -91,7 +111,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run rust tests
         run: |
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/tests/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command cargo test --manifest-path rust/tests/Cargo.toml


### PR DESCRIPTION
# Rationale for this change
The current runner for the gpu jobs is self-hosted and has gone unmaintained for some time. Now, github provides some larger runners with GPUs that we can use instead for easier maintenance. This PR attempts to use them.

# What changes are included in this PR?
Any job previously using the public blitzar runner now uses `nvidia-nc4as-t4`.

# Are these changes tested?
They will be tested by a successful CI run on this PR.
