### PR TITLE
ci: use ubuntu-latest for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     name: Build Publish Library - Linux-x86_64
-    runs-on: public-blitzar-T4-gpu-vm
+    runs-on: ubuntu-latest
     timeout-minutes: 600
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
@@ -25,9 +25,12 @@ jobs:
 
       - run: git config --global --add safe.directory $(realpath .)
 
+      - name: Install nix
+        uses: cachix/install-nix-action@v31
+
       - name: Semantic release
         run: |
-          nix develop --command npm install semantic-release
+          nix develop --extra-experimental-features "nix-command flakes" --command npm install semantic-release
           TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Semantic release
         run: |
           nix develop --extra-experimental-features "nix-command flakes" --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
# Rationale for this change
The release job does not need a GPU to run its processes, but it was using the gpu-enabled runner. This runner also has an intense firewall, preventing it from accessing the node packages the release workflow needs. This changes uses the github-hosted ubuntu-latest instead.

# What changes are included in this PR?
- switch to ubuntu-latest in release workflow
- add install nix step, since ubuntu-latest won't have it

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
