### PR TITLE
feat: upgrade CUDA and use github hosted runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,10 +23,15 @@ jobs:
 
       - run: git config --global --add safe.directory $(realpath .)
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Semantic release
         run: |
-          nix develop --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
+          nix develop --extra-experimental-features "nix-command flakes" --command npm install semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command npx semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   release:
     name: Build Publish Library - Linux-x86_64
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -33,16 +33,26 @@ jobs:
     runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
+
       - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Check nvidia version
+        run: nvidia-smi
 
       - name: Install nix
         uses: cachix/install-nix-action@v31
         with:
           install_options: --no-daemon
 
+      - name: Enter nix env
+        run: nix develop --extra-experimental-features "nix-command flakes"
+
+      - name: Check nvidia version
+        run: nvidia-smi
+
       - name: Run cpp tests
-        run: TEST_TMPDIR=$HOME/.bazel_test nix develop --extra-experimental-features "nix-command flakes" --command bazel test //...
+        run: TEST_TMPDIR=$HOME/.bazel_test bazel test //...
   
           # Note: There are some steps we need to our
           # custom nix derivation from https://github.com/spaceandtimefdn/blitzar/pull/96

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   format-code:
     name: Check code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
   
   test-cpp:
     name: C++ code
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -42,7 +42,7 @@ jobs:
           #
           # test-cpp-compute-sanitizer:
           #   name: C++ code with compute sanitizer
-          #   runs-on: public-blitzar-T4-gpu-vm
+          #   runs-on: nvidia-nc4as-t4
           #   timeout-minutes: 600
           #   steps:
           #     - name: Checkout Code
@@ -63,7 +63,7 @@ jobs:
          
   test-cpp-opt:
     name: C++ code with optimizations
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -74,7 +74,7 @@ jobs:
   
   test-cpp-asan:
     name: C++ code with address sanitizer
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code
@@ -85,7 +85,7 @@ jobs:
 
   test-rust:
     name: Rust Sys Crate
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: nvidia-nc4as-t4
     timeout-minutes: 600
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-check-lint.yml
+++ b/.github/workflows/test-check-lint.yml
@@ -19,9 +19,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
   
       - name: Run check
-        run: nix develop --command ./tools/code_format/check_format.py check
+        run: nix develop --extra-experimental-features "nix-command flakes" --command ./tools/code_format/check_format.py check
   
   test-cpp:
     name: C++ code
@@ -31,8 +36,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run cpp tests
-        run: TEST_TMPDIR=$HOME/.bazel_test nix develop --command bazel test //...
+        run: TEST_TMPDIR=$HOME/.bazel_test nix develop --extra-experimental-features "nix-command flakes" --command bazel test //...
   
           # Note: There are some steps we need to our
           # custom nix derivation from https://github.com/spaceandtimefdn/blitzar/pull/96
@@ -68,9 +78,14 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
   
       - name: Run cpp tests with optimization flags on
-        run: TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command bazel test --jobs=1 -c opt //...
+        run: TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command bazel test --jobs=1 -c opt //...
   
   test-cpp-asan:
     name: C++ code with address sanitizer
@@ -80,8 +95,13 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run cpp-asan tests
-        run: TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --command bazel test --config=asan //sxt/...
+        run: TEST_TMPDIR=$HOME/.bazel_test_asan nix develop --extra-experimental-features "nix-command flakes" --command bazel test --config=asan //sxt/...
 
   test-rust:
     name: Rust Sys Crate
@@ -91,7 +111,12 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v3
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+        with:
+          install_options: --no-daemon
+
       - name: Run rust tests
         run: |
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command cargo test --manifest-path rust/tests/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command cargo test --manifest-path rust/blitzar-sys/Cargo.toml
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command cargo test --manifest-path rust/tests/Cargo.toml

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@
     </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.6-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8-green?style=flat&logo=nvidia">
     </a>
 
   <p align="center">
@@ -166,7 +166,7 @@ See the [example](./example) folder for some examples.
 Prerequisites:
 * `x86_64` Linux instance.
 * Nix with flake support (check out [The Determinate Nix Installer](https://github.com/DeterminateSystems/nix-installer)).
-* Nvidia GPU capable of running CUDA 12.6 code.
+* Nvidia GPU capable of running CUDA 12.8 code.
 
 From your terminal, run the following command in the root of the source directory to set
 up a build environment. 

--- a/nix/cuda.nix
+++ b/nix/cuda.nix
@@ -7,8 +7,8 @@ with pkgs;
 pkgs.stdenvNoCC.mkDerivation {
   name = "cudatoolkit";
   src = fetchurl {
-    url = "https://developer.download.nvidia.com/compute/cuda/12.6.1/local_installers/cuda_12.6.1_560.35.03_linux.run";
-    sha256 = "179fx44j0f6fm4m8afx5vhivv3ywyv7mv7shb7r2b5ji8drcxb3k";
+    url = "https://developer.download.nvidia.com/compute/cuda/12.8.1/local_installers/cuda_12.8.1_570.124.06_linux.run";
+    sha256 = "15wpl4k2yl14i84kgglysdg0wbf99y8k3x1r541qsqdpyp56p3r2";
   };
   patches = [
     # patch host_defines.h to work with libc++

--- a/rust/blitzar-sys/README.md
+++ b/rust/blitzar-sys/README.md
@@ -45,7 +45,7 @@
   </a>
 
   <a href="https://developer.nvidia.com/cuda-downloads">
-    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.1-green?style=flat&logo=nvidia">
+    <img alt="CUDA" src="https://img.shields.io/badge/CUDA-12.8-green?style=flat&logo=nvidia">
     </a>
   </a>
 


### PR DESCRIPTION
# Rationale for this change
This PR is a combination of #276 and #277. The CI needs to be fixed, which is what #277 aims to do, in order to upgrade CUDA, which is what #276 aims to do. However, there are now errors in the CI about CUDA/driver version mismatch, so I'm pushing this pull request to see if both changes at once resolve the issue.

# What changes are included in this PR?
- **feat: bump CUDA to 12.8**
- **ci: switch to nvidia runner for gpu dependent jobs**
- **ci: install nix in all jobs that depend on it**

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
