### PR TITLE
revert: ci: use ubuntu-latest for release workflow (#282)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       issues: write
       pull-requests: write
     name: Build Publish Library - Linux-x86_64
-    runs-on: ubuntu-latest
+    runs-on: public-blitzar-T4-gpu-vm
     timeout-minutes: 600
     needs: [test-check-lint]
     environment: deploy #!! DO NOT CHANGE THIS LINE !! #
@@ -25,13 +25,10 @@ jobs:
 
       - run: git config --global --add safe.directory $(realpath .)
 
-      - name: Install nix
-        uses: cachix/install-nix-action@v31
-
       - name: Semantic release
         run: |
-          nix develop --extra-experimental-features "nix-command flakes" --command npm install semantic-release
-          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --extra-experimental-features "nix-command flakes" --command npx semantic-release
+          nix develop --command npm install semantic-release
+          TEST_TMPDIR=$HOME/.bazel_test_opt nix develop --command npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}


### PR DESCRIPTION
# Rationale for this change
This reverts commit 4dad26ab5214bdccb198304c548c383e06c19afd. This commit switched to using ubuntu-latest for the release workflow instead of dealing with firewall issues on the blitzar vm runner. However, the release workflow now takes over an hour, because it needs to build cuda from scratch when entering the nix environment instead of taking advantage of the nix store (cache) on the blitzar vm runner. It will likely be faster to just squash the firewall issues.


# What changes are included in this PR?
- reverts commit 4dad26ab5214bdccb198304c548c383e06c19afd.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
