### PR TITLE
fix: format bazel.nix

### DIFF
--- a/nix/bazel.nix
+++ b/nix/bazel.nix
@@ -1,5 +1,8 @@
-{ pkgs, clang, cuda }:
-let
+{
+  pkgs,
+  clang,
+  cuda,
+}: let
   # Set PATH so that it only includes things bazel needs.
   path = pkgs.lib.strings.concatStringsSep ":" [
     "${clang}/bin"
@@ -16,21 +19,20 @@ let
   ];
   bazel = "${pkgs.bazel_7}/bin/bazel";
 in
-pkgs.writeShellScriptBin "bazel" ''
-  if [[
-    "$1" == "build" ||
-    "$1" == "test" ||
-    "$1" == "run"
-  ]]; then
-    exec ${bazel} $1 \
-     --action_env CC=${clang}/bin/clang \
-     --action_env CXX=${clang}/bin/clang++ \
-     --action_env PATH="${path}" \
-     --action_env CUDA_PATH="${cuda}" \
-     --action_env=BAZEL_LINKLIBS='-l%:libc++.a' \
-     --action_env=BAZEL_LINKOPTS='-L${clang}/lib' \
-     ''${@:2}
-  else
-    exec ${bazel} $@
-  fi''
-
+  pkgs.writeShellScriptBin "bazel" ''
+    if [[
+      "$1" == "build" ||
+      "$1" == "test" ||
+      "$1" == "run"
+    ]]; then
+      exec ${bazel} $1 \
+       --action_env CC=${clang}/bin/clang \
+       --action_env CXX=${clang}/bin/clang++ \
+       --action_env PATH="${path}" \
+       --action_env CUDA_PATH="${cuda}" \
+       --action_env=BAZEL_LINKLIBS='-l%:libc++.a' \
+       --action_env=BAZEL_LINKOPTS='-L${clang}/lib' \
+       ''${@:2}
+    else
+      exec ${bazel} $@
+    fi''


### PR DESCRIPTION
# Rationale for this change
A recent release workflow created a new tag, and new crates, but failed to create a github release due to firewall issues. This introduces a minor change with `fix:` in an attempt to increment the release version and retry creating a new release.

# What changes are included in this PR?
`nix/bazel.nix` has been formatted.

# Are these changes tested?
These changes do not affect existing functionality, which should be verified by existing tests.
