### PR TITLE
ci: switch to using default GITHUB_TOKEN secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,10 @@ jobs:
     uses: ./.github/workflows/test-check-lint.yml
 
   release:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     name: Build Publish Library - Linux-x86_64
     runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
@@ -18,8 +22,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
-        with:
-          token: ${{ secrets.GH_TOKEN }}
 
       - run: git config --global --add safe.directory $(realpath .)
 
@@ -28,5 +30,5 @@ jobs:
           nix develop --command npm install semantic-release
           TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION

# Rationale for this change
A custom GH_TOKEN is currently used to checkout the repository and perform release operations in the release workflow. However, it is likely that we will be able to use the default GITHUB_TOKEN secret. This PR attempts to switch to this default secret.

# What changes are included in this PR?
Switch to `GITHUB_TOKEN` (with some special permissions) in release workflow for semantic-release and checkout.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
